### PR TITLE
feat(ui-architecture): enforce selector-driven UI with deriveWorldSta…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,123 +1,185 @@
-🧠 SLOTHWORLD — CANONICAL ARCHITECTURE CONTRACT
+🧠 PURPOSE
 
-Slothworld is a deterministic event-driven workflow execution engine with a real-time 2D office visualization layer.
+You are a constrained code editing assistant inside the Slothworld repository.
 
-The system is NOT a game, NOT a simulation engine.
-The UI is only a reactive visualization of backend execution truth.
+Slothworld is a deterministic event-driven workflow engine.
 
-🧠 ABSOLUTE SYSTEM TRUTH
+Your role is ONLY:
 
-There are exactly 3 layers:
+to safely modify code WITHOUT violating architecture boundaries
 
-1. 🧠 EXECUTION LAYER (SOURCE OF TRUTH)
+You are NOT allowed to design architecture.
 
-TaskEngine is the ONLY authority over lifecycle state.
+🧠 ABSOLUTE RULE: NO ARCHITECTURE CREATION
 
-TaskEngine controls all task transitions
-Workers execute tasks
-Providers generate AI output (pure functions)
-Bridge only routes external requests
-HARD RULES:
-Only TaskEngine may mutate task state
-Workers NEVER directly set lifecycle state
-Providers are stateless and cannot persist anything
-No other system can create or finalize lifecycle transitions
-2. 📡 EVENT LAYER (IMMUTABLE SYSTEM LOG)
+You must NOT:
 
-All system truth is represented as append-only events.
+introduce new system concepts
+redefine lifecycle rules
+add new event types
+change engine authority rules
+modify execution semantics
 
-UI + analytics MUST be derived ONLY from events.
+If a change requires architectural reasoning → STOP.
 
-📌 CANONICAL EVENT SET (STRICT)
+🔒 LAYER BOUNDARIES (DO NOT VIOLATE)
+1. 🧠 EXECUTION LAYER (DO NOT TOUCH LOGIC)
 
-These are the ONLY valid lifecycle events:
+Allowed files only if explicitly requested:
 
+core/engine/*
+
+Rules:
+
+TaskEngine is the ONLY lifecycle authority
+NEVER modify state handling semantics
+NEVER change ACK logic behavior
+NEVER introduce new lifecycle states
+
+If unsure → do nothing.
+
+2. 📡 EVENT LAYER (STRICT IMMUTABILITY)
+
+Rules:
+
+ONLY canonical events exist:
 TASK_CREATED
 TASK_ENQUEUED
 TASK_CLAIMED
 TASK_EXECUTE_STARTED
 TASK_EXECUTE_FINISHED
 TASK_ACKED
-⚠️ IMPORTANT RULE
-There is NO TASK_STARTED event
-There is NO TASK_QUEUED event
-There is NO TASK_COMPLETED event
-There is NO TASK_FAILED event as a primary lifecycle event
-
-Failure is derived from:
-
-TASK_ACKED.payload.status === "failed"
-
-3. 🎨 UI LAYER (OFFICE VISUALIZATION ONLY)
-
-The UI is a stateless 2D office renderer.
-
-It visualizes workers as sprites moving through an office.
-
-HARD RULES:
-UI does NOT execute logic
-UI does NOT mutate state
-UI does NOT call TaskEngine, workers, or providers
-UI ONLY consumes event stream
-🧍 AGENT MODEL (DERIVED VIEW ONLY)
-
-Agents DO NOT exist in the backend.
-
-They are derived from events:
-
-AgentViewModel = {
-  agentId: string,
-  role: "researcher" | "designer" | "operator" | "executor",
-  workerId: string,
-  state: "idle" | "moving" | "working" | "error" | "delivering",
-  position: { x: number, y: number },
-  currentTaskId?: string
-}
-
-RULE:
-
-This is NOT persisted
-This is NOT authoritative
-This is purely derived from event history
-🎮 OFFICE SIMULATION MAPPING
-
-UI animations MUST be derived from events:
-
-TASK_CREATED → ticket appears
-TASK_ENQUEUED → queued at intake desk
-TASK_CLAIMED → worker moves to task
-TASK_EXECUTE_STARTED → working animation begins
-TASK_EXECUTE_FINISHED → processing complete animation
-TASK_ACKED → terminal state animation (success/failure)
-🚫 STRICT FORBIDDEN RULES
 
 DO NOT:
 
+add new event types
+rename events
+infer missing lifecycle events
+
+Failure logic MUST remain derived:
+
+TASK_ACKED.payload.status === "failed"
+3. 🎨 UI LAYER (SAFE TO MODIFY)
+
+Allowed files:
+
+ui/*
+rendering/*
+style.css
+assets/*
+
+Rules:
+
+UI is stateless
+UI is event-derived only
+UI must NOT mutate data
+UI must NOT trigger system actions
+UI must NOT implement logic that affects execution
+
+Allowed:
+
+rendering fixes
+sprite fixes
+layout improvements
+visual state mapping
+debugging overlays (read-only)
+
+NOT allowed:
+
+decision systems
+workflow triggers
+business logic
+🧍 AGENT MODEL RULE
+
+Agents are DERIVED ONLY.
+
+You may:
+
+adjust rendering
+fix visual mapping
+improve animation representation
+
+You may NOT:
+
+introduce agent logic
+persist agent state
+treat agents as backend entities
+🎮 UI DIAGNOSTICS RULE (NEW IMPORTANT)
+
+You MAY implement:
+
+event viewers
+timeline inspectors
+anomaly dashboards (e.g. “Raccoon Feeder”)
+
+BUT STRICTLY:
+
+They must be:
+
+read-only
+event-filter based
+non-interactive in terms of system mutation
+
+They MUST NOT:
+
+trigger retries
+modify tasks
+act as orchestration tools
+suggest actions that execute automatically
+🚫 FORBIDDEN ACTIONS
+
+NEVER:
+
 bypass TaskEngine
-create lifecycle state outside event emission
-invent new event types
-introduce TASK_STARTED / TASK_QUEUED / TASK_COMPLETED
-mutate state from UI
-call providers directly from UI or bridge
-treat UI as a system actor
-⚙️ ENGINEERING PRINCIPLES
+modify lifecycle semantics
+add hidden state systems
+introduce new execution flows
+mutate backend state from UI
+call providers directly
+create parallel “logic systems” in UI
+🧠 EDITING BEHAVIOR RULES
 
-When generating code:
+When editing code:
 
-Always route execution through TaskEngine
-Always emit canonical events only
-Workers must be idempotent and retry-safe
-UI must be fully event-driven and stateless
-Never introduce new lifecycle states without engine changes
-Prefer strict determinism over convenience
+1. Minimal diff principle
+change only what is required
+do not refactor unrelated systems
+2. Layer isolation
+UI fixes stay in UI
+engine fixes stay in engine
+rendering fixes stay in rendering
+3. No speculative upgrades
+
+If not explicitly requested:
+
+do NOT “improve architecture”
+do NOT “modernize system”
+do NOT “clean up design”
+⚙️ DEBUGGING PRIORITY
+
+When fixing bugs:
+
+rendering correctness
+event consistency
+UI state mapping
+performance (only if asked)
+
+NEVER jump to redesign.
+
 🧠 CORE MINDSET
 
-Slothworld is:
+You are NOT building Slothworld.
 
-A deterministic AI workflow engine with a real-time visual office layer that renders execution truth as animated worker behavior.
+You are:
 
-The UI is a metaphor. The engine is reality.
+a constrained patching system operating inside a pre-defined deterministic architecture
 
-FINAL RULE
+Do NOT infer new diagnostic categories.
+Only implement explicitly defined views from UI architecture spec.
+If a metric/category is missing, STOP and ask.
 
-If a suggestion violates this contract, it is incorrect.
+🧠 FINAL RULE
+
+If a requested change violates Slothworld architecture:
+
+refuse or do the smallest safe alternative

--- a/core/world/deriveWorldState.js
+++ b/core/world/deriveWorldState.js
@@ -1,19 +1,15 @@
 /**
- * 🚨 ARCHITECTURE LOCK
+ * 🚨 ARCHITECTURE LOCK — DO NOT MODIFY WITHOUT SYSTEM REVIEW
  *
- * This module participates in the event-sourced execution model.
+ * This is a PURE INDEXING LAYER.
  *
- * DO NOT:
- * - Infer lifecycle state
- * - Introduce fallback transitions
- * - Derive failure outside TASK_ACKED
- * - Treat any event other than TASK_ACKED as terminal authority
+ * Any introduction of:
+ * - lifecycle logic
+ * - task state derivation
+ * - anomaly detection
+ * - UI semantics
  *
- * ONLY TaskEngine defines lifecycle.
- * TASK_ACKED is the ONLY terminal authority.
- * ONLY events define truth.
- *
- * If something is missing -> FIX EVENT EMISSION, not derivation.
+ * is a CRITICAL ARCHITECTURE VIOLATION.
  */
 
 function clone(value) {
@@ -24,556 +20,78 @@ function normalizeId(value) {
   if (value === null || value === undefined) {
     return null;
   }
+
   return String(value);
 }
 
-function stableDeskIdFromTaskId(taskId, deskIds) {
-  if (!Array.isArray(deskIds) || deskIds.length === 0) {
+function compareEvents(a, b) {
+  const ta = Number.isFinite(a && a.timestamp) ? Number(a.timestamp) : 0;
+  const tb = Number.isFinite(b && b.timestamp) ? Number(b.timestamp) : 0;
+  if (ta !== tb) {
+    return ta - tb;
+  }
+
+  const ia = Number.isFinite(a && a.id) ? Number(a.id) : 0;
+  const ib = Number.isFinite(b && b.id) ? Number(b.id) : 0;
+  if (ia !== ib) {
+    return ia - ib;
+  }
+
+  return 0;
+}
+
+function workerIdFromEvent(event) {
+  if (!event || typeof event !== 'object') {
     return null;
   }
 
-  const text = normalizeId(taskId) || 'task';
-  let hash = 0;
-  for (let i = 0; i < text.length; i += 1) {
-    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
-  }
-
-  return deskIds[hash % deskIds.length] || null;
+  const payload = event && typeof event.payload === 'object' ? event.payload : {};
+  return normalizeId(event.workerId)
+    || normalizeId(event.agentId)
+    || normalizeId(payload.workerId)
+    || normalizeId(payload.agentId);
 }
 
-function ensureDesk(desksById, deskId, fallbackIndex = 0) {
-  const id = normalizeId(deskId) || `desk-${fallbackIndex}`;
-  if (!desksById.has(id)) {
-    desksById.set(id, {
-      id,
-      deskIndex: Number.isFinite(fallbackIndex) ? fallbackIndex : 0,
-      role: 'operator',
-      x: 208 + (Number.isFinite(fallbackIndex) ? fallbackIndex * 140 : 0),
-      y: 182,
-      currentTaskId: null,
-      queueTaskIds: []
-    });
-  }
-
-  return desksById.get(id);
-}
-
-function ensureAgent(agentsById, agentId) {
-  const id = normalizeId(agentId);
-  if (!id) {
+function taskIdFromEvent(event) {
+  if (!event || typeof event !== 'object') {
     return null;
   }
 
-  if (!agentsById.has(id)) {
-    agentsById.set(id, {
-      id,
-      name: 'Julia',
-      role: 'operator',
-      deskId: null,
-      state: 'idle',
-      currentTaskId: undefined,
-      targetDeskId: undefined
-    });
-  }
-
-  return agentsById.get(id);
-}
-
-function ensureTask(tasksById, taskId) {
-  const id = normalizeId(taskId);
-  if (!id) {
-    return null;
-  }
-
-  if (!tasksById.has(id)) {
-    tasksById.set(id, {
-      id,
-      type: 'unknown',
-      title: id,
-      status: 'created',
-      deskId: null,
-      assignedAgentId: null,
-      progress: 0,
-      required: 100,
-      createdAt: null,
-      updatedAt: null,
-      payload: null,
-      error: null
-    });
-  }
-
-  return tasksById.get(id);
-}
-
-function desksInOrder(desksById) {
-  return Array.from(desksById.values())
-    .sort((a, b) => {
-      const ai = Number.isFinite(a.deskIndex) ? a.deskIndex : 0;
-      const bi = Number.isFinite(b.deskIndex) ? b.deskIndex : 0;
-      if (ai !== bi) {
-        return ai - bi;
-      }
-      return a.id.localeCompare(b.id);
-    });
-}
-
-function resolveDeskIdForTask(event, task, desksById) {
   const payload = event && typeof event.payload === 'object' ? event.payload : {};
-
-  const payloadDeskId = normalizeId(payload.deskId);
-  if (payloadDeskId && desksById.has(payloadDeskId)) {
-    return payloadDeskId;
-  }
-
-  if (Number.isFinite(payload.deskIndex)) {
-    const byIndex = desksInOrder(desksById).find((desk) => Number(desk.deskIndex) === Number(payload.deskIndex));
-    if (byIndex) {
-      return byIndex.id;
-    }
-  }
-
-  if (event && event.task && Number.isFinite(event.task.deskIndex)) {
-    const byIndex = desksInOrder(desksById).find((desk) => Number(desk.deskIndex) === Number(event.task.deskIndex));
-    if (byIndex) {
-      return byIndex.id;
-    }
-  }
-
-  if (task && task.deskId && desksById.has(task.deskId)) {
-    return task.deskId;
-  }
-
-  const orderedDeskIds = desksInOrder(desksById).map((desk) => desk.id);
-  return stableDeskIdFromTaskId(task && task.id, orderedDeskIds);
+  return normalizeId(event.taskId)
+    || normalizeId(payload.taskId)
+    || normalizeId(event && event.task && event.task.id);
 }
 
-function applyEntityEvent(event, desksById, agentsById) {
-  const type = event && event.type ? String(event.type) : null;
-  const payload = event && typeof event.payload === 'object' ? event.payload : {};
-
-  if (type === 'SYSTEM_BOOT') {
-    return true;
-  }
-
-  if (type === 'DESK_CREATED') {
-    const deskId = normalizeId(payload.deskId) || (Number.isFinite(payload.deskIndex) ? `desk-${payload.deskIndex}` : null);
-    const desk = ensureDesk(
-      desksById,
-      deskId,
-      Number.isFinite(payload.deskIndex) ? Number(payload.deskIndex) : desksById.size
-    );
-
-    desk.role = payload.role ? String(payload.role) : desk.role;
-    desk.deskIndex = Number.isFinite(payload.deskIndex) ? Number(payload.deskIndex) : desk.deskIndex;
-
-    if (payload.position && Number.isFinite(payload.position.x) && Number.isFinite(payload.position.y)) {
-      desk.x = Number(payload.position.x);
-      desk.y = Number(payload.position.y);
-    }
-
-    return true;
-  }
-
-  if (type === 'AGENT_SPAWNED') {
-    const agent = ensureAgent(agentsById, payload.agentId);
-    if (!agent) {
-      return true;
-    }
-
-    agent.name = typeof payload.name === 'string' ? payload.name : agent.name;
-    agent.role = typeof payload.role === 'string' ? payload.role : agent.role;
-    agent.state = 'idle';
-    agent.currentTaskId = undefined;
-    agent.targetDeskId = undefined;
-    return true;
-  }
-
-  if (type === 'AGENT_ASSIGNED_IDLE') {
-    const agent = ensureAgent(agentsById, payload.agentId);
-    if (!agent) {
-      return true;
-    }
-
-    const deskId = normalizeId(payload.deskId);
-    if (deskId) {
-      ensureDesk(desksById, deskId, desksById.size);
-      agent.deskId = deskId;
-      agent.targetDeskId = deskId;
-    }
-
-    agent.state = 'idle';
-    agent.currentTaskId = undefined;
-    return true;
-  }
-
-  return false;
-}
-
-function applyTaskSnapshot(task, snapshot, timestamp, desksById) {
-  task.type = snapshot && snapshot.type ? String(snapshot.type) : task.type;
-  task.title = snapshot && snapshot.title ? String(snapshot.title) : task.title;
-  task.status = snapshot && snapshot.status ? String(snapshot.status) : task.status;
-  task.progress = Number.isFinite(snapshot && snapshot.progress) ? Number(snapshot.progress) : task.progress;
-  task.required = Number.isFinite(snapshot && snapshot.required) ? Number(snapshot.required) : task.required;
-  task.payload = snapshot && snapshot.payload ? clone(snapshot.payload) : task.payload;
-  task.updatedAt = timestamp;
-  if (!task.createdAt) {
-    task.createdAt = timestamp;
-  }
-
-  if (Number.isFinite(snapshot && snapshot.deskIndex)) {
-    const desk = desksInOrder(desksById).find((item) => Number(item.deskIndex) === Number(snapshot.deskIndex));
-    if (desk) {
-      task.deskId = desk.id;
-    }
-  }
-}
-
-function resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId) {
-  const payload = event && typeof event.payload === 'object' ? event.payload : {};
-
-  const payloadAgentId = normalizeId(payload.agentId);
-  if (payloadAgentId) {
-    return ensureAgent(agentsById, payloadAgentId);
-  }
-
-  if (task && task.assignedAgentId) {
-    return ensureAgent(agentsById, task.assignedAgentId);
-  }
-
-  const existingAgentId = taskToAgentId.get(task.id);
-  if (existingAgentId) {
-    return ensureAgent(agentsById, existingAgentId);
-  }
-
-  const deskId = task && task.deskId ? task.deskId : null;
-  if (deskId) {
-    const deskAgent = ensureAgent(agentsById, `agent-${deskId}`);
-    if (deskAgent && !deskAgent.deskId) {
-      deskAgent.deskId = deskId;
-    }
-    return deskAgent;
-  }
-
-  const idleAgent = Array.from(agentsById.values())
-    .find((agent) => !agentToTaskId.has(agent.id));
-
-  return idleAgent || null;
-}
-
-function unbindTaskFromAgent(taskId, taskToAgentId, agentToTaskId) {
-  const existingAgentId = taskToAgentId.get(taskId);
-  if (!existingAgentId) {
+function pushGrouped(map, key, event) {
+  if (!key) {
     return;
   }
 
-  taskToAgentId.delete(taskId);
-  if (agentToTaskId.get(existingAgentId) === taskId) {
-    agentToTaskId.delete(existingAgentId);
-  }
-}
-
-function bindTaskToAgent(task, agent, taskToAgentId, agentToTaskId) {
-  if (!task || !agent) {
-    return;
+  if (!map.has(key)) {
+    map.set(key, []);
   }
 
-  const previousTaskForAgent = agentToTaskId.get(agent.id);
-  if (previousTaskForAgent && previousTaskForAgent !== task.id) {
-    taskToAgentId.delete(previousTaskForAgent);
-  }
-
-  unbindTaskFromAgent(task.id, taskToAgentId, agentToTaskId);
-
-  taskToAgentId.set(task.id, agent.id);
-  agentToTaskId.set(agent.id, task.id);
-  task.assignedAgentId = agent.id;
-}
-
-function applyTaskLifecycleEvent(event, task, desksById, agentsById, taskToAgentId, agentToTaskId, tasksById) {
-  const type = event && event.type ? String(event.type) : null;
-  const timestamp = Number.isFinite(event && event.timestamp) ? Number(event.timestamp) : null;
-  const payload = event && typeof event.payload === 'object' ? event.payload : {};
-
-  const deskId = resolveDeskIdForTask(event, task, desksById);
-  if (deskId) {
-    ensureDesk(desksById, deskId, desksById.size);
-    task.deskId = deskId;
-  }
-
-  task.updatedAt = timestamp;
-  if (!task.createdAt) {
-    task.createdAt = timestamp;
-  }
-
-  if (type === 'TASK_CREATED') {
-    task.status = 'created';
-    return;
-  }
-
-  if (type === 'TASK_QUEUED' || type === 'TASK_ENQUEUED') {
-    task.status = 'queued';
-    return;
-  }
-
-  if (type === 'TASK_CLAIMED') {
-    task.status = 'claimed';
-
-    const agent = resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId);
-    if (!agent) {
-      return;
-    }
-
-    bindTaskToAgent(task, agent, taskToAgentId, agentToTaskId);
-    agent.state = 'moving';
-    agent.currentTaskId = task.id;
-    agent.targetDeskId = task.deskId || agent.deskId || undefined;
-    if (!agent.deskId && task.deskId) {
-      agent.deskId = task.deskId;
-    }
-    return;
-  }
-
-  if (type === 'TASK_STARTED' || type === 'TASK_EXECUTE_STARTED') {
-    task.status = 'executing';
-
-    const agent = resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId);
-    if (!agent) {
-      return;
-    }
-
-    bindTaskToAgent(task, agent, taskToAgentId, agentToTaskId);
-    agent.state = 'working';
-    agent.currentTaskId = task.id;
-    agent.targetDeskId = task.deskId || agent.deskId || undefined;
-    if (!agent.deskId && task.deskId) {
-      agent.deskId = task.deskId;
-    }
-    return;
-  }
-
-  if (type === 'TASK_PROGRESS') {
-    task.status = 'executing';
-    if (Number.isFinite(payload.progress)) {
-      task.progress = Number(payload.progress);
-    }
-    if (Number.isFinite(payload.required)) {
-      task.required = Number(payload.required);
-    }
-
-    const agent = resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId);
-    if (!agent) {
-      return;
-    }
-
-    bindTaskToAgent(task, agent, taskToAgentId, agentToTaskId);
-    agent.state = 'working';
-    agent.currentTaskId = task.id;
-    agent.targetDeskId = task.deskId || agent.deskId || undefined;
-    return;
-  }
-
-  if (type === 'TASK_COMPLETED' || type === 'TASK_FAILED') {
-    // Accept legacy terminal aliases for replay tolerance, but do not
-    // derive terminal lifecycle authority from them.
-    return;
-  }
-
-  if (type === 'TASK_EXECUTE_FINISHED') {
-    task.status = 'awaiting_ack';
-    task.error = payload && Object.prototype.hasOwnProperty.call(payload, 'error')
-      ? (payload.error || null)
-      : task.error;
-
-    const agent = resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId);
-    if (!agent) {
-      return;
-    }
-
-    bindTaskToAgent(task, agent, taskToAgentId, agentToTaskId);
-    agent.state = 'delivering';
-    agent.currentTaskId = task.id;
-    agent.targetDeskId = task.deskId || agent.deskId || undefined;
-    return;
-  }
-
-  if (type === 'TASK_ACKED') {
-    const ackStatus = typeof payload.status === 'string' ? payload.status : null;
-    if (!ackStatus) {
-      return;
-    }
-
-    task.status = ackStatus;
-    if (ackStatus === 'failed') {
-      task.error = payload.error || task.error || 'ack_failed';
-    }
-
-    const agent = resolveAgentForTask(event, task, desksById, agentsById, taskToAgentId, agentToTaskId);
-    if (!agent) {
-      return;
-    }
-
-    unbindTaskFromAgent(task.id, taskToAgentId, agentToTaskId);
-    agent.state = 'idle';
-    agent.currentTaskId = undefined;
-    agent.targetDeskId = agent.deskId || undefined;
-  }
-
-  // Keep tasksById referenced to satisfy no overlap cleanup in bind path.
-  void tasksById;
-}
-
-function rebuildDeskQueues(desksById, tasks) {
-  for (const desk of desksById.values()) {
-    desk.currentTaskId = null;
-    desk.queueTaskIds = [];
-  }
-
-  for (const task of tasks) {
-    if (!task.deskId || !desksById.has(task.deskId)) {
-      continue;
-    }
-
-    const desk = desksById.get(task.deskId);
-
-    if (task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack') {
-      desk.currentTaskId = task.id;
-      continue;
-    }
-
-    if (task.status === 'queued' || task.status === 'created') {
-      desk.queueTaskIds.push(task.id);
-    }
-  }
-
-  for (const desk of desksById.values()) {
-    desk.queueTaskIds.sort((a, b) => String(a).localeCompare(String(b)));
-  }
-}
-
-function finalizeAgents(agentsById, taskToAgentId) {
-  for (const agent of agentsById.values()) {
-    const activeTaskId = agent.currentTaskId;
-    if (!activeTaskId) {
-      agent.state = 'idle';
-      agent.currentTaskId = undefined;
-      agent.targetDeskId = agent.deskId || undefined;
-      continue;
-    }
-
-    if (taskToAgentId.get(activeTaskId) !== agent.id) {
-      agent.state = 'idle';
-      agent.currentTaskId = undefined;
-      agent.targetDeskId = agent.deskId || undefined;
-    }
-  }
+  map.get(key).push(event);
 }
 
 export function deriveWorldState(events) {
   const immutableEvents = Array.isArray(events) ? events.map((event) => clone(event)) : [];
+  const sortedEvents = immutableEvents
+    .filter((event) => event && typeof event === 'object')
+    .sort(compareEvents);
 
-  const desksById = new Map();
-  const agentsById = new Map();
-  const tasksById = new Map();
-  const taskToAgentId = new Map();
-  const agentToTaskId = new Map();
+  const eventsByTaskId = new Map();
+  const eventsByWorkerId = new Map();
 
-  for (const event of immutableEvents) {
-    if (!event || typeof event !== 'object') {
-      continue;
-    }
-
-    if (applyEntityEvent(event, desksById, agentsById)) {
-      continue;
-    }
-
-    const eventTaskId = normalizeId(event.taskId) || normalizeId(event && event.payload && event.payload.taskId);
-    const timestamp = Number.isFinite(event.timestamp) ? Number(event.timestamp) : null;
-
-    if (event.task && typeof event.task === 'object') {
-      const snapshotTaskId = normalizeId(event.task.id) || eventTaskId;
-      if (snapshotTaskId) {
-        const task = ensureTask(tasksById, snapshotTaskId);
-        applyTaskSnapshot(task, event.task, timestamp, desksById);
-      }
-      continue;
-    }
-
-    if (!eventTaskId) {
-      continue;
-    }
-
-    const task = ensureTask(tasksById, eventTaskId);
-    if (!task) {
-      continue;
-    }
-
-    applyTaskLifecycleEvent(event, task, desksById, agentsById, taskToAgentId, agentToTaskId, tasksById);
+  for (const event of sortedEvents) {
+    pushGrouped(eventsByTaskId, taskIdFromEvent(event), event);
+    pushGrouped(eventsByWorkerId, workerIdFromEvent(event), event);
   }
 
-  const tasks = Array.from(tasksById.values())
-    .map((task) => ({
-      ...task,
-      payload: clone(task.payload)
-    }))
-    .sort((a, b) => {
-      const aTime = Number.isFinite(a.createdAt) ? a.createdAt : 0;
-      const bTime = Number.isFinite(b.createdAt) ? b.createdAt : 0;
-      if (aTime !== bTime) {
-        return aTime - bTime;
-      }
-      return a.id.localeCompare(b.id);
-    });
-
-  rebuildDeskQueues(desksById, tasks);
-  finalizeAgents(agentsById, taskToAgentId);
-
-  const desks = desksInOrder(desksById)
-    .map((desk) => ({
-      ...desk,
-      queueTaskIds: [...desk.queueTaskIds]
-    }));
-
-  const agents = Array.from(agentsById.values())
-    .map((agent) => ({
-      id: agent.id,
-      name: agent.name,
-      role: agent.role,
-      deskId: agent.deskId,
-      state: agent.state,
-      currentTaskId: agent.currentTaskId,
-      targetDeskId: agent.targetDeskId
-    }))
-    .sort((a, b) => a.id.localeCompare(b.id));
-
-  const notifications = tasks
-    .filter((task) => task.status === 'failed')
-    .slice(-8)
-    .map((task) => ({
-      type: 'task_failed',
-      taskId: task.id,
-      message: task.error || 'Task failed'
-    }));
-
-  const overlays = [
-    {
-      type: 'hud',
-      counts: {
-        queued: tasks.filter((task) => task.status === 'queued' || task.status === 'created').length,
-        active: tasks.filter((task) => task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack').length,
-        done: tasks.filter((task) => task.status === 'acknowledged' || task.status === 'completed').length,
-        failed: tasks.filter((task) => task.status === 'failed').length
-      }
-    }
-  ];
-
   return {
-    agents,
-    tasks,
-    desks,
-    ui: {
-      overlays,
-      notifications
-    }
+    events: sortedEvents,
+    eventsByTaskId,
+    eventsByWorkerId
   };
 }

--- a/core/world/indexedWorldSnapshot.js
+++ b/core/world/indexedWorldSnapshot.js
@@ -1,0 +1,6 @@
+import { getRawEvents } from './eventStore.js';
+import { deriveWorldState } from './deriveWorldState.js';
+
+export function getIndexedWorldSnapshot() {
+  return deriveWorldState(getRawEvents());
+}

--- a/docs/ui-architecture-spec-v1.md
+++ b/docs/ui-architecture-spec-v1.md
@@ -1,0 +1,425 @@
+Here is your **clean, consolidated, production-grade UI Architecture Spec v2** — combining everything you already built plus the missing enforcement layer so Copilot stops drifting.
+
+You can paste this directly into:
+
+```text
+docs/ui-architecture-spec-v2.md
+```
+
+---
+
+# 🎨 SLOTHWORLD — UI ARCHITECTURE SPEC v2
+
+---
+
+# 🧠 PURPOSE
+
+The Slothworld UI is a **read-only observability system** for a deterministic event-driven execution engine.
+
+It is NOT:
+
+* a game
+* a simulation
+* a control system
+* a workflow orchestrator
+
+It is:
+
+> a real-time visual debugger for TaskEngine execution
+
+---
+
+# 🧠 ABSOLUTE UI TRUTH
+
+The UI has NO authority over system state.
+
+It only renders truth derived from:
+
+```text
+event stream → deriveWorldState → selectors → UI views
+```
+
+---
+
+# 🧱 UI DESIGN PRINCIPLES (NON-NEGOTIABLE)
+
+## 1. Event-first architecture
+
+All UI originates from the immutable event stream.
+
+No UI state is authoritative.
+
+---
+
+## 2. Read-only system
+
+UI MUST NOT:
+
+* mutate tasks
+* trigger execution
+* influence engine behavior
+* call providers or backend actions
+
+---
+
+## 3. Multi-view consistency
+
+All panels represent the SAME underlying truth.
+
+Different views ≠ different interpretations.
+
+---
+
+## 4. No hidden logic
+
+UI may:
+
+* filter
+* group
+* visualize
+* highlight
+
+UI may NOT:
+
+* infer lifecycle meaning beyond spec
+* invent new system concepts
+* create workflow behavior
+* introduce decision systems
+
+---
+
+# 🧩 UI SYSTEM MODULES
+
+---
+
+# 1. 🧠 EVENT STREAM CORE
+
+## Role
+
+Immutable backbone of UI.
+
+### Input
+
+* append-only event log
+
+### Output
+
+* normalized event objects
+
+### Rules
+
+* immutable
+* chronological ordering guaranteed
+* no interpretation logic
+
+### Consumers
+
+* Task Inspector
+* Raccoon Feeder
+* Canvas Renderer
+* Dashboard
+
+---
+
+# 2. 📜 TASK LIFECYCLE INSPECTOR (PRIMARY DEBUG VIEW)
+
+## Role
+
+Explains a single task’s full history.
+
+### Shows:
+
+* full event chain
+* timestamps between transitions
+* worker involvement
+* execution duration
+* ACK outcome
+
+### Canonical flow:
+
+```text
+TASK_CREATED
+→ TASK_ENQUEUED
+→ TASK_CLAIMED
+→ TASK_EXECUTE_STARTED
+→ TASK_EXECUTE_FINISHED
+→ TASK_ACKED
+```
+
+### Rules:
+
+* derived ONLY from events
+* no inferred states
+* must flag missing transitions
+
+---
+
+# 3. 🦝 RACCOON FEEDER (EXCEPTION VIEW)
+
+## Role
+
+Read-only anomaly aggregation dashboard.
+
+### Input (ONLY event filters)
+
+* TASK_ACKED failures
+* stalled ACK windows
+* execution timeouts
+* missing transitions
+* enforcement violations
+
+### Output
+
+Grouped incident clusters:
+
+* failed_tasks
+* stalled_tasks
+* unacked_tasks
+* execution_timeouts
+
+---
+
+## 🚫 HARD RULES
+
+The Raccoon Feeder MUST NOT:
+
+* trigger retries
+* modify tasks
+* execute actions
+* act as a control system
+
+It is:
+
+> a log intelligence view, not an operator system
+
+---
+
+# 4. 🎮 CANVAS OFFICE RENDERER (SPATIAL VIEW)
+
+## Role
+
+Visual metaphor of execution state.
+
+### Entities (derived only)
+
+* workers
+* tasks
+* desks
+* movement paths
+
+---
+
+## Event mapping:
+
+| Event                 | Visual              |
+| --------------------- | ------------------- |
+| TASK_CREATED          | ticket spawns       |
+| TASK_ENQUEUED         | queued              |
+| TASK_CLAIMED          | worker moves        |
+| TASK_EXECUTE_STARTED  | working animation   |
+| TASK_EXECUTE_FINISHED | processing complete |
+| TASK_ACKED            | terminal animation  |
+
+---
+
+## Rules:
+
+* no lifecycle inference
+* no stored state
+* no logic decisions
+
+---
+
+# 5. 🧭 SYSTEM OVERVIEW DASHBOARD
+
+## Role
+
+High-level system observability.
+
+### Displays:
+
+* active tasks
+* throughput
+* ACK success/failure rate
+* worker utilization
+* queue depth
+* execution latency
+
+---
+
+## Rules:
+
+* aggregation only
+* no per-task mutation
+* no semantic inference
+
+---
+
+# 🧍 AGENT VISUAL MODEL (UI ONLY)
+
+Agents DO NOT exist in backend.
+
+They are derived views:
+
+```ts
+AgentViewModel = {
+  agentId: string,
+  role: "researcher" | "designer" | "operator" | "executor",
+  state: "idle" | "moving" | "working" | "error" | "delivering",
+  position: { x: number, y: number },
+  currentTaskId?: string
+}
+```
+
+---
+
+## RULES
+
+* NOT persisted
+* NOT authoritative
+* NOT system actors
+
+Agents are:
+
+> animated projections of worker activity
+
+---
+
+# 📊 UI SEMANTIC REGISTRY (STRICT DEFINITION LAYER)
+
+UI is ONLY allowed to use semantics defined here.
+
+---
+
+## 1. TASK DERIVED STATES
+
+Allowed derived states:
+
+* active_task
+* executing_task
+* pending_ack_task
+* completed_task (TASK_ACKED success)
+* failed_task (TASK_ACKED failure)
+
+---
+
+## 2. TIME METRICS (STRICT)
+
+Only allowed timing calculations:
+
+* queue_time
+  = TASK_CREATED → TASK_CLAIMED
+
+* execution_duration
+  = TASK_EXECUTE_STARTED → TASK_EXECUTE_FINISHED
+
+* ack_latency
+  = TASK_EXECUTE_FINISHED → TASK_ACKED
+
+NO other timing interpretations allowed.
+
+---
+
+## 3. ANOMALY DEFINITIONS (STRICT RULES)
+
+Only valid anomalies:
+
+* stalled_ack
+  TASK_EXECUTE_FINISHED exists AND no TASK_ACKED after threshold
+
+* execution_missing_finish
+  TASK_EXECUTE_STARTED exists AND no TASK_EXECUTE_FINISHED
+
+* duplicate_ack
+  multiple TASK_ACKED for same taskId
+
+---
+
+## 🚫 PROHIBITED SEMANTICS
+
+UI MUST NOT invent:
+
+* retry storms
+* failure clusters
+* behavioral intelligence layers
+* system health heuristics
+* execution irregularities (unless defined above)
+
+If not in registry → it does not exist.
+
+---
+
+# 🔁 DATA FLOW MODEL
+
+```text
+Event Stream
+   ↓
+Event Normalizer
+   ↓
+deriveWorldState()
+   ↓
+Semantic Selectors (REGISTRY ONLY)
+   ↓
+UI Panels
+```
+
+---
+
+# 🎨 VISUAL DESIGN RULES
+
+* same event = same meaning everywhere
+* no panel may reinterpret lifecycle independently
+* animation is representation, not state
+
+---
+
+# 🚫 FORBIDDEN UI PATTERNS
+
+DO NOT:
+
+* mutate tasks
+* introduce control actions
+* store hidden state per panel
+* build smart agents
+* infer lifecycle transitions
+* create new semantics outside registry
+* introduce UI-driven workflows
+
+---
+
+# 🧠 CORE UI MINDSET
+
+The UI is:
+
+> a deterministic observability system for a workflow engine
+
+NOT:
+
+> an interactive simulation of agents
+
+---
+
+# 🧠 FINAL RULE
+
+If a feature requires:
+
+* new lifecycle meaning
+* new semantic category
+* execution influence
+* or system authority
+
+👉 it does NOT belong in UI.
+
+---
+
+# 🧭 VERSION GUARANTEE
+
+This spec is:
+
+* deterministic
+* event-bound
+* Copilot-safe
+* implementation-constrained
+* extension-controlled via registry only
+
+---

--- a/rendering/canvas-renderer.js
+++ b/rendering/canvas-renderer.js
@@ -2,6 +2,17 @@ import { canvas, ctx } from '../core/app-state.js';
 import { loadedAssets } from './assets.js';
 import { spriteConfigs } from '../core/constants.js';
 import { resolveAgentVisual } from '../ui/config/agentVisualConfig.js';
+import { getAllTasks, getAllDesks } from '../ui/selectors/taskSelectors.js';
+import { getAllAgents } from '../ui/selectors/agentSelectors.js';
+import { getTaskCounts } from '../ui/selectors/metricsSelectors.js';
+import { getIncidentClusters } from '../ui/selectors/anomalySelectors.js';
+
+let debugBindingsAttached = false;
+const debugPointer = {
+  x: null,
+  y: null,
+  inside: false
+};
 
 function hashString(text) {
   const value = String(text || '');
@@ -36,6 +47,51 @@ function easeInOutSine(t) {
 function easeOutCubic(t) {
   const x = clamp01(t);
   return 1 - Math.pow(1 - x, 3);
+}
+
+function isRenderDebugEnabled() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (window.__SLOTHWORLD_RENDER_DEBUG__ === true) {
+    return true;
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).has('renderDebug');
+  } catch (_error) {
+    return false;
+  }
+}
+
+function ensureDebugBindings() {
+  if (debugBindingsAttached || typeof window === 'undefined' || !canvas) {
+    return;
+  }
+
+  const updatePointer = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    debugPointer.x = (event.clientX - rect.left) * scaleX;
+    debugPointer.y = (event.clientY - rect.top) * scaleY;
+    debugPointer.inside = true;
+  };
+
+  canvas.addEventListener('mousemove', updatePointer);
+  canvas.addEventListener('mouseenter', updatePointer);
+  canvas.addEventListener('mouseleave', () => {
+    debugPointer.inside = false;
+    debugPointer.x = null;
+    debugPointer.y = null;
+  });
+
+  debugBindingsAttached = true;
 }
 
 function deskAnchor(desk) {
@@ -141,6 +197,69 @@ function statusColor(status) {
   return '#94a3b8';
 }
 
+function resolveSpriteFrame(visual, spriteImage, frameNow, agentId) {
+  const imageWidth = spriteImage && Number.isFinite(spriteImage.naturalWidth) ? spriteImage.naturalWidth : spriteImage.width;
+  const imageHeight = spriteImage && Number.isFinite(spriteImage.naturalHeight) ? spriteImage.naturalHeight : spriteImage.height;
+  const frameWidth = Number.isFinite(visual && visual.frameWidth) ? visual.frameWidth : imageWidth;
+  const frameHeight = Number.isFinite(visual && visual.frameHeight) ? visual.frameHeight : imageHeight;
+  const frameCount = Math.max(1, Number.isFinite(visual && visual.frameCount) ? visual.frameCount : Math.floor(imageWidth / frameWidth) || 1);
+  const frameDurationMs = Math.max(1, Number.isFinite(visual && visual.frameDurationMs) ? visual.frameDurationMs : 200);
+  const frameIndex = frameCount <= 1
+    ? 0
+    : Math.floor((frameNow + hashString(agentId) * 17) / frameDurationMs) % frameCount;
+
+  return {
+    sourceX: frameIndex * frameWidth,
+    sourceY: 0,
+    sourceWidth: frameWidth,
+    sourceHeight: frameHeight,
+    frameIndex,
+    frameCount
+  };
+}
+
+function resolveSpriteDrawSize(frame) {
+  const targetHeight = spriteConfigs && spriteConfigs.agent && Number.isFinite(spriteConfigs.agent.height)
+    ? spriteConfigs.agent.height
+    : 48;
+  const scale = frame && Number.isFinite(frame.sourceHeight) && frame.sourceHeight > 0
+    ? targetHeight / frame.sourceHeight
+    : 1;
+
+  return {
+    width: (frame && Number.isFinite(frame.sourceWidth) ? frame.sourceWidth : targetHeight) * scale,
+    height: targetHeight,
+    scale
+  };
+}
+
+function drawSpriteDebugOverlay(x, y, drawSize, frame, hovered) {
+  if (!isRenderDebugEnabled()) {
+    return;
+  }
+
+  ctx.save();
+  ctx.strokeStyle = hovered ? 'rgba(251, 191, 36, 0.95)' : 'rgba(56, 189, 248, 0.85)';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x - drawSize.width / 2, y - drawSize.height, drawSize.width, drawSize.height);
+
+  ctx.fillStyle = 'rgba(239, 68, 68, 0.95)';
+  ctx.beginPath();
+  ctx.arc(x, y, 2.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (hovered) {
+    const label = `${frame.sourceWidth}x${frame.sourceHeight} f${frame.frameIndex + 1}/${frame.frameCount}`;
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.92)';
+    ctx.fillRect(x - 36, y - drawSize.height - 16, 72, 12);
+    ctx.fillStyle = '#f8fafc';
+    ctx.font = '8px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, x, y - drawSize.height - 7);
+  }
+  ctx.restore();
+}
+
 function drawDesk(desk) {
   const width = 92;
   const height = 56;
@@ -191,20 +310,29 @@ function drawAgent(agent, desksById, tasksById, frameNow) {
   const spriteImage = visual && visual.spriteFilename ? loadedAssets[visual.spriteFilename] : null;
 
   if (spriteImage) {
-    const width = spriteConfigs && spriteConfigs.agent && Number.isFinite(spriteConfigs.agent.width)
-      ? spriteConfigs.agent.width
-      : 48;
-    const height = spriteConfigs && spriteConfigs.agent && Number.isFinite(spriteConfigs.agent.height)
-      ? spriteConfigs.agent.height
-      : 48;
+    const frame = resolveSpriteFrame(visual, spriteImage, frameNow, agent && agent.id);
+    const drawSize = resolveSpriteDrawSize(frame);
+    const isHovered = debugPointer.inside
+      && Number.isFinite(debugPointer.x)
+      && Number.isFinite(debugPointer.y)
+      && debugPointer.x >= x - drawSize.width / 2
+      && debugPointer.x <= x + drawSize.width / 2
+      && debugPointer.y >= y - drawSize.height
+      && debugPointer.y <= y;
 
     ctx.drawImage(
       spriteImage,
-      x - width / 2,
-      y - height / 2,
-      width,
-      height
+      frame.sourceX,
+      frame.sourceY,
+      frame.sourceWidth,
+      frame.sourceHeight,
+      x - drawSize.width / 2,
+      y - drawSize.height,
+      drawSize.width,
+      drawSize.height
     );
+
+    drawSpriteDebugOverlay(x, y, drawSize, frame, isHovered);
   } else {
     // Fallback: preserve previous circle visualization when no sprite is available.
     ctx.fillStyle = statusColor(visualState);
@@ -255,53 +383,53 @@ function drawAgent(agent, desksById, tasksById, frameNow) {
   ctx.fillText(visualState, x, y + 30);
 }
 
-function drawHud(worldState) {
-  const overlays = worldState && worldState.ui && Array.isArray(worldState.ui.overlays)
-    ? worldState.ui.overlays
-    : [];
-  const hud = overlays.find((item) => item && item.type === 'hud');
-
-  const counts = hud && hud.counts ? hud.counts : { queued: 0, active: 0, done: 0, failed: 0 };
+function drawHud(counts, incidents) {
+  const safeCounts = counts && typeof counts === 'object'
+    ? counts
+    : { queued: 0, active: 0, done: 0, failed: 0 };
 
   ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
-  ctx.fillRect(10, 10, 340, 38);
+  ctx.fillRect(10, 10, 360, 38);
   ctx.strokeStyle = '#334155';
-  ctx.strokeRect(10, 10, 340, 38);
+  ctx.strokeRect(10, 10, 360, 38);
 
   ctx.fillStyle = '#e2e8f0';
   ctx.font = '11px monospace';
   ctx.textAlign = 'left';
-  ctx.fillText(`Queued: ${counts.queued}`, 18, 25);
-  ctx.fillText(`Active: ${counts.active}`, 105, 25);
-  ctx.fillText(`Done: ${counts.done}`, 188, 25);
-  ctx.fillText(`Failed: ${counts.failed}`, 260, 25);
+  ctx.fillText(`Queued: ${safeCounts.queued}`, 18, 25);
+  ctx.fillText(`Active: ${safeCounts.active}`, 105, 25);
+  ctx.fillText(`Done: ${safeCounts.done}`, 188, 25);
+  ctx.fillText(`Failed: ${safeCounts.failed}`, 260, 25);
 
-  const notifications = worldState && worldState.ui && Array.isArray(worldState.ui.notifications)
-    ? worldState.ui.notifications
-    : [];
+  const list = Array.isArray(incidents) ? incidents : [];
 
-  if (!notifications.length) {
+  if (!list.length) {
     return;
   }
 
-  const latest = notifications[notifications.length - 1];
+  const latest = list[0];
   ctx.fillStyle = '#fecaca';
   ctx.font = '10px monospace';
-  ctx.fillText(`Alert: ${latest.message}`, 18, 40);
+  ctx.fillText(`Alert: ${latest.category}${latest.taskId ? ` (${latest.taskId})` : ''}`, 18, 40);
 }
 
-export function render(worldState) {
-  const safeWorld = worldState && typeof worldState === 'object'
-    ? worldState
-    : { agents: [], tasks: [], desks: [], ui: { overlays: [], notifications: [] } };
+export function render(indexedWorld) {
+  const safeIndexed = indexedWorld && typeof indexedWorld === 'object'
+    ? indexedWorld
+    : { events: [], eventsByTaskId: new Map(), eventsByWorkerId: new Map() };
 
-  const desks = Array.isArray(safeWorld.desks) ? safeWorld.desks : [];
-  const tasks = Array.isArray(safeWorld.tasks) ? safeWorld.tasks : [];
-  const agents = Array.isArray(safeWorld.agents) ? safeWorld.agents : [];
+  const desks = getAllDesks(safeIndexed);
+  const tasks = getAllTasks(safeIndexed);
+  const agents = getAllAgents(safeIndexed);
+  const counts = getTaskCounts(safeIndexed);
+  const incidents = getIncidentClusters(safeIndexed, { now: Date.now() });
 
   const desksById = new Map(desks.map((desk) => [desk.id, desk]));
   const tasksById = new Map(tasks.map((task) => [task.id, task]));
   const frameNow = Date.now();
+
+  ensureDebugBindings();
+  ctx.imageSmoothingEnabled = false;
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#0b1220';
@@ -320,5 +448,5 @@ export function render(worldState) {
     drawAgent(agent, desksById, tasksById, frameNow);
   }
 
-  drawHud(safeWorld);
+  drawHud(counts, incidents);
 }

--- a/style.css
+++ b/style.css
@@ -355,4 +355,81 @@ canvas {
   body {
     overflow: auto;
   }
+
+  #raccoon-feeder-panel {
+    width: 100%;
+    box-sizing: border-box;
+    background: rgba(18, 22, 30, 0.72);
+    border: 1px solid #2f343d;
+    border-radius: 4px;
+    padding: 10px;
+  }
+
+  .rfp-header h2 {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .rfp-header p {
+    margin: 4px 0 10px;
+    color: #9ca3af;
+    font-size: 11px;
+  }
+
+  .rfp-section {
+    border: 1px solid #313741;
+    padding: 8px;
+  }
+
+  .rfp-section h3 {
+    margin: 0 0 8px;
+    font-size: 12px;
+  }
+
+  .rfp-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    max-height: 150px;
+    overflow-y: auto;
+  }
+
+  .rfp-item {
+    width: 100%;
+    background: #1c2129;
+    color: #d1d5db;
+    border: 1px solid #3a424f;
+    text-align: left;
+    padding: 4px;
+    margin-bottom: 3px;
+    font: 11px monospace;
+    cursor: pointer;
+  }
+
+  .rfp-item:hover {
+    border-color: #6b7280;
+  }
+
+  .rfp-item.is-selected {
+    border-color: #f59e0b;
+    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.45);
+  }
+
+  .rfp-empty {
+    font-size: 11px;
+    color: #9ca3af;
+    padding: 2px 0;
+  }
+
+  .rfp-detail {
+    margin: 6px 0 0;
+    background: #0f1318;
+    border: 1px solid #2d3340;
+    padding: 6px;
+    font: 11px/1.35 monospace;
+    color: #cbd5e1;
+    white-space: pre-wrap;
+    max-height: 200px;
+    overflow: auto;
+  }
 }

--- a/tests/event-contract-lock.test.mjs
+++ b/tests/event-contract-lock.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { deriveWorldState } from '../core/world/deriveWorldState.js';
+import { getTaskStatus, getTaskEvents } from '../ui/selectors/taskSelectors.js';
 
 test('does NOT mark task failed without TASK_ACKED', () => {
   const events = [
@@ -9,11 +10,12 @@ test('does NOT mark task failed without TASK_ACKED', () => {
   ];
 
   const world = deriveWorldState(events);
-  const task = world.tasks.find((item) => item.id === 't1');
+  const status = getTaskStatus(world, 't1');
+  const taskEvents = getTaskEvents(world, 't1');
 
-  assert.ok(task, 'task should be present in world state');
-  assert.equal(task.status, 'awaiting_ack');
-  assert.notEqual(task.status, 'failed');
+  assert.ok(taskEvents.length > 0, 'task should be present in indexed world');
+  assert.equal(status, 'awaiting_ack');
+  assert.notEqual(status, 'failed');
 });
 
 test('marks task failed only when TASK_ACKED payload.status is failed', () => {
@@ -24,10 +26,11 @@ test('marks task failed only when TASK_ACKED payload.status is failed', () => {
   ];
 
   const world = deriveWorldState(events);
-  const task = world.tasks.find((item) => item.id === 't2');
+  const status = getTaskStatus(world, 't2');
+  const taskEvents = getTaskEvents(world, 't2');
 
-  assert.ok(task, 'task should be present in world state');
-  assert.equal(task.status, 'failed');
+  assert.ok(taskEvents.length > 0, 'task should be present in indexed world');
+  assert.equal(status, 'failed');
 });
 
 test('ignores TASK_FAILED without ACK', () => {
@@ -37,11 +40,12 @@ test('ignores TASK_FAILED without ACK', () => {
   ];
 
   const world = deriveWorldState(events);
-  const task = world.tasks.find((item) => item.id === 't3');
+  const status = getTaskStatus(world, 't3');
+  const taskEvents = getTaskEvents(world, 't3');
 
-  assert.ok(task, 'task should be present in world state');
-  assert.notEqual(task.status, 'failed');
-  assert.equal(task.status, 'created');
+  assert.ok(taskEvents.length > 0, 'task should be present in indexed world');
+  assert.notEqual(status, 'failed');
+  assert.equal(status, 'created');
 });
 
 test('ACK always produces terminal state', () => {
@@ -52,10 +56,11 @@ test('ACK always produces terminal state', () => {
   ];
 
   const world = deriveWorldState(events);
-  const task = world.tasks.find((item) => item.id === 't4');
+  const status = getTaskStatus(world, 't4');
+  const taskEvents = getTaskEvents(world, 't4');
 
-  assert.ok(task, 'task should be present in world state');
-  assert.ok(['completed', 'failed'].includes(task.status), 'ACK should produce a terminal state');
+  assert.ok(taskEvents.length > 0, 'task should be present in indexed world');
+  assert.ok(['completed', 'failed'].includes(status), 'ACK should produce a terminal state');
 });
 
 test('does NOT mark task completed without TASK_ACKED', () => {
@@ -65,10 +70,11 @@ test('does NOT mark task completed without TASK_ACKED', () => {
   ];
 
   const world = deriveWorldState(events);
-  const task = world.tasks.find((item) => item.id === 't5');
+  const status = getTaskStatus(world, 't5');
+  const taskEvents = getTaskEvents(world, 't5');
 
-  assert.ok(task, 'task should be present in world state');
-  assert.equal(task.status, 'awaiting_ack');
-  assert.notEqual(task.status, 'completed');
-  assert.notEqual(task.status, 'failed');
+  assert.ok(taskEvents.length > 0, 'task should be present in indexed world');
+  assert.equal(status, 'awaiting_ack');
+  assert.notEqual(status, 'completed');
+  assert.notEqual(status, 'failed');
 });

--- a/ui/config/agentVisualConfig.js
+++ b/ui/config/agentVisualConfig.js
@@ -2,11 +2,41 @@ export const agentVisualConfig = {
   operator: {
     baseSprite: 'julia_idle.png',
     animations: {
-      idle: 'julia_idle',
-      moving: 'julia_walk',
-      working: 'julia_typing',
-      delivering: 'julia_walk',
-      error: 'julia_error'
+      idle: {
+        key: 'julia_idle',
+        frameWidth: 32,
+        frameHeight: 32,
+        frameCount: 4,
+        frameDurationMs: 220
+      },
+      moving: {
+        key: 'julia_walk',
+        frameWidth: 64,
+        frameHeight: 64,
+        frameCount: 4,
+        frameDurationMs: 140
+      },
+      working: {
+        key: 'julia_typing',
+        frameWidth: 64,
+        frameHeight: 64,
+        frameCount: 6,
+        frameDurationMs: 120
+      },
+      delivering: {
+        key: 'julia_walk',
+        frameWidth: 64,
+        frameHeight: 64,
+        frameCount: 4,
+        frameDurationMs: 140
+      },
+      error: {
+        key: 'julia_error',
+        frameWidth: 32,
+        frameHeight: 32,
+        frameCount: 4,
+        frameDurationMs: 180
+      }
     }
   }
 };
@@ -25,9 +55,13 @@ export function resolveAgentVisual(role, state) {
   const stateKey = typeof state === 'string' && state.trim() ? state : 'idle';
 
   const visualByRole = agentVisualConfig[roleKey] || agentVisualConfig.operator;
-  const animationKey = (visualByRole && visualByRole.animations && visualByRole.animations[stateKey])
+  const animationDef = (visualByRole && visualByRole.animations && visualByRole.animations[stateKey])
     || (visualByRole && visualByRole.animations && visualByRole.animations.idle)
     || null;
+  const normalizedAnimation = typeof animationDef === 'string'
+    ? { key: animationDef }
+    : animationDef;
+  const animationKey = normalizedAnimation && normalizedAnimation.key ? normalizedAnimation.key : null;
 
   const spriteFilename = animationKey ? (agentAnimationSprites[animationKey] || null) : null;
 
@@ -36,6 +70,10 @@ export function resolveAgentVisual(role, state) {
     state: stateKey,
     baseSprite: visualByRole ? visualByRole.baseSprite : null,
     animation: animationKey,
-    spriteFilename
+    spriteFilename,
+    frameWidth: normalizedAnimation && Number.isFinite(normalizedAnimation.frameWidth) ? normalizedAnimation.frameWidth : null,
+    frameHeight: normalizedAnimation && Number.isFinite(normalizedAnimation.frameHeight) ? normalizedAnimation.frameHeight : null,
+    frameCount: normalizedAnimation && Number.isFinite(normalizedAnimation.frameCount) ? normalizedAnimation.frameCount : 1,
+    frameDurationMs: normalizedAnimation && Number.isFinite(normalizedAnimation.frameDurationMs) ? normalizedAnimation.frameDurationMs : 200
   };
 }

--- a/ui/control-api.js
+++ b/ui/control-api.js
@@ -1,6 +1,7 @@
 import { parseCommandInput } from './command-parser.js';
-import { getRawEvents } from '../core/world/eventStore.js';
-import { deriveWorldState } from '../core/world/deriveWorldState.js';
+import { getIndexedWorldSnapshot } from '../core/world/indexedWorldSnapshot.js';
+import { getAllTasks, getAllDesks, getRecentEvents } from './selectors/taskSelectors.js';
+import { getAllAgents } from './selectors/agentSelectors.js';
 
 function toTaskPayload(task) {
   const payload = task && typeof task.payload === 'object' && task.payload !== null
@@ -72,22 +73,23 @@ async function injectTask(task) {
 }
 
 function getWorldState() {
-  return deriveWorldState(getRawEvents());
+  return getIndexedWorldSnapshot();
 }
 
 function getTasks() {
-  const world = getWorldState();
-  return Array.isArray(world.tasks) ? world.tasks : [];
+  return getAllTasks(getWorldState());
 }
 
 function getAgents() {
-  const world = getWorldState();
-  return Array.isArray(world.agents) ? world.agents : [];
+  return getAllAgents(getWorldState());
 }
 
 function getDeskState() {
-  const world = getWorldState();
-  return Array.isArray(world.desks) ? world.desks : [];
+  return getAllDesks(getWorldState());
+}
+
+function getEventView(limit = 100) {
+  return getRecentEvents(getWorldState(), limit);
 }
 
 export const controlAPI = {
@@ -96,7 +98,7 @@ export const controlAPI = {
   getTasks,
   getAgents,
   getDeskState,
-  getRawEvents
+  getEventView
 };
 
 export async function dispatchCommand(inputString) {

--- a/ui/operator-control-panel.js
+++ b/ui/operator-control-panel.js
@@ -1,23 +1,21 @@
 /**
  * 🚨 ARCHITECTURE LOCK
  *
- * This module participates in the event-sourced execution model.
- *
- * DO NOT:
- * - Infer lifecycle state
- * - Introduce fallback transitions
- * - Derive failure outside TASK_ACKED
- * - Treat any event other than TASK_ACKED as terminal authority
- *
- * ONLY TaskEngine defines lifecycle.
- * TASK_ACKED is the ONLY terminal authority.
- * ONLY events define truth.
- *
- * If something is missing -> FIX EVENT EMISSION, not derivation.
+ * UI module is read-only and selector-driven:
+ * events -> deriveWorldState -> selectors -> rendering
  */
 
-import { getRawEvents, subscribeEventStream } from '../core/world/eventStore.js';
-import { deriveWorldState } from '../core/world/deriveWorldState.js';
+import { subscribeEventStream } from '../core/world/eventStore.js';
+import {
+  getAllTasks,
+  getTaskTimeline,
+  getRecentEvents,
+  filterTasks,
+  getTaskBuckets,
+  getDeskIndexForTask,
+  getDeskPosition
+} from './selectors/taskSelectors.js';
+import { getAllAgents } from './selectors/agentSelectors.js';
 
 const panelState = {
   selectedTaskId: null,
@@ -28,13 +26,6 @@ const panelState = {
   maxEventRows: 100
 };
 
-function formatTime(timestamp) {
-  if (!Number.isFinite(timestamp)) {
-    return 'n/a';
-  }
-  return new Date(timestamp).toLocaleTimeString();
-}
-
 function stringify(value) {
   try {
     return JSON.stringify(value, null, 2);
@@ -43,80 +34,90 @@ function stringify(value) {
   }
 }
 
-function eventTaskId(event) {
-  if (!event || typeof event !== 'object') {
-    return null;
+function formatIso(timestamp) {
+  if (!Number.isFinite(timestamp)) {
+    return 'n/a';
   }
-
-  if (event.taskId) {
-    return String(event.taskId);
-  }
-
-  if (event.task && event.task.id) {
-    return String(event.task.id);
-  }
-
-  if (event.payload && event.payload.taskId) {
-    return String(event.payload.taskId);
-  }
-
-  return null;
+  return new Date(timestamp).toISOString();
 }
 
-function eventTypeLabel(event) {
-  if (!event || typeof event !== 'object') {
-    return 'UNKNOWN';
+function taskTone(status) {
+  if (status === 'failed') {
+    return 'failed';
   }
-
-  if (typeof event.type === 'string') {
-    return event.type;
+  if (status === 'awaiting_ack') {
+    return 'pending';
   }
-
-  if (event.task && event.task.status) {
-    return `TASK_SNAPSHOT:${event.task.status}`;
+  if (status === 'claimed' || status === 'executing') {
+    return 'active';
   }
-
-  return 'UNKNOWN';
+  if (status === 'completed' || status === 'acknowledged') {
+    return 'done';
+  }
+  return 'queued';
 }
 
-function deskAnchor(desk) {
-  if (!desk) {
-    return null;
+function taskIcon(status) {
+  if (status === 'failed') {
+    return '✖';
   }
-
-  return {
-    x: Number(desk.x),
-    y: Number(desk.y) + 34
-  };
+  if (status === 'awaiting_ack') {
+    return '⧗';
+  }
+  if (status === 'claimed') {
+    return '➤';
+  }
+  if (status === 'executing') {
+    return '⚙';
+  }
+  if (status === 'completed' || status === 'acknowledged') {
+    return '✔';
+  }
+  return '•';
 }
 
-function computeDerivedAgentPosition(agent, desksById, frameNow) {
-  if (!agent) {
-    return null;
+function renderTaskList(listElement, tasks, selectedTaskId) {
+  listElement.innerHTML = '';
+
+  if (!tasks.length) {
+    const empty = document.createElement('li');
+    empty.className = 'ocp-empty';
+    empty.textContent = 'none';
+    listElement.appendChild(empty);
+    return;
   }
 
-  const homeDesk = agent.deskId ? desksById.get(agent.deskId) : null;
-  const targetDesk = agent.targetDeskId ? desksById.get(agent.targetDeskId) : null;
-  const home = deskAnchor(homeDesk || targetDesk);
-  const target = deskAnchor(targetDesk || homeDesk);
+  tasks.slice(0, 25).forEach((task) => {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `ocp-item ocp-task-${taskTone(task.status)}${selectedTaskId === task.id ? ' is-selected' : ''}`;
+    button.dataset.taskId = task.id;
+    const label = `${task.title} | ${task.status}${task.assignedAgentId ? ` | ${task.assignedAgentId}` : ''}`;
+    button.textContent = `${taskIcon(task.status)} ${label}`;
+    li.appendChild(button);
+    listElement.appendChild(li);
+  });
+}
 
-  if (!home && !target) {
-    return null;
+function agentPoint(agent, index, selectedTaskDesk) {
+  const value = String(agent && agent.id ? agent.id : index);
+  let seed = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    seed = (seed * 31 + value.charCodeAt(i)) >>> 0;
   }
 
-  const start = home || target;
-  const end = target || home;
-  const seed = String(agent.id || 'agent').length;
-  const phase = ((frameNow / 1000) + (seed % 11) * 0.13) % 1;
-
-  if (agent.state === 'moving') {
+  if (selectedTaskDesk && agent && agent.currentTaskId) {
     return {
-      x: start.x + (end.x - start.x) * phase,
-      y: start.y + (end.y - start.y) * phase
+      x: selectedTaskDesk.x + Math.sin(seed) * 12,
+      y: selectedTaskDesk.y + 28 + Math.cos(seed) * 6
     };
   }
 
-  return end;
+  return {
+    x: 120 + (index % 6) * 96,
+    y: 540 - Math.floor(index / 6) * 56
+  };
 }
 
 function ensureSelectionOverlay() {
@@ -139,24 +140,13 @@ function ensureSelectionOverlay() {
     overlay = document.createElement('canvas');
     overlay.dataset.role = 'task-selection-overlay';
     overlay.style.position = 'absolute';
-    overlay.style.left = `${canvas.offsetLeft}px`;
-    overlay.style.top = `${canvas.offsetTop}px`;
-    overlay.style.width = `${canvas.clientWidth}px`;
-    overlay.style.height = `${canvas.clientHeight}px`;
     overlay.style.pointerEvents = 'none';
     overlay.style.zIndex = '4';
     parent.appendChild(overlay);
   }
 
-  const width = canvas.width;
-  const height = canvas.height;
-  if (overlay.width !== width) {
-    overlay.width = width;
-  }
-  if (overlay.height !== height) {
-    overlay.height = height;
-  }
-
+  overlay.width = canvas.width;
+  overlay.height = canvas.height;
   overlay.style.left = `${canvas.offsetLeft}px`;
   overlay.style.top = `${canvas.offsetTop}px`;
   overlay.style.width = `${canvas.clientWidth}px`;
@@ -165,7 +155,7 @@ function ensureSelectionOverlay() {
   return overlay;
 }
 
-function drawTaskSelectionOverlay(worldState, selectedTaskId) {
+function drawTaskSelectionOverlay(tasks, agents, selectedTaskId) {
   const overlay = ensureSelectionOverlay();
   if (!(overlay instanceof HTMLCanvasElement)) {
     return;
@@ -177,60 +167,50 @@ function drawTaskSelectionOverlay(worldState, selectedTaskId) {
   }
 
   octx.clearRect(0, 0, overlay.width, overlay.height);
-
   if (!selectedTaskId) {
     return;
   }
 
-  const tasks = Array.isArray(worldState && worldState.tasks) ? worldState.tasks : [];
-  const desks = Array.isArray(worldState && worldState.desks) ? worldState.desks : [];
-  const agents = Array.isArray(worldState && worldState.agents) ? worldState.agents : [];
-
-  const task = tasks.find((item) => item && item.id === selectedTaskId);
+  const task = tasks.find((item) => item.id === selectedTaskId);
   if (!task) {
     return;
   }
 
-  const desksById = new Map(desks.map((desk) => [desk.id, desk]));
-  const selectedDesk = task.deskId ? desksById.get(task.deskId) : null;
-  const deskPoint = deskAnchor(selectedDesk);
-  const selectedAgent = agents.find((agent) => {
-    if (!agent) {
-      return false;
-    }
+  const desk = getDeskPosition(getDeskIndexForTask(task));
+  const selectedAgentIndex = agents.findIndex((agent) => agent.currentTaskId === selectedTaskId || agent.id === task.assignedAgentId);
+  const selectedAgent = selectedAgentIndex >= 0 ? agents[selectedAgentIndex] : null;
+  const point = selectedAgent ? agentPoint(selectedAgent, selectedAgentIndex, desk) : null;
 
-    if (task.assignedAgentId && agent.id === task.assignedAgentId) {
-      return true;
-    }
+  octx.strokeStyle = 'rgba(56, 189, 248, 0.95)';
+  octx.lineWidth = 2;
+  octx.strokeRect(desk.x - 52, desk.y - 34, 104, 68);
 
-    return agent.currentTaskId && agent.currentTaskId === task.id;
-  }) || null;
-  const agentPoint = computeDerivedAgentPosition(selectedAgent, desksById, Date.now());
-
-  if (deskPoint) {
-    octx.strokeStyle = 'rgba(56, 189, 248, 0.95)';
-    octx.lineWidth = 2;
-    octx.strokeRect(deskPoint.x - 52, deskPoint.y - 34, 104, 68);
-  }
-
-  if (agentPoint) {
+  if (point) {
     octx.strokeStyle = 'rgba(34, 197, 94, 0.95)';
-    octx.lineWidth = 2;
     octx.beginPath();
-    octx.arc(agentPoint.x, agentPoint.y, 16, 0, Math.PI * 2);
+    octx.arc(point.x, point.y, 16, 0, Math.PI * 2);
     octx.stroke();
-  }
 
-  if (deskPoint && agentPoint) {
     octx.strokeStyle = 'rgba(251, 191, 36, 0.9)';
-    octx.lineWidth = 2;
     octx.setLineDash([6, 4]);
     octx.beginPath();
-    octx.moveTo(deskPoint.x, deskPoint.y);
-    octx.lineTo(agentPoint.x, agentPoint.y);
+    octx.moveTo(desk.x, desk.y);
+    octx.lineTo(point.x, point.y);
     octx.stroke();
     octx.setLineDash([]);
   }
+}
+
+function getIndexedWorldSnapshot() {
+  if (window.controlAPI && typeof window.controlAPI.getWorldState === 'function') {
+    return window.controlAPI.getWorldState();
+  }
+
+  return {
+    events: [],
+    eventsByTaskId: new Map(),
+    eventsByWorkerId: new Map()
+  };
 }
 
 function createPanelRoot() {
@@ -239,7 +219,7 @@ function createPanelRoot() {
   panel.innerHTML = `
     <div class="ocp-header">
       <h2>Operator Control Panel</h2>
-      <p>Derived world observer (event-sourced)</p>
+      <p>Selector-driven observer (event-sourced)</p>
     </div>
 
     <section class="ocp-section" data-section="tasks">
@@ -291,7 +271,7 @@ function createPanelRoot() {
     </section>
 
     <section class="ocp-section" data-section="events">
-      <h3>Raw Event Stream</h3>
+      <h3>Event Stream</h3>
       <div class="ocp-toolbar">
         <label class="ocp-control">
           Show last
@@ -308,111 +288,6 @@ function createPanelRoot() {
   `;
 
   return panel;
-}
-
-function renderTaskList(listElement, tasks, selectedTaskId, builder) {
-  listElement.innerHTML = '';
-
-  if (!tasks.length) {
-    const empty = document.createElement('li');
-    empty.className = 'ocp-empty';
-    empty.textContent = 'none';
-    listElement.appendChild(empty);
-    return;
-  }
-
-  tasks.slice(0, 25).forEach((task) => {
-    const li = document.createElement('li');
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = `ocp-item${selectedTaskId === task.id ? ' is-selected' : ''}`;
-    button.dataset.taskId = task.id;
-    const itemView = builder(task);
-    button.classList.add(`ocp-task-${itemView.tone}`);
-    button.textContent = `${itemView.icon} ${itemView.label}`;
-    li.appendChild(button);
-    listElement.appendChild(li);
-  });
-}
-
-function isTaskActive(task) {
-  return task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack';
-}
-
-function isTaskTerminal(task) {
-  return task.status === 'completed' || task.status === 'acknowledged' || task.status === 'failed';
-}
-
-function taskLabelView(task, section) {
-  const agentHint = task.assignedAgentId ? ` | claimed by ${task.assignedAgentId}` : '';
-  if (section === 'failed') {
-    return {
-      icon: '✖',
-      tone: 'failed',
-      label: `${task.id} | failed${task.error ? ` | ${task.error}` : ''}`
-    };
-  }
-
-  if (task.status === 'awaiting_ack') {
-    return { icon: '⧗', tone: 'pending', label: `${task.title} | awaiting_ack` };
-  }
-  if (task.status === 'executing') {
-    return { icon: '⚙', tone: 'active', label: `${task.title} | executing${agentHint}` };
-  }
-  if (task.status === 'claimed') {
-    return { icon: '➤', tone: 'active', label: `${task.title} | claimed${agentHint}` };
-  }
-  if (task.status === 'acknowledged' || task.status === 'completed') {
-    return { icon: '✔', tone: 'done', label: `${task.id} | ${task.status}` };
-  }
-
-  return { icon: '•', tone: 'queued', label: `${task.title} | ${task.status}` };
-}
-
-function filterTasks(tasks, now) {
-  let filtered = tasks;
-
-  if (panelState.activeTasksOnly) {
-    filtered = filtered.filter((task) => isTaskActive(task));
-  }
-
-  if (panelState.recentSeconds > 0) {
-    const cutoff = now - panelState.recentSeconds * 1000;
-    filtered = filtered.filter((task) => {
-      const touchedAt = Number.isFinite(task.updatedAt) ? task.updatedAt : task.createdAt;
-      return isTaskActive(task) || (Number.isFinite(touchedAt) && touchedAt >= cutoff);
-    });
-  }
-
-  return filtered;
-}
-
-function classifyTasks(tasks) {
-  const queued = [];
-  const active = [];
-  const done = [];
-  const failed = [];
-
-  for (const task of tasks) {
-    if (task.status === 'failed') {
-      failed.push(task);
-      continue;
-    }
-
-    if (task.status === 'acknowledged' || task.status === 'completed') {
-      done.push(task);
-      continue;
-    }
-
-    if (task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack') {
-      active.push(task);
-      continue;
-    }
-
-    queued.push(task);
-  }
-
-  return { queued, active, done, failed };
 }
 
 export function initOperatorControlPanel() {
@@ -457,19 +332,19 @@ export function initOperatorControlPanel() {
     if (target.dataset.taskId) {
       panelState.selectedTaskId = target.dataset.taskId;
       panelState.selectedTimelineIndex = null;
-      renderPanel(getRawEvents());
+      renderPanel();
       return;
     }
 
     if (target.dataset.agentId) {
       panelState.selectedAgentId = target.dataset.agentId;
-      renderPanel(getRawEvents());
+      renderPanel();
       return;
     }
 
     if (target.dataset.timelineIndex) {
       panelState.selectedTimelineIndex = Number(target.dataset.timelineIndex);
-      renderPanel(getRawEvents());
+      renderPanel();
     }
   });
 
@@ -481,34 +356,56 @@ export function initOperatorControlPanel() {
 
     if (target.matches('[data-control="active-only"]')) {
       panelState.activeTasksOnly = Boolean(target.checked);
-      renderPanel(getRawEvents());
+      renderPanel();
       return;
     }
 
     if (target.matches('[data-control="recent-seconds"]')) {
       panelState.recentSeconds = Number(target.value) || 0;
-      renderPanel(getRawEvents());
+      renderPanel();
       return;
     }
 
     if (target.matches('[data-control="max-events"]')) {
       panelState.maxEventRows = Math.max(1, Number(target.value) || 100);
-      renderPanel(getRawEvents());
+      renderPanel();
     }
   });
 
-  function renderPanel(eventStreamSnapshot) {
-    const events = Array.isArray(eventStreamSnapshot) ? eventStreamSnapshot : getRawEvents();
-    const worldState = deriveWorldState(events);
-    const allTasks = Array.isArray(worldState.tasks) ? worldState.tasks : [];
-    const tasks = filterTasks(allTasks, Date.now());
-    const agents = Array.isArray(worldState.agents) ? worldState.agents : [];
-    const buckets = classifyTasks(tasks);
+  function renderPanel() {
+    const indexedWorld = getIndexedWorldSnapshot();
+    const allTasks = getAllTasks(indexedWorld);
+    const tasks = filterTasks(indexedWorld, {
+      activeOnly: panelState.activeTasksOnly,
+      recentSeconds: panelState.recentSeconds,
+      now: Date.now()
+    });
+    const agents = getAllAgents(indexedWorld);
+    const buckets = getTaskBuckets(indexedWorld, { tasks });
 
-    renderTaskList(queuedList, buckets.queued, panelState.selectedTaskId, (task) => taskLabelView(task, 'queued'));
-    renderTaskList(activeList, buckets.active, panelState.selectedTaskId, (task) => taskLabelView(task, 'active'));
-    renderTaskList(doneList, buckets.done, panelState.selectedTaskId, (task) => taskLabelView(task, 'done'));
-    renderTaskList(failedList, buckets.failed, panelState.selectedTaskId, (task) => taskLabelView(task, 'failed'));
+    renderTaskList(queuedList, buckets.queued, panelState.selectedTaskId);
+    renderTaskList(activeList, buckets.active, panelState.selectedTaskId);
+    renderTaskList(doneList, buckets.done, panelState.selectedTaskId);
+    renderTaskList(failedList, buckets.failed, panelState.selectedTaskId);
+
+    const recentEvents = getRecentEvents(indexedWorld, panelState.maxEventRows).reverse();
+    eventsList.innerHTML = '';
+    if (!recentEvents.length) {
+      const empty = document.createElement('li');
+      empty.className = 'ocp-empty';
+      empty.textContent = 'none';
+      eventsList.appendChild(empty);
+    } else {
+      recentEvents.forEach((entry) => {
+        const li = document.createElement('li');
+        li.className = 'ocp-event';
+        li.textContent = `${formatIso(entry.timestamp)} | ${entry.type} ${entry.taskId || ''}`.trim();
+        if (panelState.selectedTaskId && entry.taskId === panelState.selectedTaskId) {
+          li.classList.add('is-selected');
+        }
+        eventsList.appendChild(li);
+      });
+    }
 
     agentsList.innerHTML = '';
     if (!agents.length) {
@@ -521,120 +418,61 @@ export function initOperatorControlPanel() {
         const li = document.createElement('li');
         const button = document.createElement('button');
         button.type = 'button';
-        button.className = 'ocp-item';
-        button.dataset.agentId = agent.id;
-        const selectedTaskId = panelState.selectedTaskId;
-        const selectedTask = selectedTaskId ? allTasks.find((task) => task.id === selectedTaskId) : null;
-        const isSelectedTaskWorker = !!(
-          selectedTask
-          && (
-            (selectedTask.assignedAgentId && selectedTask.assignedAgentId === agent.id)
-            || (agent.currentTaskId && agent.currentTaskId === selectedTask.id)
-          )
-        );
-
-        if (isSelectedTaskWorker) {
+        button.className = `ocp-item${panelState.selectedAgentId === agent.id ? ' is-selected' : ''}`;
+        if (panelState.selectedTaskId && agent.currentTaskId === panelState.selectedTaskId) {
           button.classList.add('ocp-agent-active');
         }
-        if (panelState.selectedAgentId === agent.id) {
-          button.classList.add('is-selected');
-        }
-
-        button.textContent = `${isSelectedTaskWorker ? '▶ ' : ''}${agent.id} | ${agent.state} | desk ${agent.deskId}`;
-        if (agent.state === 'working') {
-          button.classList.add('ocp-agent-working');
-        } else if (agent.state === 'delivering') {
-          button.classList.add('ocp-agent-delivering');
-        } else if (agent.state === 'error') {
-          button.classList.add('ocp-agent-error');
-        }
+        button.dataset.agentId = agent.id;
+        button.textContent = `${agent.id} | ${agent.state} | task ${agent.currentTaskId || 'none'}`;
         li.appendChild(button);
         agentsList.appendChild(li);
       });
     }
 
-    const recentEvents = events.slice(-panelState.maxEventRows).reverse();
-    eventsList.innerHTML = '';
-    if (!recentEvents.length) {
-      const empty = document.createElement('li');
-      empty.className = 'ocp-empty';
-      empty.textContent = 'none';
-      eventsList.appendChild(empty);
-    } else {
-      recentEvents.forEach((event) => {
-        const li = document.createElement('li');
-        li.className = 'ocp-event';
-        const eventType = eventTypeLabel(event);
-        const taskId = eventTaskId(event) || '';
-        const stamp = Number.isFinite(event.timestamp) ? new Date(event.timestamp).toISOString() : 'n/a';
-        li.textContent = `${stamp} | ${eventType} ${taskId}`.trim();
-        if (panelState.selectedTaskId && taskId === panelState.selectedTaskId) {
-          li.classList.add('is-selected');
-        }
-        eventsList.appendChild(li);
-      });
-    }
-
     if (panelState.selectedTaskId) {
-      const selectedTask = allTasks.find((task) => task.id === panelState.selectedTaskId);
+      const selectedTask = allTasks.find((task) => task.id === panelState.selectedTaskId) || null;
       if (!selectedTask) {
-        taskDetail.textContent = 'Selected task not found in derived world.';
+        taskDetail.textContent = 'Selected task not found.';
         eventDetail.textContent = 'Selected event not found.';
         timelineList.innerHTML = '';
-        const empty = document.createElement('li');
-        empty.className = 'ocp-empty';
-        empty.textContent = 'No timeline available.';
-        timelineList.appendChild(empty);
       } else {
-        const timeline = events
-          .filter((event) => eventTaskId(event) === selectedTask.id)
-          .slice(-20)
-          .map((event, index) => ({
-            index,
-            timestamp: Number.isFinite(event.timestamp) ? event.timestamp : null,
-            isoTime: Number.isFinite(event.timestamp) ? new Date(event.timestamp).toISOString() : 'n/a',
-            localTime: formatTime(event.timestamp),
-            event: eventTypeLabel(event),
-            payload: event && typeof event.payload === 'object' ? event.payload : null,
-            taskId: eventTaskId(event)
-          }));
+        const timeline = getTaskTimeline(indexedWorld, selectedTask.id).slice(-20);
+        const timelineRows = timeline.map((entry, index) => ({
+          ...entry,
+          index,
+          isoTime: formatIso(entry.timestamp)
+        }));
 
-        if (!timeline.some((entry) => entry.index === panelState.selectedTimelineIndex)) {
-          panelState.selectedTimelineIndex = timeline.length ? timeline[timeline.length - 1].index : null;
+        if (!timelineRows.some((entry) => entry.index === panelState.selectedTimelineIndex)) {
+          panelState.selectedTimelineIndex = timelineRows.length ? timelineRows[timelineRows.length - 1].index : null;
         }
 
         timelineList.innerHTML = '';
-        if (!timeline.length) {
+        if (!timelineRows.length) {
           const empty = document.createElement('li');
           empty.className = 'ocp-empty';
           empty.textContent = 'No events observed for this task yet.';
           timelineList.appendChild(empty);
         } else {
-          timeline.forEach((entry) => {
+          timelineRows.forEach((entry) => {
             const li = document.createElement('li');
             li.className = 'ocp-event';
             const button = document.createElement('button');
             button.type = 'button';
             button.className = `ocp-item ocp-event-row${panelState.selectedTimelineIndex === entry.index ? ' is-selected' : ''}`;
             button.dataset.timelineIndex = String(entry.index);
-            button.textContent = `${entry.isoTime} | ${entry.event}`;
+            button.textContent = `${entry.isoTime} | ${entry.type}`;
             li.appendChild(button);
             timelineList.appendChild(li);
           });
 
-          const selectedEntry = timeline.find((entry) => entry.index === panelState.selectedTimelineIndex) || timeline[timeline.length - 1];
-          eventDetail.textContent = stringify({
-            time: selectedEntry.isoTime,
-            localTime: selectedEntry.localTime,
-            event: selectedEntry.event,
-            taskId: selectedEntry.taskId,
-            payload: selectedEntry.payload
-          });
+          const selectedEntry = timelineRows.find((entry) => entry.index === panelState.selectedTimelineIndex) || timelineRows[timelineRows.length - 1];
+          eventDetail.textContent = stringify(selectedEntry);
         }
 
         taskDetail.textContent = stringify({
           ...selectedTask,
-          eventTimeline: timeline
+          timeline: timelineRows
         });
       }
     } else {
@@ -647,21 +485,17 @@ export function initOperatorControlPanel() {
     }
 
     if (panelState.selectedAgentId) {
-      const selectedAgent = agents.find((agent) => agent.id === panelState.selectedAgentId);
-      agentDetail.textContent = selectedAgent ? stringify(selectedAgent) : 'Selected agent not found in derived world.';
+      const selectedAgent = agents.find((agent) => agent.id === panelState.selectedAgentId) || null;
+      agentDetail.textContent = selectedAgent ? stringify(selectedAgent) : 'Selected agent not found.';
+    } else {
+      agentDetail.textContent = 'Click an agent to inspect derived assignment.';
     }
 
-    drawTaskSelectionOverlay(worldState, panelState.selectedTaskId);
+    drawTaskSelectionOverlay(allTasks, agents, panelState.selectedTaskId);
   }
 
-  const initialEvents = getRawEvents();
-  renderPanel(initialEvents);
-  subscribeEventStream((appendedEvents) => {
-    if (!Array.isArray(appendedEvents) || appendedEvents.length === 0) {
-      return;
-    }
-
-    const fullEvents = getRawEvents();
-    renderPanel(fullEvents);
+  renderPanel();
+  subscribeEventStream(() => {
+    renderPanel();
   });
 }

--- a/ui/raccoon-feeder-panel.js
+++ b/ui/raccoon-feeder-panel.js
@@ -1,0 +1,140 @@
+/**
+ * 🚨 ARCHITECTURE LOCK
+ *
+ * Read-only anomaly view derived from:
+ * event stream -> deriveWorldState -> selectors
+ *
+ * DO NOT:
+ * - Mutate tasks/agents/events
+ * - Introduce lifecycle authority
+ * - Trigger execution side effects
+ */
+
+import { subscribeEventStream } from '../core/world/eventStore.js';
+import { getIncidentClusters } from './selectors/anomalySelectors.js';
+import { getTaskTimeline } from './selectors/taskSelectors.js';
+
+const STALLED_ACK_MS = 15000;
+
+function stringify(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (_error) {
+    return String(value);
+  }
+}
+
+function severityRank(severity) {
+  if (severity === 'high') {
+    return 3;
+  }
+  if (severity === 'medium') {
+    return 2;
+  }
+  return 1;
+}
+
+export function initRaccoonFeederPanel() {
+  const panel = document.createElement('aside');
+  panel.id = 'raccoon-feeder-panel';
+  panel.innerHTML = `
+    <div class="rfp-header">
+      <h2>Raccoon Feeder</h2>
+      <p>Read-only anomaly aggregation</p>
+    </div>
+    <section class="rfp-section">
+      <h3>Incident Clusters</h3>
+      <ul class="rfp-list" data-list="incidents"></ul>
+      <pre class="rfp-detail" data-detail="incident">Select an incident to inspect details.</pre>
+    </section>
+  `;
+
+  const panelStack = document.getElementById('control-panels-stack');
+  if (panelStack) {
+    panelStack.appendChild(panel);
+  } else {
+    document.body.appendChild(panel);
+  }
+
+  const incidentsList = panel.querySelector('[data-list="incidents"]');
+  const incidentDetail = panel.querySelector('[data-detail="incident"]');
+  let selectedIncidentId = null;
+
+  function getIndexedWorldSnapshot() {
+    if (window.controlAPI && typeof window.controlAPI.getWorldState === 'function') {
+      return window.controlAPI.getWorldState();
+    }
+
+    return {
+      events: [],
+      eventsByTaskId: new Map(),
+      eventsByWorkerId: new Map()
+    };
+  }
+
+  panel.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const incidentId = target.dataset.incidentId;
+    if (!incidentId) {
+      return;
+    }
+
+    selectedIncidentId = incidentId;
+    renderPanel();
+  });
+
+  function renderPanel() {
+    const indexedWorld = getIndexedWorldSnapshot();
+    const incidents = getIncidentClusters(indexedWorld, { thresholdMs: STALLED_ACK_MS, now: Date.now() })
+      .sort((a, b) => {
+        const diff = severityRank(b.severity) - severityRank(a.severity);
+        if (diff !== 0) {
+          return diff;
+        }
+        return String(a.taskId || '').localeCompare(String(b.taskId || ''));
+      });
+
+    if (!incidents.some((item) => item.id === selectedIncidentId)) {
+      selectedIncidentId = incidents.length ? incidents[0].id : null;
+    }
+
+    incidentsList.innerHTML = '';
+    if (!incidents.length) {
+      const empty = document.createElement('li');
+      empty.className = 'rfp-empty';
+      empty.textContent = 'No anomalies detected in current event view.';
+      incidentsList.appendChild(empty);
+      incidentDetail.textContent = 'No incident selected.';
+      return;
+    }
+
+    incidents.forEach((incident) => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `rfp-item${incident.id === selectedIncidentId ? ' is-selected' : ''}`;
+      button.dataset.incidentId = incident.id;
+      button.textContent = `${incident.severity.toUpperCase()} | ${incident.category} | ${incident.taskId || 'n/a'}`;
+      li.appendChild(button);
+      incidentsList.appendChild(li);
+    });
+
+    const selected = incidents.find((item) => item.id === selectedIncidentId) || incidents[0];
+    const selectedTimeline = selected && selected.taskId
+      ? getTaskTimeline(indexedWorld, selected.taskId).slice(-8)
+      : [];
+    incidentDetail.textContent = stringify({
+      ...selected,
+      timeline: selectedTimeline
+    });
+  }
+
+  renderPanel();
+  subscribeEventStream(() => {
+    renderPanel();
+  });
+}

--- a/ui/selectors/agentSelectors.js
+++ b/ui/selectors/agentSelectors.js
@@ -1,0 +1,108 @@
+import { getTaskSnapshot, getTaskStatus } from './taskSelectors.js';
+
+function normalizeWorkerId(workerId) {
+  return workerId === null || workerId === undefined ? null : String(workerId);
+}
+
+function eventTaskId(event) {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  const payload = event && typeof event.payload === 'object' ? event.payload : {};
+  return (event.taskId !== undefined && event.taskId !== null)
+    ? String(event.taskId)
+    : (payload.taskId !== undefined && payload.taskId !== null)
+      ? String(payload.taskId)
+      : null;
+}
+
+export function getAgentTasks(indexedWorld, workerId) {
+  const id = normalizeWorkerId(workerId);
+  if (!id || !indexedWorld || !(indexedWorld.eventsByWorkerId instanceof Map)) {
+    return [];
+  }
+
+  const workerEvents = indexedWorld.eventsByWorkerId.get(id) || [];
+  const orderedTaskIds = [];
+  const seen = new Set();
+
+  for (const event of workerEvents) {
+    const taskId = eventTaskId(event);
+    if (!taskId || seen.has(taskId)) {
+      continue;
+    }
+    seen.add(taskId);
+    orderedTaskIds.push(taskId);
+  }
+
+  return orderedTaskIds;
+}
+
+export function getAgentState(indexedWorld, workerId) {
+  const taskIds = getAgentTasks(indexedWorld, workerId);
+  let state = 'idle';
+
+  for (const taskId of taskIds) {
+    const status = getTaskStatus(indexedWorld, taskId);
+
+    if (status === 'claimed') {
+      state = 'moving';
+      continue;
+    }
+
+    if (status === 'executing') {
+      state = 'working';
+      continue;
+    }
+
+    if (status === 'awaiting_ack') {
+      state = 'delivering';
+      continue;
+    }
+
+    if (status === 'failed') {
+      state = 'error';
+    }
+  }
+
+  return state;
+}
+
+export function getAllAgentIds(indexedWorld) {
+  if (!indexedWorld || !(indexedWorld.eventsByWorkerId instanceof Map)) {
+    return [];
+  }
+
+  return Array.from(indexedWorld.eventsByWorkerId.keys())
+    .map((value) => String(value))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function getAgentSnapshot(indexedWorld, workerId) {
+  const id = normalizeWorkerId(workerId);
+  if (!id) {
+    return null;
+  }
+
+  const tasks = getAgentTasks(indexedWorld, id);
+  const state = getAgentState(indexedWorld, id);
+  const currentTaskId = tasks.length ? tasks[tasks.length - 1] : null;
+  const currentTask = currentTaskId ? getTaskSnapshot(indexedWorld, currentTaskId) : null;
+  const deskId = currentTask && currentTask.deskId ? currentTask.deskId : null;
+
+  return {
+    id,
+    role: 'operator',
+    state,
+    currentTaskId,
+    deskId,
+    targetDeskId: deskId
+  };
+}
+
+export function getAllAgents(indexedWorld) {
+  return getAllAgentIds(indexedWorld)
+    .map((workerId) => getAgentSnapshot(indexedWorld, workerId))
+    .filter(Boolean);
+}

--- a/ui/selectors/anomalySelectors.js
+++ b/ui/selectors/anomalySelectors.js
@@ -1,0 +1,79 @@
+import { getTaskEvents } from './taskSelectors.js';
+
+function allTaskIds(indexedWorld) {
+  if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
+    return [];
+  }
+
+  return Array.from(indexedWorld.eventsByTaskId.keys());
+}
+
+export function getStalledAckTasks(indexedWorld, thresholdMs = 15000, now = Date.now()) {
+  return allTaskIds(indexedWorld)
+    .filter((taskId) => {
+      const events = getTaskEvents(indexedWorld, taskId);
+      const lastFinish = [...events].reverse().find((event) => event && event.type === 'TASK_EXECUTE_FINISHED');
+      if (!lastFinish || !Number.isFinite(lastFinish.timestamp)) {
+        return false;
+      }
+
+      const hasAckAfterFinish = events.some((event) => {
+        return event
+          && event.type === 'TASK_ACKED'
+          && Number.isFinite(event.timestamp)
+          && Number(event.timestamp) > Number(lastFinish.timestamp);
+      });
+
+      return !hasAckAfterFinish && (now - Number(lastFinish.timestamp)) >= thresholdMs;
+    });
+}
+
+export function getExecutionMissingFinishTasks(indexedWorld) {
+  return allTaskIds(indexedWorld)
+    .filter((taskId) => {
+      const events = getTaskEvents(indexedWorld, taskId);
+      const hasStart = events.some((event) => event && (event.type === 'TASK_EXECUTE_STARTED' || event.type === 'TASK_STARTED'));
+      const hasFinish = events.some((event) => event && event.type === 'TASK_EXECUTE_FINISHED');
+      return hasStart && !hasFinish;
+    });
+}
+
+export function getDuplicateAckTasks(indexedWorld) {
+  return allTaskIds(indexedWorld)
+    .filter((taskId) => {
+      const events = getTaskEvents(indexedWorld, taskId);
+      const ackCount = events.filter((event) => event && event.type === 'TASK_ACKED').length;
+      return ackCount > 1;
+    });
+}
+
+export function getIncidentClusters(indexedWorld, options = {}) {
+  const thresholdMs = Number.isFinite(options.thresholdMs) ? Number(options.thresholdMs) : 15000;
+  const now = Number.isFinite(options.now) ? Number(options.now) : Date.now();
+
+  const stalled = getStalledAckTasks(indexedWorld, thresholdMs, now).map((taskId) => ({
+    id: `stalled-${taskId}`,
+    severity: 'medium',
+    category: 'Stalled Awaiting ACK',
+    taskId,
+    summary: 'Execution finished but ACK is missing beyond threshold.'
+  }));
+
+  const missingFinish = getExecutionMissingFinishTasks(indexedWorld).map((taskId) => ({
+    id: `missing-finish-${taskId}`,
+    severity: 'low',
+    category: 'Execution Missing Finish',
+    taskId,
+    summary: 'Execution start observed without execution finish event.'
+  }));
+
+  const duplicateAck = getDuplicateAckTasks(indexedWorld).map((taskId) => ({
+    id: `duplicate-ack-${taskId}`,
+    severity: 'high',
+    category: 'Duplicate ACK',
+    taskId,
+    summary: 'Multiple TASK_ACKED events observed for one task.'
+  }));
+
+  return [...duplicateAck, ...stalled, ...missingFinish];
+}

--- a/ui/selectors/metricsSelectors.js
+++ b/ui/selectors/metricsSelectors.js
@@ -1,0 +1,74 @@
+import { getTaskEvents } from './taskSelectors.js';
+import { getAllTasks } from './taskSelectors.js';
+
+function firstTimestamp(events, type) {
+  const match = events.find((event) => event && event.type === type);
+  return match && Number.isFinite(match.timestamp) ? Number(match.timestamp) : null;
+}
+
+export function getQueueTime(indexedWorld, taskId) {
+  const events = getTaskEvents(indexedWorld, taskId);
+  const createdAt = firstTimestamp(events, 'TASK_CREATED');
+  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED') || firstTimestamp(events, 'TASK_STARTED');
+
+  if (!Number.isFinite(createdAt) || !Number.isFinite(startedAt)) {
+    return null;
+  }
+
+  return Math.max(0, startedAt - createdAt);
+}
+
+export function getExecutionDuration(indexedWorld, taskId) {
+  const events = getTaskEvents(indexedWorld, taskId);
+  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED') || firstTimestamp(events, 'TASK_STARTED');
+  const finishedAt = firstTimestamp(events, 'TASK_EXECUTE_FINISHED');
+
+  if (!Number.isFinite(startedAt) || !Number.isFinite(finishedAt)) {
+    return null;
+  }
+
+  return Math.max(0, finishedAt - startedAt);
+}
+
+export function getAckLatency(indexedWorld, taskId) {
+  const events = getTaskEvents(indexedWorld, taskId);
+  const finishedAt = firstTimestamp(events, 'TASK_EXECUTE_FINISHED');
+  const ackedAt = firstTimestamp(events, 'TASK_ACKED');
+
+  if (!Number.isFinite(finishedAt) || !Number.isFinite(ackedAt)) {
+    return null;
+  }
+
+  return Math.max(0, ackedAt - finishedAt);
+}
+
+export function getTaskCounts(indexedWorld) {
+  const tasks = getAllTasks(indexedWorld);
+  const counts = {
+    queued: 0,
+    active: 0,
+    done: 0,
+    failed: 0
+  };
+
+  for (const task of tasks) {
+    if (task.status === 'failed') {
+      counts.failed += 1;
+      continue;
+    }
+
+    if (task.status === 'completed' || task.status === 'acknowledged') {
+      counts.done += 1;
+      continue;
+    }
+
+    if (task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack') {
+      counts.active += 1;
+      continue;
+    }
+
+    counts.queued += 1;
+  }
+
+  return counts;
+}

--- a/ui/selectors/taskSelectors.js
+++ b/ui/selectors/taskSelectors.js
@@ -1,0 +1,357 @@
+function normalizeTaskId(taskId) {
+  return taskId === null || taskId === undefined ? null : String(taskId);
+}
+
+function eventTaskId(event) {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  const payload = event && typeof event.payload === 'object' ? event.payload : {};
+  return normalizeTaskId(event.taskId)
+    || normalizeTaskId(payload.taskId)
+    || normalizeTaskId(event && event.task && event.task.id);
+}
+
+function payloadStatus(event) {
+  const payload = event && typeof event.payload === 'object' ? event.payload : {};
+  return typeof payload.status === 'string' ? payload.status : null;
+}
+
+function hashString(text) {
+  const value = String(text || '');
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function payloadValue(event, key) {
+  const payload = event && typeof event.payload === 'object' ? event.payload : {};
+  return Object.prototype.hasOwnProperty.call(payload, key) ? payload[key] : undefined;
+}
+
+function normalizeSeconds(value) {
+  return Number.isFinite(value) && value > 0 ? Number(value) : 0;
+}
+
+function taskTouchedAt(task) {
+  if (!task || typeof task !== 'object') {
+    return null;
+  }
+
+  if (Number.isFinite(task.updatedAt)) {
+    return Number(task.updatedAt);
+  }
+
+  if (Number.isFinite(task.createdAt)) {
+    return Number(task.createdAt);
+  }
+
+  return null;
+}
+
+export function isActiveTaskStatus(status) {
+  return status === 'claimed' || status === 'executing' || status === 'awaiting_ack';
+}
+
+export function getTaskIds(indexedWorld) {
+  if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
+    return [];
+  }
+
+  return Array.from(indexedWorld.eventsByTaskId.keys());
+}
+
+export function getTaskEvents(indexedWorld, taskId) {
+  const id = normalizeTaskId(taskId);
+  if (!id || !indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
+    return [];
+  }
+
+  const events = indexedWorld.eventsByTaskId.get(id);
+  return Array.isArray(events) ? events : [];
+}
+
+export function getTaskStatus(indexedWorld, taskId) {
+  const events = getTaskEvents(indexedWorld, taskId);
+  let status = 'unknown';
+
+  for (const event of events) {
+    const type = typeof event.type === 'string' ? event.type : null;
+    if (type === 'TASK_CREATED') {
+      status = 'created';
+      continue;
+    }
+
+    if (type === 'TASK_ENQUEUED' || type === 'TASK_QUEUED') {
+      status = 'queued';
+      continue;
+    }
+
+    if (type === 'TASK_CLAIMED') {
+      status = 'claimed';
+      continue;
+    }
+
+    if (type === 'TASK_EXECUTE_STARTED' || type === 'TASK_STARTED') {
+      status = 'executing';
+      continue;
+    }
+
+    if (type === 'TASK_EXECUTE_FINISHED') {
+      status = 'awaiting_ack';
+      continue;
+    }
+
+    if (type === 'TASK_ACKED') {
+      const ack = payloadStatus(event);
+      if (ack === 'failed') {
+        status = 'failed';
+      } else if (ack) {
+        status = 'completed';
+      }
+    }
+  }
+
+  return status;
+}
+
+export function getTaskTimeline(indexedWorld, taskId) {
+  const events = getTaskEvents(indexedWorld, taskId);
+  let previousTimestamp = null;
+
+  return events
+    .filter((event) => eventTaskId(event) === normalizeTaskId(taskId))
+    .map((event) => {
+      const timestamp = Number.isFinite(event && event.timestamp) ? Number(event.timestamp) : null;
+      const deltaMs = Number.isFinite(previousTimestamp) && Number.isFinite(timestamp)
+        ? Math.max(0, timestamp - previousTimestamp)
+        : null;
+
+      previousTimestamp = Number.isFinite(timestamp) ? timestamp : previousTimestamp;
+
+      return {
+        taskId: normalizeTaskId(taskId),
+        timestamp,
+        type: typeof event.type === 'string' ? event.type : 'UNKNOWN',
+        payload: event && typeof event.payload === 'object' ? event.payload : {},
+        deltaMs
+      };
+    });
+}
+
+export function getTaskSnapshot(indexedWorld, taskId) {
+  const id = normalizeTaskId(taskId);
+  if (!id) {
+    return null;
+  }
+
+  const events = getTaskEvents(indexedWorld, id);
+  if (!events.length) {
+    return null;
+  }
+
+  const firstEvent = events[0];
+  const lastEvent = events[events.length - 1];
+  const status = getTaskStatus(indexedWorld, id);
+
+  let title = id;
+  let type = 'unknown';
+  let assignedAgentId = null;
+  let deskId = null;
+  let error = null;
+
+  for (const event of events) {
+    const eventType = typeof event.type === 'string' ? event.type : null;
+    const payload = event && typeof event.payload === 'object' ? event.payload : {};
+
+    const payloadTitle = payloadValue(event, 'title');
+    if (typeof payloadTitle === 'string' && payloadTitle.trim()) {
+      title = payloadTitle.trim();
+    }
+
+    const payloadType = payloadValue(event, 'type');
+    if (typeof payloadType === 'string' && payloadType.trim()) {
+      type = payloadType.trim();
+    }
+
+    const agentId = payload.agentId !== undefined && payload.agentId !== null
+      ? String(payload.agentId)
+      : (payload.workerId !== undefined && payload.workerId !== null ? String(payload.workerId) : null);
+    if (agentId) {
+      assignedAgentId = agentId;
+    }
+
+    const eventDeskId = payload.deskId !== undefined && payload.deskId !== null ? String(payload.deskId) : null;
+    if (eventDeskId) {
+      deskId = eventDeskId;
+    }
+
+    if (eventType === 'TASK_ACKED' && payload.status === 'failed') {
+      error = typeof payload.error === 'string' ? payload.error : (error || 'ack_failed');
+    }
+
+    if (eventType === 'TASK_EXECUTE_FINISHED' && typeof payload.error === 'string') {
+      error = payload.error;
+    }
+  }
+
+  return {
+    id,
+    title,
+    type,
+    status,
+    assignedAgentId,
+    deskId: deskId || `desk-${hashString(id) % 6}`,
+    error,
+    createdAt: Number.isFinite(firstEvent && firstEvent.timestamp) ? Number(firstEvent.timestamp) : null,
+    updatedAt: Number.isFinite(lastEvent && lastEvent.timestamp) ? Number(lastEvent.timestamp) : null
+  };
+}
+
+export function getAllTasks(indexedWorld) {
+  return getTaskIds(indexedWorld)
+    .map((taskId) => getTaskSnapshot(indexedWorld, taskId))
+    .filter(Boolean)
+    .sort((a, b) => {
+      const ta = Number.isFinite(a.createdAt) ? a.createdAt : 0;
+      const tb = Number.isFinite(b.createdAt) ? b.createdAt : 0;
+      if (ta !== tb) {
+        return ta - tb;
+      }
+      return String(a.id).localeCompare(String(b.id));
+    });
+}
+
+export function filterTasks(indexedWorld, options = {}) {
+  const activeOnly = options && options.activeOnly === true;
+  const recentSeconds = normalizeSeconds(options && options.recentSeconds);
+  const now = Number.isFinite(options && options.now) ? Number(options.now) : Date.now();
+
+  let tasks = getAllTasks(indexedWorld);
+
+  if (activeOnly) {
+    tasks = tasks.filter((task) => isActiveTaskStatus(task.status));
+  }
+
+  if (recentSeconds > 0) {
+    const cutoff = now - recentSeconds * 1000;
+    tasks = tasks.filter((task) => {
+      const touchedAt = taskTouchedAt(task);
+      return isActiveTaskStatus(task.status) || (Number.isFinite(touchedAt) && touchedAt >= cutoff);
+    });
+  }
+
+  return tasks;
+}
+
+export function getTaskBuckets(indexedWorld, options = {}) {
+  const tasks = Array.isArray(options && options.tasks)
+    ? options.tasks
+    : filterTasks(indexedWorld, options);
+
+  const queued = [];
+  const active = [];
+  const done = [];
+  const failed = [];
+
+  for (const task of tasks) {
+    if (task.status === 'failed') {
+      failed.push(task);
+      continue;
+    }
+
+    if (task.status === 'completed' || task.status === 'acknowledged') {
+      done.push(task);
+      continue;
+    }
+
+    if (isActiveTaskStatus(task.status)) {
+      active.push(task);
+      continue;
+    }
+
+    queued.push(task);
+  }
+
+  return { queued, active, done, failed };
+}
+
+export function getTaskById(indexedWorld, taskId) {
+  const id = normalizeTaskId(taskId);
+  if (!id) {
+    return null;
+  }
+
+  return getTaskSnapshot(indexedWorld, id);
+}
+
+export function getDeskIndexForTask(task, deskCount = 6) {
+  const safeDeskCount = Math.max(1, Number.isFinite(deskCount) ? Number(deskCount) : 6);
+  const fallbackTaskId = task && task.id ? String(task.id) : 'task';
+  const rawDeskId = task && task.deskId ? String(task.deskId) : `desk-${hashString(fallbackTaskId) % safeDeskCount}`;
+  const parsed = /^desk-(\d+)$/.exec(rawDeskId);
+  if (parsed) {
+    return Number(parsed[1]) % safeDeskCount;
+  }
+
+  return hashString(rawDeskId) % safeDeskCount;
+}
+
+export function getDeskPosition(index, deskCount = 6) {
+  const cols = [208, 348, 488];
+  const rows = [220, 360];
+  const safeDeskCount = Math.max(1, Number.isFinite(deskCount) ? Number(deskCount) : 6);
+  const i = Math.max(0, Number.isFinite(index) ? Number(index) : 0) % safeDeskCount;
+
+  return {
+    x: cols[i % cols.length],
+    y: rows[Math.floor(i / cols.length)]
+  };
+}
+
+export function getAllDesks(indexedWorld, options = {}) {
+  const deskCount = Math.max(1, Number.isFinite(options && options.deskCount) ? Number(options.deskCount) : 6);
+  const tasks = getAllTasks(indexedWorld);
+  const buckets = Array.from({ length: deskCount }, (_, idx) => ({
+    id: `desk-${idx}`,
+    deskIndex: idx,
+    queueTaskIds: [],
+    currentTaskId: null,
+    ...getDeskPosition(idx, deskCount)
+  }));
+
+  for (const task of tasks) {
+    const deskIndex = getDeskIndexForTask(task, deskCount);
+    const desk = buckets[deskIndex];
+    if (!desk) {
+      continue;
+    }
+
+    if (isActiveTaskStatus(task.status)) {
+      desk.currentTaskId = task.id;
+      continue;
+    }
+
+    if (task.status === 'queued' || task.status === 'created' || task.status === 'unknown') {
+      desk.queueTaskIds.push(task.id);
+    }
+  }
+
+  return buckets;
+}
+
+export function getRecentEvents(indexedWorld, limit = 100) {
+  const events = indexedWorld && Array.isArray(indexedWorld.events) ? indexedWorld.events : [];
+  const capped = events.slice(-Math.max(1, Number(limit) || 100));
+
+  return capped.map((event) => ({
+    id: Number.isFinite(event && event.id) ? Number(event.id) : null,
+    timestamp: Number.isFinite(event && event.timestamp) ? Number(event.timestamp) : null,
+    type: typeof event.type === 'string' ? event.type : 'UNKNOWN',
+    taskId: eventTaskId(event),
+    payload: event && typeof event.payload === 'object' ? event.payload : {}
+  }));
+}

--- a/ui/task-creator-panel.js
+++ b/ui/task-creator-panel.js
@@ -1,6 +1,19 @@
-import { subscribeEventStream, getRawEvents } from '../core/world/eventStore.js';
+import { subscribeEventStream } from '../core/world/eventStore.js';
+import { getTaskStatus } from './selectors/taskSelectors.js';
 
 export function initTaskCreatorPanel() {
+    function getIndexedWorldSnapshot() {
+      if (window.controlAPI && typeof window.controlAPI.getWorldState === 'function') {
+        return window.controlAPI.getWorldState();
+      }
+
+      return {
+        events: [],
+        eventsByTaskId: new Map(),
+        eventsByWorkerId: new Map()
+      };
+    }
+
   const FIXED_DISCORD_CHANNEL_ID = '1491500223288184964';
 
   const panelRuntime = {
@@ -9,56 +22,29 @@ export function initTaskCreatorPanel() {
     observedLifecycleByTaskId: new Map()
   };
 
-  function eventTaskId(event) {
-    if (!event || typeof event !== 'object') {
-      return null;
-    }
-
-    if (event.taskId) {
-      return String(event.taskId);
-    }
-
-    if (event.task && event.task.id) {
-      return String(event.task.id);
-    }
-
-    if (event.payload && event.payload.taskId) {
-      return String(event.payload.taskId);
-    }
-
-    return null;
-  }
-
-  function lifecycleFromEvent(event) {
-    if (!event || typeof event !== 'object') {
-      return null;
-    }
-
-    const type = typeof event.type === 'string' ? event.type : null;
-    if (type === 'TASK_CREATED') {
+  function lifecycleFromStatus(status) {
+    if (status === 'created') {
       return { code: 'created', label: 'created' };
     }
-    if (type === 'TASK_ENQUEUED') {
+    if (status === 'queued') {
       return { code: 'queued', label: 'queued' };
     }
-    if (type === 'TASK_CLAIMED') {
-      const payload = event.payload && typeof event.payload === 'object' ? event.payload : {};
-      const agentId = payload.agentId || payload.workerId || 'unknown';
-      return { code: 'claimed', label: `claimed by agent ${agentId}` };
+    if (status === 'claimed') {
+      return { code: 'claimed', label: 'claimed' };
     }
-    if (type === 'TASK_EXECUTE_STARTED') {
+    if (status === 'executing') {
       return { code: 'executing', label: 'executing' };
     }
-    if (type === 'TASK_EXECUTE_FINISHED') {
+    if (status === 'awaiting_ack') {
       return { code: 'finished', label: 'finished' };
     }
-    if (type === 'TASK_ACKED') {
-      const payload = event.payload && typeof event.payload === 'object' ? event.payload : {};
-      if (payload && payload.status === 'failed') {
-        return { code: 'failed', label: 'failed' };
-      }
+    if (status === 'failed') {
+      return { code: 'failed', label: 'failed' };
+    }
+    if (status === 'completed' || status === 'acknowledged') {
       return { code: 'completed', label: 'completed' };
     }
+
     return null;
   }
 
@@ -133,36 +119,32 @@ export function initTaskCreatorPanel() {
       statusDiv.className = 'tcp-status tcp-success';
     }
 
-    function observeLifecycleEvents(events) {
-      if (!Array.isArray(events) || events.length === 0) {
+    function observeLifecycleEvents() {
+      const indexedWorld = getIndexedWorldSnapshot();
+      const pendingTaskId = panelRuntime.pendingTaskId;
+      if (!pendingTaskId) {
         return;
       }
 
-      for (const event of events) {
-        const taskId = eventTaskId(event);
-        if (!taskId) {
-          continue;
-        }
-
-        const lifecycle = lifecycleFromEvent(event);
-        if (!lifecycle) {
-          continue;
-        }
-
-        panelRuntime.observedLifecycleByTaskId.set(taskId, lifecycle);
-
-        if (panelRuntime.pendingTaskId === taskId && panelRuntime.waitingForCreated && lifecycle.code === 'created') {
-          panelRuntime.waitingForCreated = false;
-        }
-
-        if (panelRuntime.pendingTaskId === taskId) {
-          renderLifecycleStatus(taskId);
-        }
+      const status = getTaskStatus(indexedWorld, pendingTaskId);
+      const lifecycle = lifecycleFromStatus(status);
+      if (!lifecycle) {
+        return;
       }
+
+      panelRuntime.observedLifecycleByTaskId.set(pendingTaskId, lifecycle);
+
+      if (panelRuntime.waitingForCreated && lifecycle.code === 'created') {
+        panelRuntime.waitingForCreated = false;
+      }
+
+      renderLifecycleStatus(pendingTaskId);
     }
 
-    observeLifecycleEvents(getRawEvents());
-    subscribeEventStream(observeLifecycleEvents);
+    observeLifecycleEvents();
+    subscribeEventStream(() => {
+      observeLifecycleEvents();
+    });
 
   const createProductButton = panel.querySelector('#tcp-create-product');
   const productPromptInput = panel.querySelector('#tcp-product-prompt');

--- a/ui/ui-bootstrap.js
+++ b/ui/ui-bootstrap.js
@@ -1,9 +1,11 @@
 import { bindKeyboard } from './keyboard-input.js';
 import { initOperatorControlPanel } from './operator-control-panel.js';
+import { initRaccoonFeederPanel } from './raccoon-feeder-panel.js';
 import { initTaskCreatorPanel } from './task-creator-panel.js';
 
 export function initUI() {
   bindKeyboard();
   initOperatorControlPanel();
+  initRaccoonFeederPanel();
   initTaskCreatorPanel();
 }

--- a/ui/window-api.js
+++ b/ui/window-api.js
@@ -1,6 +1,4 @@
 import { controlAPI, dispatchCommand } from './control-api.js';
-import { getRawEvents } from '../core/world/eventStore.js';
-import { deriveWorldState } from '../core/world/deriveWorldState.js';
 
 async function createTestProduct(options = {}) {
   const promptText = typeof options === 'string'
@@ -53,6 +51,9 @@ export function exposeWindowAPI() {
   window.dispatchCommand = dispatchCommand;
   window.createTestProduct = createTestProduct;
 
-  window.getRawEvents = () => getRawEvents();
-  window.getDerivedWorldState = () => deriveWorldState(getRawEvents());
+  window.getIndexedWorldState = () => controlAPI.getWorldState();
+  window.getTaskView = () => controlAPI.getTasks();
+  window.getAgentView = () => controlAPI.getAgents();
+  window.getDeskView = () => controlAPI.getDeskState();
+  window.getEventView = (limit) => controlAPI.getEventView(limit);
 }


### PR DESCRIPTION
…te v2

- refactored deriveWorldState into pure event indexer (no lifecycle or semantic logic)
- introduced selector layer as the ONLY source of UI meaning (task, agent, metrics, anomaly)
- removed all raw event interpretation from UI modules and renderer
- centralized indexed world snapshot via control API boundary
- updated canvas renderer to consume selector-derived data only
- deduplicated semantic logic into selector modules
- updated invariant tests to validate selector-based lifecycle interpretation
- preserved strict event-driven architecture (TaskEngine authority, ACK-only terminal state)

UI now strictly follows:
events → index → selectors → render

This prevents logic leakage and enforces deterministic, read-only observability.