### PR TITLE
feat(ui-architecture-v2): enforce selector-driven UI, event taxonomy,…

### DIFF
--- a/bridge-server.js
+++ b/bridge-server.js
@@ -96,6 +96,21 @@ function appendEventToLog(event) {
   }
 }
 
+function emitBridgeEvent(event) {
+  const timestamp = Number.isFinite(event && event.timestamp) ? event.timestamp : Date.now();
+  const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {};
+
+  appendEventToLog({
+    id: nextEventId++,
+    type: event.event,
+    taskId: String(event.taskId),
+    timestamp,
+    payload
+  });
+
+  saveStore();
+}
+
 if (!process.env.DISCORD_BOT_TOKEN) {
   console.error('[DISCORD] Missing DISCORD_BOT_TOKEN. Discord execution is disabled.');
 } else {
@@ -366,6 +381,309 @@ function mapCommandToAction(command) {
   return 'reply_to_message';
 }
 
+function isDiscordSnowflake(value) {
+  return typeof value === 'string' && /^\d{17,20}$/.test(value);
+}
+
+function readPathValue(source, dottedPath) {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+
+  const parts = String(dottedPath || '').split('.').filter(Boolean);
+  let current = source;
+  for (const part of parts) {
+    if (!current || typeof current !== 'object' || !(part in current)) {
+      return undefined;
+    }
+
+    current = current[part];
+  }
+
+  return current;
+}
+
+function hasPresentValue(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  return true;
+}
+
+function collectRequiredFieldAnomalies(requiredFields, input, payload) {
+  if (!Array.isArray(requiredFields) || requiredFields.length === 0) {
+    return [];
+  }
+
+  const root = {
+    payload,
+    designIntent: input && typeof input.designIntent === 'object' && input.designIntent !== null
+      ? input.designIntent
+      : {}
+  };
+
+  const anomalies = [];
+  for (const requirement of requiredFields) {
+    const alternatives = String(requirement || '').split('|').map((part) => part.trim()).filter(Boolean);
+    if (alternatives.length === 0) {
+      continue;
+    }
+
+    const satisfied = alternatives.some((candidate) => hasPresentValue(readPathValue(root, candidate)));
+    if (!satisfied) {
+      anomalies.push(`missing_required_field:${alternatives.join('|')}`);
+    }
+  }
+
+  return anomalies;
+}
+
+function normalizeIntentMode(mode) {
+  if (mode === 'soft' || mode === 'experimental') {
+    return mode;
+  }
+
+  return 'strict';
+}
+
+const INTENT_REGISTRY = Object.freeze({
+  discord_message: Object.freeze({
+    mode: 'soft',
+    requiredFields: Object.freeze(['payload.channelId']),
+    mapAction: () => 'send_channel_message',
+    validate: ({ payload }) => {
+      if (!isDiscordSnowflake(payload.channelId)) {
+        return 'payload.channelId must be a Discord snowflake';
+      }
+
+      return null;
+    },
+    fallback: ({ input, payload }) => {
+      const nextPayload = {
+        ...payload
+      };
+
+      if (typeof nextPayload.content !== 'string' || !nextPayload.content.trim()) {
+        nextPayload.content = input.title || 'Untitled task';
+      }
+
+      return nextPayload;
+    }
+  }),
+  discord_reply: Object.freeze({
+    mode: 'strict',
+    requiredFields: Object.freeze(['payload.channelId', 'payload.messageId']),
+    mapAction: () => 'reply_to_message',
+    validate: ({ payload }) => {
+      if (!isDiscordSnowflake(payload.channelId)) {
+        return 'payload.channelId must be a Discord snowflake';
+      }
+
+      if (!isDiscordSnowflake(payload.messageId)) {
+        return 'payload.messageId must be a Discord snowflake';
+      }
+
+      return null;
+    },
+    fallback: null
+  }),
+  shopify_process_order: Object.freeze({
+    mode: 'soft',
+    requiredFields: Object.freeze([]),
+    mapAction: () => 'process_order',
+    validate: () => null,
+    fallback: null
+  }),
+  render_product_image: Object.freeze({
+    mode: 'experimental',
+    requiredFields: Object.freeze(['payload.prompt|designIntent.prompt']),
+    mapAction: () => 'render_product_image',
+    validate: ({ input, payload }) => {
+      const bodyDesignIntent = input.designIntent && typeof input.designIntent === 'object' ? input.designIntent : {};
+      const payloadDesignIntent = payload.designIntent && typeof payload.designIntent === 'object' ? payload.designIntent : {};
+      const promptFromPayload = typeof payload.prompt === 'string' ? payload.prompt.trim() : '';
+      const promptFromBodyDesignIntent = typeof bodyDesignIntent.prompt === 'string' ? bodyDesignIntent.prompt.trim() : '';
+      const promptFromPayloadDesignIntent = typeof payloadDesignIntent.prompt === 'string' ? payloadDesignIntent.prompt.trim() : '';
+
+      if (!promptFromPayload && !promptFromBodyDesignIntent && !promptFromPayloadDesignIntent) {
+        return 'payload.prompt or designIntent.prompt is required';
+      }
+
+      return null;
+    },
+    fallback: null
+  })
+});
+
+function normalizeIntentName(intent) {
+  if (typeof intent !== 'string') {
+    return '';
+  }
+
+  return intent.trim().toLowerCase();
+}
+
+function getIntentContract(intent) {
+  const normalizedIntent = normalizeIntentName(intent);
+  if (!normalizedIntent) {
+    return null;
+  }
+
+  const contract = INTENT_REGISTRY[normalizedIntent];
+  if (!contract) {
+    return null;
+  }
+
+  return {
+    name: normalizedIntent,
+    mode: normalizeIntentMode(contract.mode),
+    ...contract
+  };
+}
+
+function mapIntentToAction(intent) {
+  const contract = getIntentContract(intent);
+  return contract ? contract.mapAction() : null;
+}
+
+function applyIntentFallback(intentContract, input, payload) {
+  if (!intentContract || typeof intentContract.fallback !== 'function') {
+    return {
+      ...payload
+    };
+  }
+
+  const fallbackPayload = intentContract.fallback({ input, payload: { ...payload } });
+  if (!fallbackPayload || typeof fallbackPayload !== 'object') {
+    return {
+      ...payload
+    };
+  }
+
+  return fallbackPayload;
+}
+
+function validateIntentContract(intentContract, input, payload) {
+  if (!intentContract || typeof intentContract.validate !== 'function') {
+    return null;
+  }
+
+  return intentContract.validate({ input, payload });
+}
+
+function evaluateIntentContractAtIngestion(intentContract, input, payload) {
+  if (!intentContract) {
+    return {
+      accepted: true,
+      payload,
+      anomalies: []
+    };
+  }
+
+  const payloadWithFallback = applyIntentFallback(intentContract, input, payload);
+  const anomalies = collectRequiredFieldAnomalies(intentContract.requiredFields, input, payloadWithFallback);
+  const validationError = validateIntentContract(intentContract, input, payloadWithFallback);
+  if (typeof validationError === 'string' && validationError.trim()) {
+    anomalies.push(`validation_error:${validationError}`);
+  }
+
+  if (anomalies.length === 0) {
+    return {
+      accepted: true,
+      payload: payloadWithFallback,
+      anomalies: []
+    };
+  }
+
+  if (intentContract.mode === 'strict') {
+    return {
+      accepted: false,
+      payload: payloadWithFallback,
+      anomalies,
+      error: `${intentContract.name}: ${anomalies.join('; ')}`
+    };
+  }
+
+  if (intentContract.mode === 'experimental') {
+    console.warn('[INTENT_CONTRACT_ANOMALY]', {
+      intent: intentContract.name,
+      mode: intentContract.mode,
+      anomalies,
+      taskType: input && input.type ? input.type : null
+    });
+  }
+
+  return {
+    accepted: true,
+    payload: payloadWithFallback,
+    anomalies
+  };
+}
+
+function defaultActionForType(type, payload) {
+  if (type === 'discord') {
+    if (typeof payload.messageId === 'string' && payload.messageId.trim()) {
+      return 'reply_to_message';
+    }
+
+    return 'send_channel_message';
+  }
+
+  if (type === 'shopify') {
+    return 'process_order';
+  }
+
+  if (type === 'image_render') {
+    return 'render_product_image';
+  }
+
+  return null;
+}
+
+function resolveActionFromInput(input, payload, intentContract = null) {
+  const contract = intentContract || getIntentContract(input.intent);
+  if (contract) {
+    return contract.mapAction();
+  }
+
+  if (typeof input.action === 'string' && input.action.trim()) {
+    return input.action.trim().toLowerCase();
+  }
+
+  return defaultActionForType(input.type, payload);
+}
+
+function resolveImageRenderFields(input, payload) {
+  const provider = typeof input.provider === 'string' && input.provider.trim()
+    ? input.provider.trim()
+    : (typeof payload.provider === 'string' && payload.provider.trim() ? payload.provider.trim() : 'openai');
+  const productId = typeof input.productId === 'string' && input.productId.trim()
+    ? input.productId.trim()
+    : (typeof payload.productId === 'string' && payload.productId.trim() ? payload.productId.trim() : `product-${generateId()}`);
+  const providedDesignIntent = typeof input.designIntent === 'object' && input.designIntent !== null
+    ? input.designIntent
+    : (typeof payload.designIntent === 'object' && payload.designIntent !== null ? payload.designIntent : {});
+  const promptText = typeof payload.prompt === 'string' && payload.prompt.trim() ? payload.prompt.trim() : null;
+  const designIntent = {
+    ...providedDesignIntent
+  };
+
+  if (!designIntent.prompt && promptText) {
+    designIntent.prompt = promptText;
+  }
+
+  return {
+    provider,
+    productId,
+    designIntent
+  };
+}
+
 function normalizeTask(input) {
   const now = Date.now();
   const requiredRange = input.type === 'shopify' ? [120, 260] : [80, 200];
@@ -376,6 +694,31 @@ function normalizeTask(input) {
   const depth = Math.max(0, Math.floor(toFiniteNumber(input.depth, toFiniteNumber(payload.depth, 0))));
   const internal = input.internal === true || input.domain === 'system' || payload.internal === true || payload.domain === 'system';
 
+  const intentContract = getIntentContract(input.intent);
+  const resolvedAction = resolveActionFromInput(input, payload, intentContract);
+  const payloadWithIntentFallback = applyIntentFallback(intentContract, input, payload);
+  const imageRenderFields = input.type === 'image_render'
+    ? resolveImageRenderFields(input, payloadWithIntentFallback)
+    : null;
+  const normalizedPayload = {
+    ...payloadWithIntentFallback
+  };
+
+  if (input.type === 'discord' && (resolvedAction === 'send_channel_message' || resolvedAction === 'reply_to_message')) {
+    if (typeof normalizedPayload.content !== 'string' || !normalizedPayload.content.trim()) {
+      normalizedPayload.content = input.title || 'Untitled task';
+    }
+  }
+
+  if (imageRenderFields) {
+    normalizedPayload.provider = imageRenderFields.provider;
+    normalizedPayload.productId = imageRenderFields.productId;
+    normalizedPayload.designIntent = imageRenderFields.designIntent;
+    if (!normalizedPayload.prompt && imageRenderFields.designIntent && imageRenderFields.designIntent.prompt) {
+      normalizedPayload.prompt = imageRenderFields.designIntent.prompt;
+    }
+  }
+
   return {
     id: input.id || generateId(),
     type: input.type,
@@ -383,15 +726,17 @@ function normalizeTask(input) {
     priority: [0, 1, 2].includes(input.priority) ? input.priority : inferPriority(input),
     progress: typeof input.progress === 'number' ? input.progress : 0,
     required: typeof input.required === 'number' ? input.required : randomInRange(requiredRange[0], requiredRange[1]),
-    action: typeof input.action === 'string' ? input.action : null,
-    payload,
+    action: resolvedAction,
+    payload: normalizedPayload,
     correlationId,
     depth,
     internal,
     domain: internal ? 'system' : 'external',
-    productId: typeof input.productId === 'string' ? input.productId : null,
-    provider: typeof input.provider === 'string' ? input.provider : null,
-    designIntent: typeof input.designIntent === 'object' && input.designIntent !== null ? input.designIntent : null,
+    productId: imageRenderFields ? imageRenderFields.productId : (typeof input.productId === 'string' ? input.productId : null),
+    provider: imageRenderFields ? imageRenderFields.provider : (typeof input.provider === 'string' ? input.provider : null),
+    designIntent: imageRenderFields
+      ? imageRenderFields.designIntent
+      : (typeof input.designIntent === 'object' && input.designIntent !== null ? input.designIntent : null),
     retries: typeof input.retries === 'number' ? input.retries : 0,
     maxRetries: typeof input.maxRetries === 'number' ? input.maxRetries : 3,
     createdAt: typeof input.createdAt === 'number' ? input.createdAt : now,
@@ -452,6 +797,10 @@ function validateTaskInput(body) {
     return 'action must be a string';
   }
 
+  if (body.intent !== undefined && typeof body.intent !== 'string') {
+    return 'intent must be a string';
+  }
+
   if (body.payload !== undefined && (typeof body.payload !== 'object' || body.payload === null || Array.isArray(body.payload))) {
     return 'payload must be an object';
   }
@@ -468,6 +817,24 @@ function validateTaskInput(body) {
 
   if (body.designIntent !== undefined && (typeof body.designIntent !== 'object' || body.designIntent === null || Array.isArray(body.designIntent))) {
     return 'designIntent must be an object';
+  }
+
+  const payload = body.payload && typeof body.payload === 'object' ? body.payload : {};
+  const intentName = normalizeIntentName(body.intent);
+  const intentContract = intentName ? getIntentContract(intentName) : null;
+  if (intentName && !intentContract) {
+    return 'intent is not supported';
+  }
+
+  const intentEvaluation = evaluateIntentContractAtIngestion(intentContract, body, payload);
+  if (!intentEvaluation.accepted) {
+    return intentEvaluation.error;
+  }
+
+  const resolvedAction = resolveActionFromInput(body, intentEvaluation.payload, intentContract);
+  const messageId = payload && typeof payload.messageId === 'string' ? payload.messageId : null;
+  if (!intentContract && resolvedAction === 'reply_to_message' && !(typeof messageId === 'string' && /^\d{17,20}$/.test(messageId))) {
+    return 'reply_to_message requires payload.messageId as a Discord snowflake';
   }
 
   return null;
@@ -653,7 +1020,8 @@ function readJsonBody(req, options = {}) {
 }
 
 const discordNotificationWorker = createDiscordNotificationWorker({
-  getDiscordClient: () => discordClient
+  getDiscordClient: () => discordClient,
+  emitEvent: emitBridgeEvent
 });
 
 const taskExecutionWorker = createTaskExecutionWorker({
@@ -676,20 +1044,7 @@ const taskEngine = createTaskEngine({
   onTaskAcked: async (task) => {
     await discordNotificationWorker.notifyTaskCompletion(task);
   },
-  emitEvent: (event) => {
-    const timestamp = Number.isFinite(event && event.timestamp) ? event.timestamp : Date.now();
-    const payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {};
-
-    appendEventToLog({
-      id: nextEventId++,
-      type: event.event,
-      taskId: String(event.taskId),
-      timestamp,
-      payload
-    });
-
-    saveStore();
-  }
+  emitEvent: emitBridgeEvent
 });
 
 async function autoExecuteAndAck(taskId) {
@@ -699,8 +1054,26 @@ async function autoExecuteAndAck(taskId) {
       return;
     }
 
+    const taskSource = existing && existing.payload && typeof existing.payload.source === 'string'
+      ? existing.payload.source
+      : 'unknown';
+    console.log('[AUTO_EXECUTE_ACK_START]', {
+      taskId,
+      type: existing.type,
+      action: existing.action,
+      source: taskSource,
+      engineStatusBeforeEnsure: taskEngine.getTask(taskId) ? taskEngine.getTask(taskId).status : null
+    });
+
     const executionStartedAt = Date.now();
-    ensureTaskInEngine(existing);
+    const ensuredTask = ensureTaskInEngine(existing);
+    console.log('[AUTO_EXECUTE_ACK_AFTER_ENSURE]', {
+      taskId,
+      type: existing.type,
+      action: existing.action,
+      source: taskSource,
+      engineStatusAfterEnsure: ensuredTask ? ensuredTask.status : null
+    });
     const taskResult = await taskEngine.executeTask(taskId);
     const execution = mapTaskResultToExecution(taskResult);
     const executionCompletedAt = Date.now();
@@ -713,6 +1086,14 @@ async function autoExecuteAndAck(taskId) {
 
     const engineTaskBeforeAck = taskEngine.getTask(taskId);
     if (engineTaskBeforeAck && engineTaskBeforeAck.status === 'awaiting_ack' && engineTaskBeforeAck.executionRecord) {
+      console.log('[AUTO_EXECUTE_ACK_BEFORE_ACK]', {
+        taskId,
+        type: existing.type,
+        action: existing.action,
+        source: taskSource,
+        engineStatus: engineTaskBeforeAck.status,
+        success: execution.success
+      });
       await taskEngine.ackTask(taskId);
       const engineTask = taskEngine.getTask(taskId);
       const resolvedStatus = mapEngineStatusToPublic(engineTask ? engineTask.status : null);
@@ -737,7 +1118,25 @@ async function autoExecuteAndAck(taskId) {
         error: existing.lastError || null,
         source: 'auto_execute_ack'
       });
+      console.log('[AUTO_EXECUTE_ACK_DONE]', {
+        taskId,
+        type: existing.type,
+        action: existing.action,
+        source: taskSource,
+        resolvedStatus,
+        error: existing.lastError || null
+      });
+      return;
     }
+
+    console.log('[AUTO_EXECUTE_ACK_SKIPPED_ACK]', {
+      taskId,
+      type: existing.type,
+      action: existing.action,
+      source: taskSource,
+      engineStatus: engineTaskBeforeAck ? engineTaskBeforeAck.status : null,
+      error: execution.error || null
+    });
   } catch (error) {
     console.error('[AUTO_EXECUTE_ACK_ERROR]', taskId, error && error.message ? error.message : error);
   }
@@ -844,8 +1243,28 @@ const server = http.createServer(async (req, res) => {
         deduplicated: !isNew
       });
 
+      console.log('[POST_TASK_ACCEPTED]', {
+        taskId: storedTask && storedTask.id ? storedTask.id : null,
+        type: storedTask && storedTask.type ? storedTask.type : null,
+        action: storedTask && storedTask.action ? storedTask.action : null,
+        source: storedTask && storedTask.payload && typeof storedTask.payload.source === 'string'
+          ? storedTask.payload.source
+          : 'unknown',
+        isNew,
+        engineStatus: taskEngine.getTask(storedTask.id) ? taskEngine.getTask(storedTask.id).status : null
+      });
+
       // Engine owns the full lifecycle — fire execute+ack asynchronously after response.
       if (isNew && storedTask && storedTask.id) {
+        console.log('[POST_TASK_AUTO_EXEC_SCHEDULED]', {
+          taskId: storedTask.id,
+          type: storedTask.type,
+          action: storedTask.action,
+          source: storedTask && storedTask.payload && typeof storedTask.payload.source === 'string'
+            ? storedTask.payload.source
+            : 'unknown',
+          engineStatus: taskEngine.getTask(storedTask.id) ? taskEngine.getTask(storedTask.id).status : null
+        });
         setImmediate(() => {
           autoExecuteAndAck(storedTask.id).catch((err) => {
             console.error('[POST_TASK_AUTO_EXEC]', storedTask.id, err && err.message ? err.message : err);

--- a/cli/openai-image-standalone-test.mjs
+++ b/cli/openai-image-standalone-test.mjs
@@ -1,0 +1,68 @@
+import OpenAI from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const OPENAI_TIMEOUT_MS = Number(process.env.OPENAI_STANDALONE_TIMEOUT_MS || 15_000);
+const prompt = process.argv.slice(2).join(' ').trim() || 'minimal product test render';
+
+function timeoutAfter(ms) {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(`standalone_timeout:${ms}`)), ms);
+  });
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('[STANDALONE_OPENAI_IMAGE_ERROR] missing OPENAI_API_KEY');
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const requestPayload = {
+    model: 'gpt-5',
+    input: prompt,
+    tools: [{ type: 'image_generation' }]
+  };
+
+  console.log('[STANDALONE_OPENAI_IMAGE_REQUEST]', {
+    timeoutMs: OPENAI_TIMEOUT_MS,
+    promptLength: prompt.length,
+    requestPayload
+  });
+
+  const startedAt = Date.now();
+  try {
+    const response = await Promise.race([
+      client.responses.create(requestPayload),
+      timeoutAfter(OPENAI_TIMEOUT_MS)
+    ]);
+
+    console.log('[STANDALONE_OPENAI_IMAGE_RESOLVED]', {
+      durationMs: Date.now() - startedAt,
+      outputItems: Array.isArray(response && response.output) ? response.output.length : 0
+    });
+    console.dir(response, { depth: null, maxArrayLength: null, maxStringLength: null });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || 'unknown_error');
+    const outcome = message.startsWith('standalone_timeout:') ? 'hang_timeout' : 'rejected';
+
+    console.error('[STANDALONE_OPENAI_IMAGE_FAILURE]', {
+      outcome,
+      durationMs: Date.now() - startedAt,
+      error: {
+        name: error && error.name ? error.name : 'Error',
+        message,
+        stack: error && error.stack ? error.stack : null,
+        status: error && Object.prototype.hasOwnProperty.call(error, 'status') ? error.status : null,
+        code: error && Object.prototype.hasOwnProperty.call(error, 'code') ? error.code : null,
+        type: error && Object.prototype.hasOwnProperty.call(error, 'type') ? error.type : null
+      }
+    });
+    console.dir(error, { depth: null, maxArrayLength: null, maxStringLength: null });
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/core/workers/discordNotificationWorker.js
+++ b/core/workers/discordNotificationWorker.js
@@ -1,89 +1,219 @@
 import { AttachmentBuilder } from 'discord.js';
 import { assertSideEffectExecutionContext } from '../engine/enforcementRuntime.js';
 
-export function createDiscordNotificationWorker({ getDiscordClient }) {
+export function createDiscordNotificationWorker({ getDiscordClient, emitEvent }) {
+  function emitNotificationEvent(eventType, taskId, payload) {
+    if (typeof emitEvent !== 'function') {
+      return;
+    }
+
+    try {
+      emitEvent({
+        event: eventType,
+        taskId: String(taskId || 'unknown'),
+        timestamp: Date.now(),
+        payload: payload && typeof payload === 'object' ? payload : {}
+      });
+    } catch (_) {
+      // Non-lifecycle event emission must never throw or affect ACK
+    }
+  }
+
   return {
     async notifyTaskCompletion(task) {
       assertSideEffectExecutionContext();
 
+      const taskId = task && task.id ? task.id : 'unknown';
       const discordClient = typeof getDiscordClient === 'function' ? getDiscordClient() : null;
       const { channelId, messageId, content: taskContent } = task && task.payload ? task.payload : {};
 
-      if (!channelId || !discordClient || !discordClient.isReady || !discordClient.isReady()) {
-        console.log('[DISCORD]', 'completion_notification_skipped', {
-          taskId: task && task.id,
-          hasChannelId: !!channelId,
-          clientReady: !!(discordClient && discordClient.isReady && discordClient.isReady())
+      // Case 1 — Missing channelId: no routing target available
+      if (!channelId) {
+        console.log('[DISCORD_NOTIFICATION_SKIPPED]', {
+          taskId,
+          reason: 'missing_channelId'
         });
+        emitNotificationEvent('TASK_NOTIFICATION_SKIPPED', taskId, { reason: 'missing_channelId' });
         return null;
       }
 
+      // Case 2 — Discord client not configured
+      if (!discordClient) {
+        console.log('[DISCORD_NOTIFICATION_SKIPPED]', {
+          taskId,
+          channelId,
+          reason: 'client_not_configured'
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_SKIPPED', taskId, { reason: 'client_not_configured', channelId });
+        return null;
+      }
+
+      // Case 3 — Discord client not ready
+      if (!discordClient.isReady || !discordClient.isReady()) {
+        console.log('[DISCORD_NOTIFICATION_SKIPPED]', {
+          taskId,
+          channelId,
+          reason: 'client_not_ready'
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_SKIPPED', taskId, { reason: 'client_not_ready', channelId });
+        return null;
+      }
+
+      // Case 4 — messageId absent; will send to channel instead of replying
+      if (!messageId) {
+        console.log('[DISCORD_NOTIFICATION_FALLBACK_CHANNEL]', {
+          taskId,
+          channelId
+        });
+      }
+
+      // Fetch channel — explicit failure logging
+      let channel;
       try {
-        const channel = await discordClient.channels.fetch(channelId);
-        const executionResult = task && typeof task.executionResult === 'object' && task.executionResult !== null
-          ? task.executionResult
-          : {};
-        const executionPayload = executionResult && typeof executionResult.result === 'object' && executionResult.result !== null
-          ? executionResult.result
-          : executionResult;
-        const imageBase64 = typeof executionPayload.imageBase64 === 'string'
-          ? executionPayload.imageBase64
-          : (typeof executionPayload.contentBase64 === 'string' ? executionPayload.contentBase64 : '');
-        const imageMimeType = typeof executionPayload.mimeType === 'string' ? executionPayload.mimeType : 'image/png';
-        const imageUrl = typeof executionPayload.imageUrl === 'string'
-          ? executionPayload.imageUrl
-          : (typeof executionPayload.url === 'string' ? executionPayload.url : null);
-        const files = [];
+        channel = await discordClient.channels.fetch(channelId);
+      } catch (fetchError) {
+        const errorMessage = fetchError instanceof Error ? fetchError.message : String(fetchError);
+        console.error('[DISCORD_NOTIFICATION_FAILED]', {
+          taskId,
+          reason: 'channel_fetch_failed',
+          channelId,
+          error: errorMessage
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_FAILED', taskId, {
+          reason: 'channel_fetch_failed',
+          channelId,
+          error: errorMessage
+        });
+        return false;
+      }
 
-        if (imageBase64) {
-          const extension = imageMimeType.includes('jpeg') || imageMimeType.includes('jpg')
-            ? 'jpg'
-            : (imageMimeType.includes('webp') ? 'webp' : 'png');
-          const imageBuffer = Buffer.from(imageBase64, 'base64');
-          files.push(new AttachmentBuilder(imageBuffer, { name: `${task.id}.${extension}` }));
+      if (!channel) {
+        console.error('[DISCORD_NOTIFICATION_FAILED]', {
+          taskId,
+          reason: 'channel_not_found',
+          channelId
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_FAILED', taskId, {
+          reason: 'channel_not_found',
+          channelId
+        });
+        return false;
+      }
+
+      // Permission check for guild text channels
+      if (channel.guild && discordClient.user && typeof channel.permissionsFor === 'function') {
+        const perms = channel.permissionsFor(discordClient.user);
+        if (perms && !perms.has('SendMessages')) {
+          console.error('[DISCORD_NOTIFICATION_FAILED]', {
+            taskId,
+            reason: 'missing_send_permission',
+            channelId
+          });
+          emitNotificationEvent('TASK_NOTIFICATION_FAILED', taskId, {
+            reason: 'missing_send_permission',
+            channelId
+          });
+          return false;
         }
+      }
 
-        const completionMsg = {
-          taskId: task.id,
-          type: task.type,
-          title: task.title,
-          status: task.status,
-          durationMs: task.durationMs || 0,
-          error: task.lastError || null,
-          content: typeof taskContent === 'string' ? taskContent : null,
-          hasGeneratedImage: files.length > 0,
-          imageUrl: imageUrl || null
-        };
-        const suffix = imageUrl ? `\nImage URL: ${imageUrl}` : '';
-        const content = `**Task Completed**\n\`\`\`json\n${JSON.stringify(completionMsg, null, 2).slice(0, 1700)}\n\`\`\`${suffix}`;
+      // Build message content (unchanged logic)
+      const executionResult = task && typeof task.executionResult === 'object' && task.executionResult !== null
+        ? task.executionResult
+        : {};
+      const executionPayload = executionResult && typeof executionResult.result === 'object' && executionResult.result !== null
+        ? executionResult.result
+        : executionResult;
+      const imageBase64 = typeof executionPayload.imageBase64 === 'string'
+        ? executionPayload.imageBase64
+        : (typeof executionPayload.contentBase64 === 'string' ? executionPayload.contentBase64 : '');
+      const imageMimeType = typeof executionPayload.mimeType === 'string' ? executionPayload.mimeType : 'image/png';
+      const imageUrl = typeof executionPayload.imageUrl === 'string'
+        ? executionPayload.imageUrl
+        : (typeof executionPayload.url === 'string' ? executionPayload.url : null);
+      const files = [];
 
-        if (messageId) {
-          try {
-            const originalMessage = await channel.messages.fetch(messageId);
-            const sent = await originalMessage.reply(files.length > 0 ? { content, files } : content);
-            console.log('[DISCORD]', 'completion_notification_sent', {
-              taskId: task.id,
-              mode: 'reply',
-              channelId,
-              messageId,
-              sentMessageId: sent && sent.id ? sent.id : null
-            });
-            return true;
-          } catch (replyError) {
-            console.warn('[DISCORD]', 'completion_reply_failed_fallback_send', task.id, replyError.message);
-          }
+      if (imageBase64) {
+        const extension = imageMimeType.includes('jpeg') || imageMimeType.includes('jpg')
+          ? 'jpg'
+          : (imageMimeType.includes('webp') ? 'webp' : 'png');
+        const imageBuffer = Buffer.from(imageBase64, 'base64');
+        files.push(new AttachmentBuilder(imageBuffer, { name: `${taskId}.${extension}` }));
+      }
+
+      const completionMsg = {
+        taskId,
+        type: task.type,
+        title: task.title,
+        status: task.status,
+        durationMs: task.durationMs || 0,
+        error: task.lastError || null,
+        content: typeof taskContent === 'string' ? taskContent : null,
+        hasGeneratedImage: files.length > 0,
+        imageUrl: imageUrl || null
+      };
+      const suffix = imageUrl ? `\nImage URL: ${imageUrl}` : '';
+      const messageContent = `**Task Completed**\n\`\`\`json\n${JSON.stringify(completionMsg, null, 2).slice(0, 1700)}\n\`\`\`${suffix}`;
+
+      // Attempt reply if messageId is present
+      if (messageId) {
+        try {
+          const originalMessage = await channel.messages.fetch(messageId);
+          const sent = await originalMessage.reply(files.length > 0 ? { content: messageContent, files } : messageContent);
+          console.log('[DISCORD_NOTIFICATION_SENT]', {
+            taskId,
+            mode: 'reply',
+            channelId,
+            messageId,
+            sentMessageId: sent && sent.id ? sent.id : null
+          });
+          emitNotificationEvent('TASK_NOTIFICATION_SENT', taskId, {
+            mode: 'reply',
+            channelId,
+            messageId,
+            sentMessageId: sent && sent.id ? sent.id : null
+          });
+          return true;
+        } catch (replyError) {
+          const replyErrorMsg = replyError instanceof Error ? replyError.message : String(replyError);
+          console.warn('[DISCORD_NOTIFICATION_REPLY_FALLBACK]', {
+            taskId,
+            channelId,
+            messageId,
+            error: replyErrorMsg
+          });
+          // Fall through to channel send
         }
+      }
 
-        const sent = await channel.send(files.length > 0 ? { content, files } : content);
-        console.log('[DISCORD]', 'completion_notification_sent', {
-          taskId: task.id,
+      // Channel send (primary when no messageId, fallback when reply fails)
+      try {
+        const sent = await channel.send(files.length > 0 ? { content: messageContent, files } : messageContent);
+        console.log('[DISCORD_NOTIFICATION_SENT]', {
+          taskId,
+          mode: 'channel',
+          channelId,
+          sentMessageId: sent && sent.id ? sent.id : null
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_SENT', taskId, {
           mode: 'channel',
           channelId,
           sentMessageId: sent && sent.id ? sent.id : null
         });
         return true;
-      } catch (error) {
-        console.warn('[DISCORD]', 'completion_notification_failed', task.id, error.message);
+      } catch (sendError) {
+        const sendErrorMsg = sendError instanceof Error ? sendError.message : String(sendError);
+        console.error('[DISCORD_NOTIFICATION_FAILED]', {
+          taskId,
+          reason: 'send_failed',
+          channelId,
+          error: sendErrorMsg
+        });
+        emitNotificationEvent('TASK_NOTIFICATION_FAILED', taskId, {
+          reason: 'send_failed',
+          channelId,
+          error: sendErrorMsg
+        });
         return false;
       }
     }

--- a/core/workers/imageRenderWorker.js
+++ b/core/workers/imageRenderWorker.js
@@ -8,6 +8,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT_DIR = path.resolve(__dirname, '../../');
 const GENERATED_ASSETS_DIR = path.join(ROOT_DIR, 'assets', 'generated');
+const DEFAULT_PROVIDER_TIMEOUT_MS = Number(process.env.IMAGE_PROVIDER_TIMEOUT_MS || 60_000);
+const DEFAULT_PROVIDER_FALLBACKS = String(process.env.IMAGE_PROVIDER_FALLBACKS || 'huggingface')
+  .split(',')
+  .map((entry) => entry.trim().toLowerCase())
+  .filter(Boolean);
 
 function sanitizePathSegment(value, fallback = 'item') {
   const sanitized = String(value || fallback)
@@ -31,6 +36,56 @@ async function runProvider(provider, prompt, context) {
   assertProviderExecutionContext();
   const plugin = ProviderRegistry.get(provider);
   return plugin.generate(prompt, context);
+}
+
+async function runProviderWithTimeout(provider, prompt, context, timeoutMs) {
+  const safeTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_TIMEOUT_MS;
+  let timeoutHandle = null;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(`provider_timeout:${safeTimeoutMs}`));
+    }, safeTimeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      runProvider(provider, prompt, context),
+      timeoutPromise
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function buildProviderPlan(primaryProvider, context) {
+  const normalizedPrimary = String(primaryProvider || 'openai').trim().toLowerCase();
+  const configuredFallbacks = Array.isArray(context && context.providerFallbacks)
+    ? context.providerFallbacks.map((entry) => String(entry || '').trim().toLowerCase()).filter(Boolean)
+    : DEFAULT_PROVIDER_FALLBACKS;
+
+  const candidates = [normalizedPrimary, ...configuredFallbacks];
+  const unique = [];
+
+  for (const providerName of candidates) {
+    if (!providerName || unique.includes(providerName)) {
+      continue;
+    }
+
+    if (!ProviderRegistry.has(providerName)) {
+      continue;
+    }
+
+    unique.push(providerName);
+  }
+
+  if (!unique.length) {
+    return [normalizedPrimary];
+  }
+
+  return unique;
 }
 
 async function persistImage({ productId, contentBase64 }) {
@@ -75,25 +130,77 @@ export async function runImageRenderWorker({ provider = 'openai', prompt = '', p
   }
 
   const normalizedProvider = String(provider || 'openai').toLowerCase();
+  const providerPlan = buildProviderPlan(normalizedProvider, context);
   const maxAttemptsRaw = context && typeof context.retryCount === 'number' ? context.retryCount : 0;
   const maxAttempts = Math.max(1, Math.min(3, Math.floor(maxAttemptsRaw) + 1));
+  const providerTimeoutMs = context && Number.isFinite(context.providerTimeoutMs)
+    ? Number(context.providerTimeoutMs)
+    : DEFAULT_PROVIDER_TIMEOUT_MS;
   let providerResult = null;
   let lastError = null;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      providerResult = await runProvider(normalizedProvider, normalizedPrompt, context);
-      lastError = null;
-      break;
-    } catch (error) {
-      lastError = error;
-      if (attempt < maxAttempts) {
-        await sleep(250 * attempt);
+  for (const plannedProvider of providerPlan) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const providerCallStartedAt = Date.now();
+      console.log('[IMAGE_RENDER_PROVIDER_CALL_START]', {
+        provider: plannedProvider,
+        providerPlan,
+        productId,
+        taskId: context && context.taskId ? context.taskId : null,
+        attempt,
+        maxAttempts,
+        timeoutMs: providerTimeoutMs,
+        promptLength: normalizedPrompt.length
+      });
+
+      try {
+        providerResult = await runProviderWithTimeout(plannedProvider, normalizedPrompt, context, providerTimeoutMs);
+        console.log('[IMAGE_RENDER_PROVIDER_CALL_RESOLVED]', {
+          provider: plannedProvider,
+          providerPlan,
+          productId,
+          taskId: context && context.taskId ? context.taskId : null,
+          attempt,
+          durationMs: Date.now() - providerCallStartedAt,
+          hasContentBase64: Boolean(providerResult && typeof providerResult.contentBase64 === 'string' && providerResult.contentBase64.trim())
+        });
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        const errorMessage = error instanceof Error ? error.message : 'provider_execution_failed';
+        const errorKind = errorMessage.startsWith('provider_timeout:') ? 'timeout' : 'rejected';
+        console.error('[IMAGE_RENDER_PROVIDER_CALL_ERROR]', {
+          provider: plannedProvider,
+          providerPlan,
+          productId,
+          taskId: context && context.taskId ? context.taskId : null,
+          attempt,
+          durationMs: Date.now() - providerCallStartedAt,
+          outcome: errorKind,
+          error: errorMessage
+        });
+
+        if (attempt < maxAttempts) {
+          await sleep(250 * attempt);
+        }
       }
+    }
+
+    if (providerResult) {
+      break;
     }
   }
 
   if (!providerResult) {
+    console.error('[IMAGE_RENDER_PROVIDER_CALL_FINAL_FAILURE]', {
+      provider: normalizedProvider,
+      providerPlan,
+      productId,
+      taskId: context && context.taskId ? context.taskId : null,
+      attempts: maxAttempts,
+      error: lastError instanceof Error ? lastError.message : String(lastError || 'provider_execution_failed')
+    });
     return fail(lastError || 'provider_execution_failed');
   }
 
@@ -125,6 +232,12 @@ export async function runImageRenderWorker({ provider = 'openai', prompt = '', p
       asset
     });
   } catch (error) {
+    console.error('[IMAGE_RENDER_PERSIST_ERROR]', {
+      provider: normalizedProvider,
+      productId,
+      taskId: context && context.taskId ? context.taskId : null,
+      error: error instanceof Error ? error.message : String(error || 'persist_failed')
+    });
     return fail(error || 'persist_failed');
   }
 }

--- a/core/workers/taskExecutionWorker.js
+++ b/core/workers/taskExecutionWorker.js
@@ -42,15 +42,12 @@ async function executeDiscordTask(task, { getDiscordClient, taskTriggeredMessage
   const discordClient = typeof getDiscordClient === 'function' ? getDiscordClient() : null;
   const { channelId, messageId, content } = task.payload || {};
 
-  if (!isDiscordSnowflake(channelId) || !isDiscordSnowflake(messageId)) {
-    return ok({
-      skipped: true,
-      note: 'discord_target_unavailable'
-    });
-  }
-
   if (!discordClient || !discordClient.isReady || !discordClient.isReady()) {
     return fail('discordClient is not configured');
+  }
+
+  if (!isDiscordSnowflake(channelId)) {
+    return fail('payload.channelId must be a Discord snowflake');
   }
 
   try {
@@ -62,6 +59,20 @@ async function executeDiscordTask(task, { getDiscordClient, taskTriggeredMessage
     }
 
     const channel = await discordClient.channels.fetch(channelId);
+
+    if (task.action === 'send_channel_message') {
+      const sentMessage = await channel.send(String(content || ''));
+      if (sentMessage && sentMessage.id && taskTriggeredMessageIds) {
+        taskTriggeredMessageIds.add(sentMessage.id);
+      }
+
+      return ok({ sent: true });
+    }
+
+    if (!isDiscordSnowflake(messageId)) {
+      return fail('payload.messageId must be a Discord snowflake for reply_to_message');
+    }
+
     const message = await channel.messages.fetch(messageId);
 
     const replyMessage = await message.reply(content);
@@ -199,7 +210,13 @@ export function createTaskExecutionWorker({ getDiscordClient, taskTriggeredMessa
         const action = String(task.action || '').toLowerCase();
 
         if (
-          action === 'reply_to_message'
+          action === 'send_channel_message'
+          || action === 'discord.send_channel_message'
+          || action === 'discord_message'
+          || action === 'discord.message'
+          || action === 'reply_to_message'
+          || action === 'discord_reply'
+          || action === 'discord.reply'
           || action === 'summarize_message'
           || action === 'classify_intent'
           || action === 'fetch_order'

--- a/core/world/eventTaxonomy.js
+++ b/core/world/eventTaxonomy.js
@@ -1,0 +1,67 @@
+export const LIFECYCLE_EVENTS = Object.freeze([
+  'TASK_CREATED',
+  'TASK_ENQUEUED',
+  'TASK_CLAIMED',
+  'TASK_EXECUTE_STARTED',
+  'TASK_EXECUTE_FINISHED',
+  'TASK_ACKED'
+]);
+
+export const SYSTEM_EVENTS = Object.freeze([
+  'TASK_NOTIFICATION_SENT',
+  'TASK_NOTIFICATION_SKIPPED',
+  'TASK_NOTIFICATION_FAILED'
+]);
+
+const lifecycleSet = new Set(LIFECYCLE_EVENTS);
+const systemSet = new Set(SYSTEM_EVENTS);
+const warnedUnknownTypes = new Set();
+
+const strictUnknownEventTypes = typeof process !== 'undefined'
+  && process
+  && process.env
+  && process.env.SLOTHWORLD_STRICT_EVENT_TAXONOMY === '1';
+
+function isDevMode() {
+  if (typeof process !== 'undefined' && process && process.env && process.env.NODE_ENV) {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  if (typeof window !== 'undefined' && window && window.location) {
+    return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+  }
+
+  return true;
+}
+
+export const LIFECYCLE_EVENT_TYPES = LIFECYCLE_EVENTS;
+export const SYSTEM_EVENT_TYPES = SYSTEM_EVENTS;
+
+function guardUnknownEventType(type) {
+  if (!isDevMode() || typeof type !== 'string') {
+    return;
+  }
+
+  if (lifecycleSet.has(type) || systemSet.has(type) || warnedUnknownTypes.has(type)) {
+    return;
+  }
+
+  warnedUnknownTypes.add(type);
+  const message = `[EventTaxonomy] Unknown event type ${type}`;
+
+  if (strictUnknownEventTypes) {
+    throw new Error(message);
+  }
+
+  console.warn('[EventTaxonomy] Unknown event type', type);
+}
+
+export function isLifecycleEvent(type) {
+  guardUnknownEventType(type);
+  return typeof type === 'string' && lifecycleSet.has(type);
+}
+
+export function isSystemEvent(type) {
+  guardUnknownEventType(type);
+  return typeof type === 'string' && systemSet.has(type);
+}

--- a/integrations/rendering/providers/openaiImageProvider.js
+++ b/integrations/rendering/providers/openaiImageProvider.js
@@ -19,6 +19,42 @@ function extractBase64Image(response) {
   return null;
 }
 
+function extractBase64FromImagesGenerate(response) {
+  if (!response || !Array.isArray(response.data)) {
+    return null;
+  }
+
+  for (const item of response.data) {
+    if (!item || typeof item.b64_json !== 'string') {
+      continue;
+    }
+
+    const value = item.b64_json.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function toErrorLog(error) {
+  if (!error || typeof error !== 'object') {
+    return { message: String(error || 'unknown_error') };
+  }
+
+  return {
+    name: error.name || 'Error',
+    message: error.message || 'unknown_error',
+    stack: error.stack || null,
+    status: Object.prototype.hasOwnProperty.call(error, 'status') ? error.status : null,
+    code: Object.prototype.hasOwnProperty.call(error, 'code') ? error.code : null,
+    type: Object.prototype.hasOwnProperty.call(error, 'type') ? error.type : null,
+    param: Object.prototype.hasOwnProperty.call(error, 'param') ? error.param : null,
+    cause: error.cause || null
+  };
+}
+
 export const openAIImageProvider = {
   id: 'openai',
   async generate(prompt, context = {}) {
@@ -40,17 +76,104 @@ export const openAIImageProvider = {
 
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const createdAt = Date.now();
-    console.log('[OPENAI_IMAGE_REQUEST]', {
+    const apiTimeoutMs = Number(process.env.OPENAI_IMAGE_API_TIMEOUT_MS || 30_000);
+    const imageModel = process.env.OPENAI_IMAGE_MODEL || 'gpt-image-1';
+    const responsesImageModel = process.env.OPENAI_RESPONSES_IMAGE_MODEL || 'gpt-5';
+
+    const imagesRequestPayload = {
+      model: imageModel,
+      prompt: normalizedPrompt,
+      size: process.env.OPENAI_IMAGE_SIZE || '1024x1024'
+    };
+
+    console.log('[OPENAI_IMAGE_REQUEST_IMAGES_API]', {
       productId: normalizedProductId,
       promptLength: normalizedPrompt.length,
-      model: 'gpt-5'
+      apiTimeoutMs,
+      requestPayload: imagesRequestPayload
     });
 
-    const response = await client.responses.create({
-      model: 'gpt-5',
+    try {
+      const response = await client.images.generate(imagesRequestPayload, {
+        timeout: apiTimeoutMs
+      });
+      const base64Png = extractBase64FromImagesGenerate(response);
+
+      console.log('[OPENAI_IMAGE_RESPONSE_IMAGES_API]', {
+        productId: normalizedProductId,
+        hasDataArray: Boolean(response && Array.isArray(response.data)),
+        dataItems: response && Array.isArray(response.data) ? response.data.length : 0,
+        hasBase64: Boolean(base64Png)
+      });
+      console.dir(response, { depth: null, maxArrayLength: null, maxStringLength: null });
+
+      if (base64Png) {
+        console.log('[OPENAI_IMAGE_SUCCESS]', {
+          productId: normalizedProductId,
+          base64Length: base64Png.length,
+          path: 'images.generate',
+          model: imageModel
+        });
+
+        return {
+          path: '',
+          imageUrl: undefined,
+          provider: 'openai',
+          prompt: normalizedPrompt,
+          createdAt,
+          mimeType: 'image/png',
+          model: imageModel,
+          contentBase64: base64Png
+        };
+      }
+
+      console.warn('[OPENAI_IMAGE_IMAGES_API_NO_OUTPUT]', {
+        productId: normalizedProductId,
+        model: imageModel
+      });
+    } catch (error) {
+      console.error('[OPENAI_IMAGE_ERROR_IMAGES_API]', {
+        productId: normalizedProductId,
+        requestPayload: imagesRequestPayload,
+        error: toErrorLog(error)
+      });
+      console.dir(error, { depth: null, maxArrayLength: null, maxStringLength: null });
+    }
+
+    // Fallback path: Responses API image tool.
+    const responsesRequestPayload = {
+      model: responsesImageModel,
       input: normalizedPrompt,
       tools: [{ type: 'image_generation' }]
+    };
+
+    console.log('[OPENAI_IMAGE_REQUEST_RESPONSES_API]', {
+      productId: normalizedProductId,
+      promptLength: normalizedPrompt.length,
+      apiTimeoutMs,
+      requestPayload: responsesRequestPayload
     });
+
+    let response;
+    try {
+      response = await client.responses.create(responsesRequestPayload, {
+        timeout: apiTimeoutMs
+      });
+    } catch (error) {
+      console.error('[OPENAI_IMAGE_ERROR_RESPONSES_API]', {
+        productId: normalizedProductId,
+        requestPayload: responsesRequestPayload,
+        error: toErrorLog(error)
+      });
+      console.dir(error, { depth: null, maxArrayLength: null, maxStringLength: null });
+      throw error;
+    }
+
+    console.log('[OPENAI_IMAGE_RESPONSE_RESPONSES_API]', {
+      productId: normalizedProductId,
+      outputItems: Array.isArray(response && response.output) ? response.output.length : 0
+    });
+    console.dir(response, { depth: null, maxArrayLength: null, maxStringLength: null });
 
     const base64Png = extractBase64Image(response);
     if (!base64Png) {
@@ -59,7 +182,9 @@ export const openAIImageProvider = {
 
     console.log('[OPENAI_IMAGE_SUCCESS]', {
       productId: normalizedProductId,
-      base64Length: base64Png.length
+      base64Length: base64Png.length,
+      path: 'responses.create',
+      model: responsesImageModel
     });
 
     return {
@@ -69,7 +194,7 @@ export const openAIImageProvider = {
       prompt: normalizedPrompt,
       createdAt,
       mimeType: 'image/png',
-      model: 'gpt-5',
+      model: responsesImageModel,
       contentBase64: base64Png
     };
   }

--- a/rendering/canvas-renderer.js
+++ b/rendering/canvas-renderer.js
@@ -2,7 +2,14 @@ import { canvas, ctx } from '../core/app-state.js';
 import { loadedAssets } from './assets.js';
 import { spriteConfigs } from '../core/constants.js';
 import { resolveAgentVisual } from '../ui/config/agentVisualConfig.js';
-import { getAllTasks, getAllDesks } from '../ui/selectors/taskSelectors.js';
+import {
+  getAllTasks,
+  getAllDesks,
+  getTaskOfficeRoute,
+  getTaskVisualTarget,
+  getTaskTransitionTimestamps,
+  getOfficeLayoutSnapshot
+} from '../ui/selectors/taskSelectors.js';
 import { getAllAgents } from '../ui/selectors/agentSelectors.js';
 import { getTaskCounts } from '../ui/selectors/metricsSelectors.js';
 import { getIncidentClusters } from '../ui/selectors/anomalySelectors.js';
@@ -47,6 +54,16 @@ function easeInOutSine(t) {
 function easeOutCubic(t) {
   const x = clamp01(t);
   return 1 - Math.pow(1 - x, 3);
+}
+
+const PHASE_DURATIONS = {
+  claim: 1200,
+  execute: 2000,
+  deliver: 1400
+};
+
+function lerp(a, b, t) {
+  return a + (b - a) * clamp01(t);
 }
 
 function isRenderDebugEnabled() {
@@ -101,6 +118,43 @@ function deskAnchor(desk) {
   return { x: desk.x, y: desk.y + 34 };
 }
 
+function zoneAnchor(zone) {
+  if (!zone) {
+    return { x: 30, y: 30 };
+  }
+
+  return { x: zone.x, y: zone.y + 24 };
+}
+
+function transitionProgress(startAt, frameNow, durationMs, speedFactor) {
+  if (!Number.isFinite(startAt)) {
+    return 0;
+  }
+
+  const safeDuration = Math.max(1, durationMs * speedFactor);
+  return clamp01((frameNow - startAt) / safeDuration);
+}
+
+function quadraticBezierPoint(start, control, end, t) {
+  const x = (1 - t) * (1 - t) * start.x
+    + 2 * (1 - t) * t * control.x
+    + t * t * end.x;
+  const y = (1 - t) * (1 - t) * start.y
+    + 2 * (1 - t) * t * control.y
+    + t * t * end.y;
+
+  return { x, y };
+}
+
+function arcLerp(start, end, t, arcLift = 20) {
+  const mid = {
+    x: lerp(start.x, end.x, 0.5),
+    y: lerp(start.y, end.y, 0.5) - arcLift
+  };
+
+  return quadraticBezierPoint(start, mid, end, clamp01(t));
+}
+
 function findTask(tasksById, taskId) {
   if (!taskId) {
     return null;
@@ -116,50 +170,101 @@ function getAgentVisualState(agent) {
   return agent.state;
 }
 
-function getAgentPosition(agent, frameNow, desksById, tasksById) {
+function getAgentPosition(agent, frameNow, desksById, tasksById, transitionByTaskId, deskCount) {
   const visualState = getAgentVisualState(agent);
   const homeDesk = agent && agent.deskId ? desksById.get(agent.deskId) : null;
   const targetDesk = agent && agent.targetDeskId ? desksById.get(agent.targetDeskId) : null;
   const task = findTask(tasksById, agent && agent.currentTaskId);
 
-  const home = deskAnchor(homeDesk || targetDesk);
-  const target = deskAnchor(targetDesk || homeDesk);
-
   const idHash = hashString(agent && agent.id);
-  const phase = ((frameNow / 1000) + (idHash % 11) * 0.13) % 1;
-  const easedPhase = easeInOutSine(phase);
-  const wobble = Math.sin(frameNow * 0.02 + (idHash % 13)) * 1.2;
+  const speedFactor = 0.9 + ((idHash % 200) / 1000);
   const idleWave = Math.sin(frameNow * 0.0028 + (idHash % 29)) * 2.2;
   const idleDrift = Math.cos(frameNow * 0.0019 + (idHash % 37)) * 1.4;
 
+  const route = task
+    ? getTaskOfficeRoute(task, { deskCount })
+    : {
+      intakeDesk: homeDesk || targetDesk,
+      workerDesk: homeDesk || targetDesk,
+      executionZone: homeDesk || targetDesk,
+      deliveryZone: homeDesk || targetDesk
+    };
+  const transitions = task ? (transitionByTaskId.get(task.id) || {}) : null;
+
+  const intake = deskAnchor(route.intakeDesk || homeDesk || targetDesk);
+  const worker = deskAnchor(route.workerDesk || targetDesk || homeDesk);
+  const execution = zoneAnchor(route.executionZone || targetDesk || homeDesk);
+  const delivery = zoneAnchor(route.deliveryZone || targetDesk || homeDesk);
+  const home = deskAnchor(homeDesk || route.workerDesk || route.intakeDesk);
+
+  const queueToDesk = transitionProgress(
+    transitions && Number.isFinite(transitions.claimedAt) ? transitions.claimedAt : null,
+    frameNow,
+    PHASE_DURATIONS.claim,
+    speedFactor
+  );
+  const deskToExec = transitionProgress(
+    transitions && Number.isFinite(transitions.executingAt) ? transitions.executingAt : null,
+    frameNow,
+    PHASE_DURATIONS.execute,
+    speedFactor
+  );
+  const execToDelivery = easeInOutSine(transitionProgress(
+    transitions && Number.isFinite(transitions.awaitingAckAt) ? transitions.awaitingAckAt : null,
+    frameNow,
+    PHASE_DURATIONS.deliver,
+    speedFactor
+  ));
+
   if (visualState === 'moving') {
+    const p = easeOutCubic(queueToDesk);
+    const path = arcLerp(intake, worker, p, 20);
     return {
-      x: home.x + (target.x - home.x) * easedPhase,
-      y: home.y + (target.y - home.y) * easedPhase + wobble
+      x: path.x,
+      y: path.y
     };
   }
 
   if (visualState === 'working') {
-    const workPulse = easeOutCubic((Math.sin(frameNow * 0.0034 + (idHash % 17)) + 1) / 2);
+    const workPulse = easeOutCubic((Math.sin(frameNow * 0.0028 + (idHash % 17)) + 1) / 2);
+    const path = arcLerp(worker, execution, deskToExec, 10);
     return {
-      x: target.x,
-      y: target.y + (workPulse - 0.5) * 3.2
+      x: path.x,
+      y: path.y + (workPulse - 0.5) * 2.2
     };
   }
 
   if (visualState === 'delivering') {
-    const arc = Math.sin(frameNow * 0.02 + (hashString(agent.id) % 19));
+    const t = execToDelivery;
+    const path = arcLerp(execution, delivery, t, 20);
     return {
-      x: target.x + arc * 8,
-      y: target.y - 10 - Math.abs(arc) * 8
+      x: path.x,
+      y: path.y
     };
   }
 
   if (visualState === 'error') {
-    const jitter = Math.sin(frameNow * 0.11 + (hashString(agent.id) % 23)) * 2;
+    const jitter = Math.sin(frameNow * 0.13 + (hashString(agent.id) % 23)) * 2.4;
     return {
-      x: target.x + jitter,
-      y: target.y
+      x: delivery.x + jitter,
+      y: delivery.y
+    };
+  }
+
+  if (visualState === 'awaiting_ack') {
+    const ackPulse = Math.sin(frameNow * 0.004 + (idHash % 31));
+    const ackX = lerp(execution.x, delivery.x, execToDelivery);
+    const ackY = lerp(execution.y, delivery.y, execToDelivery);
+    return {
+      x: ackX,
+      y: ackY + ackPulse * 1.6
+    };
+  }
+
+  if (visualState === 'queued') {
+    return {
+      x: intake.x + idleDrift * 0.5,
+      y: intake.y + idleWave * 0.5
     };
   }
 
@@ -173,6 +278,48 @@ function getAgentPosition(agent, frameNow, desksById, tasksById) {
     x: home.x + idleDrift,
     y: home.y + idleWave
   };
+}
+
+function drawOfficeFlow(layout) {
+  const intake = layout && layout.intakeDesk ? layout.intakeDesk : { x: 120, y: 220 };
+  const workerDesks = layout && Array.isArray(layout.workerDesks) ? layout.workerDesks : [];
+  const execution = layout && layout.executionZone ? layout.executionZone : { x: 640, y: 220 };
+  const delivery = layout && layout.deliveryZone ? layout.deliveryZone : { x: 640, y: 360 };
+
+  ctx.save();
+  ctx.setLineDash([5, 4]);
+  ctx.strokeStyle = 'rgba(148, 163, 184, 0.35)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(intake.x + 42, intake.y + 4);
+  ctx.lineTo(execution.x - 46, execution.y + 4);
+  ctx.lineTo(delivery.x - 46, delivery.y + 4);
+  ctx.stroke();
+
+  for (const desk of workerDesks) {
+    ctx.beginPath();
+    ctx.moveTo(intake.x + 26, intake.y + 10);
+    ctx.lineTo(desk.x - 20, desk.y + 10);
+    ctx.lineTo(execution.x - 26, execution.y + 10);
+    ctx.stroke();
+  }
+  ctx.setLineDash([]);
+
+  const drawZone = (label, zone, color) => {
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.5)';
+    ctx.fillRect(zone.x - 50, zone.y - 24, 100, 48);
+    ctx.strokeStyle = color;
+    ctx.strokeRect(zone.x - 50, zone.y - 24, 100, 48);
+    ctx.fillStyle = color;
+    ctx.font = '10px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, zone.x, zone.y - 30);
+  };
+
+  drawZone('INTAKE', intake, '#94a3b8');
+  drawZone('EXECUTION', execution, '#38bdf8');
+  drawZone('DELIVERY', delivery, '#22c55e');
+  ctx.restore();
 }
 
 function statusColor(status) {
@@ -203,10 +350,16 @@ function resolveSpriteFrame(visual, spriteImage, frameNow, agentId) {
   const frameWidth = Number.isFinite(visual && visual.frameWidth) ? visual.frameWidth : imageWidth;
   const frameHeight = Number.isFinite(visual && visual.frameHeight) ? visual.frameHeight : imageHeight;
   const frameCount = Math.max(1, Number.isFinite(visual && visual.frameCount) ? visual.frameCount : Math.floor(imageWidth / frameWidth) || 1);
-  const frameDurationMs = Math.max(1, Number.isFinite(visual && visual.frameDurationMs) ? visual.frameDurationMs : 200);
+  const fps = Number.isFinite(visual && visual.fps) && visual.fps > 0
+    ? visual.fps
+    : 5;
+  const frameDurationMs = Math.max(1, Math.round(1000 / fps));
+  const loop = !(visual && visual.loop === false);
+  const elapsed = Math.max(0, frameNow + hashString(agentId) * 17);
+  const frameNumber = frameCount <= 1 ? 0 : Math.floor(elapsed / frameDurationMs);
   const frameIndex = frameCount <= 1
     ? 0
-    : Math.floor((frameNow + hashString(agentId) * 17) / frameDurationMs) % frameCount;
+    : (loop ? frameNumber % frameCount : Math.min(frameCount - 1, frameNumber));
 
   return {
     sourceX: frameIndex * frameWidth,
@@ -281,14 +434,14 @@ function drawDesk(desk) {
   ctx.fillText(`Q:${queueCount}`, desk.x, y + height + 12);
 }
 
-function drawTask(task, desk) {
-  if (!desk) {
+function drawTask(task, position) {
+  if (!position) {
     return;
   }
 
   const isActive = task.status === 'claimed' || task.status === 'executing' || task.status === 'awaiting_ack';
-  const baseX = desk.x;
-  const baseY = isActive ? desk.y - 18 : desk.y + 26;
+  const baseX = position.x;
+  const baseY = isActive ? position.y - 22 : position.y + 22;
 
   ctx.fillStyle = statusColor(task.status);
   ctx.fillRect(baseX - 34, baseY - 8, 68, 16);
@@ -300,9 +453,9 @@ function drawTask(task, desk) {
   ctx.fillText(shortId || 'task', baseX, baseY + 3);
 }
 
-function drawAgent(agent, desksById, tasksById, frameNow) {
+function drawAgent(agent, desksById, tasksById, frameNow, transitionByTaskId, deskCount) {
   const visualState = getAgentVisualState(agent);
-  const position = getAgentPosition(agent, frameNow, desksById, tasksById);
+  const position = getAgentPosition(agent, frameNow, desksById, tasksById, transitionByTaskId, deskCount);
   const x = position.x;
   const y = position.y;
 
@@ -320,6 +473,10 @@ function drawAgent(agent, desksById, tasksById, frameNow) {
       && debugPointer.y >= y - drawSize.height
       && debugPointer.y <= y;
 
+    ctx.save();
+    if (visualState === 'queued') {
+      ctx.globalAlpha = 0.58;
+    }
     ctx.drawImage(
       spriteImage,
       frame.sourceX,
@@ -331,6 +488,7 @@ function drawAgent(agent, desksById, tasksById, frameNow) {
       drawSize.width,
       drawSize.height
     );
+    ctx.restore();
 
     drawSpriteDebugOverlay(x, y, drawSize, frame, isHovered);
   } else {
@@ -358,12 +516,41 @@ function drawAgent(agent, desksById, tasksById, frameNow) {
     }
   }
 
+  if (visualState === 'awaiting_ack') {
+    const ackPulse = 0.5 + 0.5 * Math.sin(frameNow * 0.008 + (hashString(agent.id) % 41));
+    ctx.strokeStyle = `rgba(245, 158, 11, ${0.2 + ackPulse * 0.65})`;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(x, y - 8, 12 + ackPulse * 7, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
   if (visualState === 'delivering') {
-    const pulse = 0.5 + 0.5 * Math.sin(frameNow * 0.02 + (hashString(agent.id) % 29));
-    ctx.strokeStyle = `rgba(74, 222, 128, ${0.2 + pulse * 0.55})`;
+    const rippleBase = ((frameNow + hashString(agent.id) * 23) % 1800) / 1800;
+    const rippleA = rippleBase;
+    const rippleB = (rippleBase + 0.5) % 1;
+    const drawRipple = (phase) => {
+      const eased = easeOutCubic(phase);
+      const alpha = 0.45 * (1 - eased);
+      ctx.strokeStyle = `rgba(74, 222, 128, ${alpha})`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(x, y - 8, 8 + eased * 18, 0, Math.PI * 2);
+      ctx.stroke();
+    };
+    drawRipple(rippleA);
+    drawRipple(rippleB);
+  }
+
+  if (visualState === 'error') {
+    const errJitter = Math.sin(frameNow * 0.12 + hashString(agent.id)) * 2;
+    ctx.strokeStyle = 'rgba(239, 68, 68, 0.85)';
     ctx.lineWidth = 1;
     ctx.beginPath();
-    ctx.arc(x, y - 6, 11 + pulse * 4, 0, Math.PI * 2);
+    ctx.moveTo(x - 10 + errJitter, y - 22);
+    ctx.lineTo(x + 10 - errJitter, y - 2);
+    ctx.moveTo(x + 10 - errJitter, y - 22);
+    ctx.lineTo(x - 10 + errJitter, y - 2);
     ctx.stroke();
   }
 
@@ -407,10 +594,12 @@ function drawHud(counts, incidents) {
     return;
   }
 
-  const latest = list[0];
+  const latest = list.find((cluster) => Array.isArray(cluster && cluster.taskIds) && cluster.taskIds.length > 0) || list[0];
   ctx.fillStyle = '#fecaca';
   ctx.font = '10px monospace';
-  ctx.fillText(`Alert: ${latest.category}${latest.taskId ? ` (${latest.taskId})` : ''}`, 18, 40);
+  const clusterLabel = latest && typeof latest.type === 'string' ? latest.type : 'unknown';
+  const taskCount = latest && Array.isArray(latest.taskIds) ? latest.taskIds.length : 0;
+  ctx.fillText(`Alert: ${clusterLabel} (${taskCount} tasks)`, 18, 40);
 }
 
 export function render(indexedWorld) {
@@ -422,10 +611,15 @@ export function render(indexedWorld) {
   const tasks = getAllTasks(safeIndexed);
   const agents = getAllAgents(safeIndexed);
   const counts = getTaskCounts(safeIndexed);
-  const incidents = getIncidentClusters(safeIndexed, { now: Date.now() });
+  const incidents = getIncidentClusters(safeIndexed, {
+    now: Date.now(),
+    includeSystemEvents: false
+  });
+  const officeLayout = getOfficeLayoutSnapshot();
 
   const desksById = new Map(desks.map((desk) => [desk.id, desk]));
   const tasksById = new Map(tasks.map((task) => [task.id, task]));
+  const transitionByTaskId = new Map(tasks.map((task) => [task.id, getTaskTransitionTimestamps(safeIndexed, task.id)]));
   const frameNow = Date.now();
 
   ensureDebugBindings();
@@ -439,13 +633,15 @@ export function render(indexedWorld) {
     drawDesk(desk);
   }
 
+  drawOfficeFlow(officeLayout);
+
   for (const task of tasks) {
-    const desk = desksById.get(task.deskId);
-    drawTask(task, desk);
+    const taskPosition = getTaskVisualTarget(task, { deskCount: desks.length || 1 });
+    drawTask(task, taskPosition);
   }
 
   for (const agent of agents) {
-    drawAgent(agent, desksById, tasksById, frameNow);
+    drawAgent(agent, desksById, tasksById, frameNow, transitionByTaskId, desks.length || (officeLayout.workerDesks && officeLayout.workerDesks.length) || 1);
   }
 
   drawHud(counts, incidents);

--- a/style.css
+++ b/style.css
@@ -101,6 +101,50 @@ canvas {
   color: #9ca3af;
 }
 
+.ocp-debug-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.ocp-debug-create {
+  background: #2f6b43;
+  color: #ecfdf5;
+  border: 1px solid #3f8256;
+  font: 11px monospace;
+  padding: 4px 8px;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.ocp-debug-create:hover {
+  background: #3f8256;
+}
+
+.ocp-debug-create:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ocp-debug-indicator {
+  min-height: 14px;
+  font-size: 10px;
+  color: #9ca3af;
+}
+
+.ocp-debug-indicator.is-visible {
+  color: #86efac;
+}
+
+.ocp-debug-indicator.is-visible.is-success {
+  color: #86efac;
+}
+
+.ocp-debug-indicator.is-visible.is-error {
+  color: #fca5a5;
+}
+
 .ocp-grid-2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -180,6 +224,11 @@ canvas {
 
 .ocp-item.ocp-task-failed {
   border-left: 3px solid var(--status-error-red);
+}
+
+.ocp-item.ocp-task-image-failed {
+  border-color: #ef4444;
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.4);
 }
 
 .ocp-event-row {

--- a/tests/event-taxonomy.test.mjs
+++ b/tests/event-taxonomy.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  LIFECYCLE_EVENTS,
+  SYSTEM_EVENTS,
+  isLifecycleEvent,
+  isSystemEvent
+} from '../core/world/eventTaxonomy.js';
+
+test('all lifecycle events are recognized as lifecycle', () => {
+  LIFECYCLE_EVENTS.forEach((type) => {
+    assert.equal(isLifecycleEvent(type), true, `${type} should be lifecycle`);
+  });
+});
+
+test('no lifecycle event is classified as system event', () => {
+  LIFECYCLE_EVENTS.forEach((type) => {
+    assert.equal(isSystemEvent(type), false, `${type} should not be system`);
+  });
+});
+
+test('all system events are recognized as system', () => {
+  SYSTEM_EVENTS.forEach((type) => {
+    assert.equal(isSystemEvent(type), true, `${type} should be system`);
+  });
+});
+
+test('unknown events warn in non-strict mode', () => {
+  const unknownType = `TASK_UNKNOWN_WARN_${Date.now()}`;
+  const originalWarn = console.warn;
+  const warnings = [];
+
+  console.warn = (...args) => {
+    warnings.push(args);
+  };
+
+  try {
+    assert.equal(isLifecycleEvent(unknownType), false);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.ok(warnings.length >= 1, 'expected warning for unknown event type');
+  const text = warnings.map((entry) => entry.join(' ')).join(' | ');
+  assert.match(text, /Unknown event type/);
+  assert.match(text, new RegExp(unknownType));
+});
+
+test('unknown events throw in strict mode', () => {
+  const script = [
+    "import { isLifecycleEvent } from './core/world/eventTaxonomy.js';",
+    "isLifecycleEvent('TASK_UNKNOWN_STRICT_MODE');"
+  ].join('\n');
+
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      SLOTHWORLD_STRICT_EVENT_TAXONOMY: '1'
+    },
+    encoding: 'utf8'
+  });
+
+  assert.notEqual(result.status, 0, 'strict mode should fail process for unknown event types');
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  assert.match(output, /Unknown event type/);
+});

--- a/tests/selector-contract.test.mjs
+++ b/tests/selector-contract.test.mjs
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveWorldState } from '../core/world/deriveWorldState.js';
+import {
+  getLifecycleEvents,
+  getTaskEvents,
+  getTaskStatus
+} from '../ui/selectors/taskSelectors.js';
+import {
+  getQueueTime,
+  getExecutionDuration,
+  getAckLatency
+} from '../ui/selectors/metricsSelectors.js';
+import { getIncidentClusters } from '../ui/selectors/anomalySelectors.js';
+import { isSystemEvent } from '../core/world/eventTaxonomy.js';
+
+function buildWorld(events) {
+  return deriveWorldState(events);
+}
+
+function event(type, taskId, timestamp, payload = {}) {
+  return { type, taskId, timestamp, payload };
+}
+
+test('task selectors ignore system events in lifecycle derivation', () => {
+  const mixedEvents = [
+    event('TASK_CREATED', 'task-1', 1, { title: 'Task One' }),
+    event('TASK_NOTIFICATION_SKIPPED', 'task-1', 2, { reason: 'missing_channelId' }),
+    event('TASK_EXECUTE_STARTED', 'task-1', 3, {}),
+    event('TASK_NOTIFICATION_FAILED', 'task-1', 4, { reason: 'send_failed' }),
+    event('TASK_EXECUTE_FINISHED', 'task-1', 5, { success: true }),
+    event('TASK_ACKED', 'task-1', 6, { status: 'completed' })
+  ];
+
+  const world = buildWorld(mixedEvents);
+  const lifecycleEvents = getTaskEvents(world, 'task-1');
+  const status = getTaskStatus(world, 'task-1');
+
+  assert.ok(lifecycleEvents.length > 0);
+  assert.equal(lifecycleEvents.some((item) => isSystemEvent(item.type)), false);
+  assert.equal(status, 'completed');
+});
+
+test('getLifecycleEvents filters only lifecycle event types', () => {
+  const mixed = [
+    event('TASK_CREATED', 'task-2', 1, {}),
+    event('TASK_NOTIFICATION_SENT', 'task-2', 2, {}),
+    event('TASK_EXECUTE_STARTED', 'task-2', 3, {}),
+    event('TASK_UNKNOWN_TYPE', 'task-2', 4, {}),
+    event('TASK_ACKED', 'task-2', 5, { status: 'completed' })
+  ];
+
+  const lifecycleOnly = getLifecycleEvents(mixed);
+  assert.deepEqual(
+    lifecycleOnly.map((item) => item.type),
+    ['TASK_CREATED', 'TASK_EXECUTE_STARTED', 'TASK_ACKED']
+  );
+});
+
+test('metrics selectors are invariant to presence of system events', () => {
+  const lifecycleOnly = [
+    event('TASK_CREATED', 'task-3', 1000, {}),
+    event('TASK_ENQUEUED', 'task-3', 1100, {}),
+    event('TASK_EXECUTE_STARTED', 'task-3', 2000, {}),
+    event('TASK_EXECUTE_FINISHED', 'task-3', 3500, { success: true }),
+    event('TASK_ACKED', 'task-3', 4000, { status: 'completed' })
+  ];
+
+  const withSystem = [
+    ...lifecycleOnly,
+    event('TASK_NOTIFICATION_SENT', 'task-3', 4100, { mode: 'channel' }),
+    event('TASK_NOTIFICATION_FAILED', 'task-3', 4200, { reason: 'transient' })
+  ];
+
+  const worldLifecycle = buildWorld(lifecycleOnly);
+  const worldWithSystem = buildWorld(withSystem);
+
+  assert.equal(getQueueTime(worldLifecycle, 'task-3'), getQueueTime(worldWithSystem, 'task-3'));
+  assert.equal(getExecutionDuration(worldLifecycle, 'task-3'), getExecutionDuration(worldWithSystem, 'task-3'));
+  assert.equal(getAckLatency(worldLifecycle, 'task-3'), getAckLatency(worldWithSystem, 'task-3'));
+});
+
+test('getIncidentClusters returns expected shape with includeSystemEvents=true', () => {
+  const now = 100000;
+  const events = [
+    event('TASK_CREATED', 'task-4', 1000, {}),
+    event('TASK_EXECUTE_STARTED', 'task-4', 2000, {}),
+    event('TASK_EXECUTE_FINISHED', 'task-4', 3000, { success: false }),
+    event('TASK_ACKED', 'task-4', 3100, { status: 'failed', error: 'boom' }),
+
+    event('TASK_CREATED', 'task-5', 1000, {}),
+    event('TASK_EXECUTE_STARTED', 'task-5', 1500, {}),
+    event('TASK_EXECUTE_FINISHED', 'task-5', 2000, { success: true }),
+    event('TASK_NOTIFICATION_SKIPPED', 'task-5', 2500, { reason: 'missing_channelId' }),
+
+    event('TASK_CREATED', 'task-6', 1000, {}),
+    event('TASK_EXECUTE_STARTED', 'task-6', 1100, {}),
+    event('TASK_EXECUTE_FINISHED', 'task-6', 1200, { success: true })
+  ];
+
+  const world = buildWorld(events);
+  const clusters = getIncidentClusters(world, {
+    includeSystemEvents: true,
+    thresholdMs: 1000,
+    now
+  });
+
+  assert.ok(Array.isArray(clusters));
+  assert.ok(clusters.length >= 3);
+
+  clusters.forEach((cluster) => {
+    assert.equal(typeof cluster.type, 'string');
+    assert.ok(['low', 'medium', 'high'].includes(cluster.severity));
+    assert.ok(Array.isArray(cluster.taskIds));
+    assert.equal(typeof cluster.summary, 'string');
+    assert.ok(Array.isArray(cluster.representativeEvents));
+  });
+
+  const clusterTypes = new Set(clusters.map((item) => item.type));
+  assert.equal(clusterTypes.has('execution_failures'), true);
+  assert.equal(clusterTypes.has('notification_issues'), true);
+  assert.equal(clusterTypes.has('stalled_tasks'), true);
+});
+
+test('getIncidentClusters excludes notification cluster when includeSystemEvents=false', () => {
+  const now = 100000;
+  const events = [
+    event('TASK_CREATED', 'task-7', 1000, {}),
+    event('TASK_EXECUTE_STARTED', 'task-7', 1500, {}),
+    event('TASK_EXECUTE_FINISHED', 'task-7', 2000, { success: true }),
+    event('TASK_NOTIFICATION_FAILED', 'task-7', 2100, { reason: 'send_failed' })
+  ];
+
+  const world = buildWorld(events);
+  const clusters = getIncidentClusters(world, {
+    includeSystemEvents: false,
+    thresholdMs: 1000,
+    now
+  });
+
+  const clusterTypes = new Set(clusters.map((item) => item.type));
+  assert.equal(clusterTypes.has('notification_issues'), false);
+
+  clusters.forEach((cluster) => {
+    assert.equal(typeof cluster.type, 'string');
+    assert.ok(['low', 'medium', 'high'].includes(cluster.severity));
+    assert.ok(Array.isArray(cluster.taskIds));
+    assert.equal(typeof cluster.summary, 'string');
+    assert.ok(Array.isArray(cluster.representativeEvents));
+  });
+});

--- a/ui/config/agentVisualConfig.js
+++ b/ui/config/agentVisualConfig.js
@@ -4,38 +4,66 @@ export const agentVisualConfig = {
     animations: {
       idle: {
         key: 'julia_idle',
+        sprite: 'Julia-Idle.png',
         frameWidth: 32,
         frameHeight: 32,
         frameCount: 4,
-        frameDurationMs: 220
+        fps: 5,
+        loop: true
+      },
+      queued: {
+        key: 'julia_idle',
+        sprite: 'Julia-Idle.png',
+        frameWidth: 32,
+        frameHeight: 32,
+        frameCount: 4,
+        fps: 4,
+        loop: true
       },
       moving: {
         key: 'julia_walk',
+        sprite: 'Julia_walk_Foward.png',
         frameWidth: 64,
         frameHeight: 64,
         frameCount: 4,
-        frameDurationMs: 140
+        fps: 8,
+        loop: true
       },
       working: {
         key: 'julia_typing',
+        sprite: 'Julia_PC.png',
         frameWidth: 64,
         frameHeight: 64,
         frameCount: 6,
-        frameDurationMs: 120
+        fps: 9,
+        loop: true
+      },
+      awaiting_ack: {
+        key: 'julia_typing',
+        sprite: 'Julia_PC.png',
+        frameWidth: 64,
+        frameHeight: 64,
+        frameCount: 6,
+        fps: 5,
+        loop: true
       },
       delivering: {
         key: 'julia_walk',
+        sprite: 'Julia_walk_Foward.png',
         frameWidth: 64,
         frameHeight: 64,
         frameCount: 4,
-        frameDurationMs: 140
+        fps: 8,
+        loop: true
       },
       error: {
         key: 'julia_error',
+        sprite: 'Julia.png',
         frameWidth: 32,
         frameHeight: 32,
         frameCount: 4,
-        frameDurationMs: 180
+        fps: 7,
+        loop: true
       }
     }
   }
@@ -70,10 +98,14 @@ export function resolveAgentVisual(role, state) {
     state: stateKey,
     baseSprite: visualByRole ? visualByRole.baseSprite : null,
     animation: animationKey,
-    spriteFilename,
+    spriteFilename: normalizedAnimation && normalizedAnimation.sprite ? normalizedAnimation.sprite : spriteFilename,
     frameWidth: normalizedAnimation && Number.isFinite(normalizedAnimation.frameWidth) ? normalizedAnimation.frameWidth : null,
     frameHeight: normalizedAnimation && Number.isFinite(normalizedAnimation.frameHeight) ? normalizedAnimation.frameHeight : null,
     frameCount: normalizedAnimation && Number.isFinite(normalizedAnimation.frameCount) ? normalizedAnimation.frameCount : 1,
-    frameDurationMs: normalizedAnimation && Number.isFinite(normalizedAnimation.frameDurationMs) ? normalizedAnimation.frameDurationMs : 200
+    fps: normalizedAnimation && Number.isFinite(normalizedAnimation.fps) ? normalizedAnimation.fps : 5,
+    loop: normalizedAnimation && typeof normalizedAnimation.loop === 'boolean' ? normalizedAnimation.loop : true,
+    frameDurationMs: normalizedAnimation && Number.isFinite(normalizedAnimation.fps) && normalizedAnimation.fps > 0
+      ? Math.round(1000 / normalizedAnimation.fps)
+      : 200
   };
 }

--- a/ui/config/officeLayout.js
+++ b/ui/config/officeLayout.js
@@ -1,0 +1,13 @@
+export const officeLayout = {
+  intakeDesk: { x: 128, y: 196 },
+  workerDesks: [
+    { x: 250, y: 190 },
+    { x: 370, y: 190 },
+    { x: 490, y: 190 },
+    { x: 250, y: 330 },
+    { x: 370, y: 330 },
+    { x: 490, y: 330 }
+  ],
+  executionZone: { x: 650, y: 196 },
+  deliveryZone: { x: 650, y: 330 }
+};

--- a/ui/control-api.js
+++ b/ui/control-api.js
@@ -15,24 +15,12 @@ function toTaskPayload(task) {
     payload
   };
 
-  if (typeof task.action === 'string' && task.action.trim()) {
-    normalized.action = task.action.trim();
+  if (typeof task.intent === 'string' && task.intent.trim()) {
+    normalized.intent = task.intent.trim();
   }
 
   if (Number.isFinite(task && task.priority)) {
     normalized.priority = Number(task.priority);
-  }
-
-  if (typeof task.productId === 'string') {
-    normalized.productId = task.productId;
-  }
-
-  if (typeof task.provider === 'string') {
-    normalized.provider = task.provider;
-  }
-
-  if (task && task.designIntent && typeof task.designIntent === 'object') {
-    normalized.designIntent = { ...task.designIntent };
   }
 
   return normalized;
@@ -62,6 +50,8 @@ async function injectTask(task) {
     // UI intent ends here — engine auto-drives enqueue → claim → execute → ack.
     return {
       success: true,
+      statusCode: response.status,
+      body: body || null,
       data: body && body.task ? body.task : body
     };
   } catch (error) {
@@ -118,7 +108,7 @@ export async function dispatchCommand(inputString) {
         ...(await controlAPI.injectTask({
           type: 'discord',
           title: 'Manual inject',
-          action: 'reply_to_message',
+          intent: parsed.messageId ? 'discord_reply' : 'discord_message',
           payload: {
             channelId: parsed.channelId || null,
             messageId: parsed.messageId || null,
@@ -133,7 +123,7 @@ export async function dispatchCommand(inputString) {
       ...(await controlAPI.injectTask({
         type: 'shopify',
         title: parsed.message,
-        action: 'process_order',
+        intent: 'shopify_process_order',
         payload: {
           note: parsed.message
         }

--- a/ui/operator-control-panel.js
+++ b/ui/operator-control-panel.js
@@ -23,7 +23,10 @@ const panelState = {
   selectedTimelineIndex: null,
   activeTasksOnly: false,
   recentSeconds: 0,
-  maxEventRows: 100
+  maxEventRows: 100,
+  createTaskPending: false,
+  createTaskMessage: '',
+  createTaskTone: ''
 };
 
 function stringify(value) {
@@ -76,7 +79,83 @@ function taskIcon(status) {
   return '•';
 }
 
-function renderTaskList(listElement, tasks, selectedTaskId) {
+function extractTaskError(task = {}, timeline = []) {
+  const directCandidates = [
+    task.error,
+    task.lastError,
+    task.executionResult && task.executionResult.error,
+    task.executionResult && task.executionResult.result && task.executionResult.result.error,
+    task.payload && task.payload.error
+  ];
+
+  for (const candidate of directCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  for (let i = timeline.length - 1; i >= 0; i -= 1) {
+    const entry = timeline[i];
+    const payload = entry && entry.payload && typeof entry.payload === 'object' ? entry.payload : {};
+    const payloadError = payload && typeof payload.error === 'string' ? payload.error.trim() : '';
+    if (payloadError) {
+      return payloadError;
+    }
+  }
+
+  return null;
+}
+
+function formatTaskErrorMessage(task, rawError) {
+  if (!rawError) {
+    return null;
+  }
+
+  if (rawError.startsWith('provider_timeout:')) {
+    const timeoutMs = rawError.split(':')[1] || 'unknown';
+    return `provider timeout (${timeoutMs}ms)`;
+  }
+
+  if (rawError === 'openai_api_key_missing') {
+    return 'OpenAI API key missing';
+  }
+
+  if (rawError === 'huggingface_api_key_missing') {
+    return 'HuggingFace API key missing';
+  }
+
+  if (task && task.type === 'image_render') {
+    return `image render failed: ${rawError}`;
+  }
+
+  return rawError;
+}
+
+function buildExecutionTrace(timeline = []) {
+  return timeline.map((entry) => {
+    const payload = entry && entry.payload && typeof entry.payload === 'object' ? entry.payload : {};
+    const trace = {
+      at: formatIso(entry.timestamp),
+      event: entry.type
+    };
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'success')) {
+      trace.success = payload.success;
+    }
+
+    if (typeof payload.error === 'string' && payload.error.trim()) {
+      trace.error = payload.error.trim();
+    }
+
+    if (typeof payload.attempts === 'number') {
+      trace.attempts = payload.attempts;
+    }
+
+    return trace;
+  });
+}
+
+function renderTaskList(listElement, tasks, selectedTaskId, indexedWorld) {
   listElement.innerHTML = '';
 
   if (!tasks.length) {
@@ -88,13 +167,24 @@ function renderTaskList(listElement, tasks, selectedTaskId) {
   }
 
   tasks.slice(0, 25).forEach((task) => {
+    const timeline = indexedWorld ? getTaskTimeline(indexedWorld, task.id).slice(-20) : [];
+    const rawError = extractTaskError(task, timeline);
+    const displayError = formatTaskErrorMessage(task, rawError);
+
     const li = document.createElement('li');
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `ocp-item ocp-task-${taskTone(task.status)}${selectedTaskId === task.id ? ' is-selected' : ''}`;
     button.dataset.taskId = task.id;
-    const label = `${task.title} | ${task.status}${task.assignedAgentId ? ` | ${task.assignedAgentId}` : ''}`;
+    const statusLabel = `status:${task.status || 'unknown'}`;
+    const errorLabel = displayError ? ` | error:${displayError}` : '';
+    const label = `${task.title} | ${statusLabel}${task.assignedAgentId ? ` | ${task.assignedAgentId}` : ''}${errorLabel}`;
     button.textContent = `${taskIcon(task.status)} ${label}`;
+
+    if (task.type === 'image_render' && displayError) {
+      button.classList.add('ocp-task-image-failed');
+    }
+
     li.appendChild(button);
     listElement.appendChild(li);
   });
@@ -224,6 +314,10 @@ function createPanelRoot() {
 
     <section class="ocp-section" data-section="tasks">
       <h3>Tasks (Derived)</h3>
+      <div class="ocp-debug-actions">
+        <button type="button" class="ocp-debug-create" data-action="create-test-task">+ Create Test Task</button>
+        <span class="ocp-debug-indicator" data-role="create-task-indicator"></span>
+      </div>
       <div class="ocp-toolbar">
         <label class="ocp-control">
           <input type="checkbox" data-control="active-only" />
@@ -312,6 +406,8 @@ export function initOperatorControlPanel() {
   const activeOnlyInput = panel.querySelector('[data-control="active-only"]');
   const recentSecondsSelect = panel.querySelector('[data-control="recent-seconds"]');
   const maxEventsSelect = panel.querySelector('[data-control="max-events"]');
+  const createTaskButton = panel.querySelector('[data-action="create-test-task"]');
+  const createTaskIndicator = panel.querySelector('[data-role="create-task-indicator"]');
 
   if (activeOnlyInput) {
     activeOnlyInput.checked = panelState.activeTasksOnly;
@@ -345,6 +441,11 @@ export function initOperatorControlPanel() {
     if (target.dataset.timelineIndex) {
       panelState.selectedTimelineIndex = Number(target.dataset.timelineIndex);
       renderPanel();
+      return;
+    }
+
+    if (target.matches('[data-action="create-test-task"]')) {
+      createTestTask();
     }
   });
 
@@ -383,10 +484,10 @@ export function initOperatorControlPanel() {
     const agents = getAllAgents(indexedWorld);
     const buckets = getTaskBuckets(indexedWorld, { tasks });
 
-    renderTaskList(queuedList, buckets.queued, panelState.selectedTaskId);
-    renderTaskList(activeList, buckets.active, panelState.selectedTaskId);
-    renderTaskList(doneList, buckets.done, panelState.selectedTaskId);
-    renderTaskList(failedList, buckets.failed, panelState.selectedTaskId);
+    renderTaskList(queuedList, buckets.queued, panelState.selectedTaskId, indexedWorld);
+    renderTaskList(activeList, buckets.active, panelState.selectedTaskId, indexedWorld);
+    renderTaskList(doneList, buckets.done, panelState.selectedTaskId, indexedWorld);
+    renderTaskList(failedList, buckets.failed, panelState.selectedTaskId, indexedWorld);
 
     const recentEvents = getRecentEvents(indexedWorld, panelState.maxEventRows).reverse();
     eventsList.innerHTML = '';
@@ -470,7 +571,22 @@ export function initOperatorControlPanel() {
           eventDetail.textContent = stringify(selectedEntry);
         }
 
+        const rawError = extractTaskError(selectedTask, timelineRows);
+        const displayError = formatTaskErrorMessage(selectedTask, rawError);
+        const executionTrace = buildExecutionTrace(timelineRows);
+
         taskDetail.textContent = stringify({
+          id: selectedTask.id,
+          type: selectedTask.type,
+          title: selectedTask.title,
+          status: selectedTask.status,
+          engineStatus: selectedTask.engineStatus || null,
+          taskError: displayError,
+          executionResult: selectedTask.executionResult || null,
+          provider: selectedTask.provider || (selectedTask.payload && selectedTask.payload.provider) || null,
+          attempts: selectedTask.attempts || null,
+          durationMs: selectedTask.durationMs || selectedTask.executionDurationMs || null,
+          executionTrace,
           ...selectedTask,
           timeline: timelineRows
         });
@@ -491,7 +607,76 @@ export function initOperatorControlPanel() {
       agentDetail.textContent = 'Click an agent to inspect derived assignment.';
     }
 
+    if (createTaskButton) {
+      createTaskButton.disabled = panelState.createTaskPending;
+      createTaskButton.textContent = panelState.createTaskPending
+        ? 'Creating...'
+        : '+ Create Test Task';
+    }
+
+    if (createTaskIndicator) {
+      createTaskIndicator.textContent = panelState.createTaskMessage;
+      createTaskIndicator.className = panelState.createTaskMessage
+        ? `ocp-debug-indicator is-visible ${panelState.createTaskTone === 'error' ? 'is-error' : 'is-success'}`
+        : 'ocp-debug-indicator';
+    }
+
     drawTaskSelectionOverlay(allTasks, agents, panelState.selectedTaskId);
+  }
+
+  async function createTestTask() {
+    if (panelState.createTaskPending) {
+      return;
+    }
+
+    if (!window.controlAPI || typeof window.controlAPI.injectTask !== 'function') {
+      panelState.createTaskMessage = 'Create failed: controlAPI unavailable';
+      panelState.createTaskTone = 'error';
+      renderPanel();
+      console.error('[CreateTestTask] controlAPI.injectTask unavailable');
+      return;
+    }
+
+    panelState.createTaskPending = true;
+    panelState.createTaskMessage = '';
+    panelState.createTaskTone = '';
+    renderPanel();
+
+    try {
+      const response = await window.controlAPI.injectTask({
+        type: 'image_render',
+        title: 'Test Task',
+        intent: 'render_product_image',
+        payload: {
+          source: 'operator_control_panel',
+          prompt: 'minimal product test render'
+        }
+      });
+
+      console.log('[CreateTestTask] /task response', {
+        success: response && response.success === true,
+        statusCode: response && response.statusCode ? response.statusCode : null,
+        body: response && Object.prototype.hasOwnProperty.call(response, 'body') ? response.body : (response && response.data ? response.data : null),
+        error: response && response.error ? response.error : null
+      });
+
+      if (!response || !response.success) {
+        const status = response && response.statusCode ? ` (${response.statusCode})` : '';
+        const detail = response && response.data ? ` ${stringify(response.data)}` : (response && response.error ? ` ${response.error}` : '');
+        panelState.createTaskMessage = `Create failed${status}${detail}`;
+        panelState.createTaskTone = 'error';
+      } else {
+        panelState.createTaskMessage = `Task created (${response.statusCode || 200}) ${stringify(response.body || response.data || {})}`;
+        panelState.createTaskTone = 'success';
+      }
+    } catch (error) {
+      console.error('[CreateTestTask] request_failed', error);
+      panelState.createTaskMessage = `Create failed ${error && error.message ? error.message : 'request_failed'}`;
+      panelState.createTaskTone = 'error';
+    } finally {
+      panelState.createTaskPending = false;
+      renderPanel();
+    }
   }
 
   renderPanel();

--- a/ui/raccoon-feeder-panel.js
+++ b/ui/raccoon-feeder-panel.js
@@ -58,7 +58,7 @@ export function initRaccoonFeederPanel() {
 
   const incidentsList = panel.querySelector('[data-list="incidents"]');
   const incidentDetail = panel.querySelector('[data-detail="incident"]');
-  let selectedIncidentId = null;
+  let selectedClusterType = null;
 
   function getIndexedWorldSnapshot() {
     if (window.controlAPI && typeof window.controlAPI.getWorldState === 'function') {
@@ -78,28 +78,32 @@ export function initRaccoonFeederPanel() {
       return;
     }
 
-    const incidentId = target.dataset.incidentId;
-    if (!incidentId) {
+    const clusterType = target.dataset.clusterType;
+    if (!clusterType) {
       return;
     }
 
-    selectedIncidentId = incidentId;
+    selectedClusterType = clusterType;
     renderPanel();
   });
 
   function renderPanel() {
     const indexedWorld = getIndexedWorldSnapshot();
-    const incidents = getIncidentClusters(indexedWorld, { thresholdMs: STALLED_ACK_MS, now: Date.now() })
+    const incidents = getIncidentClusters(indexedWorld, {
+      thresholdMs: STALLED_ACK_MS,
+      now: Date.now(),
+      includeSystemEvents: true
+    })
       .sort((a, b) => {
         const diff = severityRank(b.severity) - severityRank(a.severity);
         if (diff !== 0) {
           return diff;
         }
-        return String(a.taskId || '').localeCompare(String(b.taskId || ''));
+        return String(a.type || '').localeCompare(String(b.type || ''));
       });
 
-    if (!incidents.some((item) => item.id === selectedIncidentId)) {
-      selectedIncidentId = incidents.length ? incidents[0].id : null;
+    if (!incidents.some((item) => item.type === selectedClusterType)) {
+      selectedClusterType = incidents.length ? incidents[0].type : null;
     }
 
     incidentsList.innerHTML = '';
@@ -116,19 +120,26 @@ export function initRaccoonFeederPanel() {
       const li = document.createElement('li');
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = `rfp-item${incident.id === selectedIncidentId ? ' is-selected' : ''}`;
-      button.dataset.incidentId = incident.id;
-      button.textContent = `${incident.severity.toUpperCase()} | ${incident.category} | ${incident.taskId || 'n/a'}`;
+      button.className = `rfp-item${incident.type === selectedClusterType ? ' is-selected' : ''}`;
+      button.dataset.clusterType = incident.type;
+      const taskCount = Array.isArray(incident.taskIds) ? incident.taskIds.length : 0;
+      button.textContent = `${incident.type} | ${incident.severity.toUpperCase()} | tasks:${taskCount}`;
       li.appendChild(button);
       incidentsList.appendChild(li);
     });
 
-    const selected = incidents.find((item) => item.id === selectedIncidentId) || incidents[0];
-    const selectedTimeline = selected && selected.taskId
-      ? getTaskTimeline(indexedWorld, selected.taskId).slice(-8)
+    const selected = incidents.find((item) => item.type === selectedClusterType) || incidents[0];
+    const selectedTaskId = selected && Array.isArray(selected.taskIds) && selected.taskIds.length
+      ? selected.taskIds[0]
+      : null;
+    const selectedTimeline = selectedTaskId
+      ? getTaskTimeline(indexedWorld, selectedTaskId).slice(-8)
       : [];
     incidentDetail.textContent = stringify({
       ...selected,
+      expandedRepresentativeEvents: selected && Array.isArray(selected.representativeEvents)
+        ? selected.representativeEvents
+        : [],
       timeline: selectedTimeline
     });
   }

--- a/ui/selectors/anomalySelectors.js
+++ b/ui/selectors/anomalySelectors.js
@@ -1,4 +1,4 @@
-import { getTaskEvents } from './taskSelectors.js';
+import { isLifecycleEvent, isSystemEvent } from '../../core/world/eventTaxonomy.js';
 
 function allTaskIds(indexedWorld) {
   if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
@@ -8,10 +8,55 @@ function allTaskIds(indexedWorld) {
   return Array.from(indexedWorld.eventsByTaskId.keys());
 }
 
+function getTaskEvents(indexedWorld, taskId) {
+  if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
+    return [];
+  }
+
+  const events = indexedWorld.eventsByTaskId.get(String(taskId));
+  return Array.isArray(events) ? events : [];
+}
+
+function getLifecycleTaskEvents(indexedWorld, taskId) {
+  return getTaskEvents(indexedWorld, taskId)
+    .filter((event) => isLifecycleEvent(event && event.type));
+}
+
+function getSystemTaskEvents(indexedWorld, taskId) {
+  return getTaskEvents(indexedWorld, taskId)
+    .filter((event) => isSystemEvent(event && event.type));
+}
+
+function safeTimestamp(event) {
+  return Number.isFinite(event && event.timestamp) ? Number(event.timestamp) : null;
+}
+
+function eventType(event) {
+  return event && typeof event.type === 'string' ? event.type : null;
+}
+
+function normalizeTaskId(taskId) {
+  return taskId === null || taskId === undefined ? null : String(taskId);
+}
+
+function taskEventsForType(events, type) {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  return events.filter((event) => eventType(event) === type);
+}
+
+function firstByTimestampDesc(events, limit = 3) {
+  return [...events]
+    .sort((a, b) => (safeTimestamp(b) || 0) - (safeTimestamp(a) || 0))
+    .slice(0, Math.max(1, Number(limit) || 3));
+}
+
 export function getStalledAckTasks(indexedWorld, thresholdMs = 15000, now = Date.now()) {
   return allTaskIds(indexedWorld)
     .filter((taskId) => {
-      const events = getTaskEvents(indexedWorld, taskId);
+      const events = getLifecycleTaskEvents(indexedWorld, taskId);
       const lastFinish = [...events].reverse().find((event) => event && event.type === 'TASK_EXECUTE_FINISHED');
       if (!lastFinish || !Number.isFinite(lastFinish.timestamp)) {
         return false;
@@ -31,8 +76,8 @@ export function getStalledAckTasks(indexedWorld, thresholdMs = 15000, now = Date
 export function getExecutionMissingFinishTasks(indexedWorld) {
   return allTaskIds(indexedWorld)
     .filter((taskId) => {
-      const events = getTaskEvents(indexedWorld, taskId);
-      const hasStart = events.some((event) => event && (event.type === 'TASK_EXECUTE_STARTED' || event.type === 'TASK_STARTED'));
+      const events = getLifecycleTaskEvents(indexedWorld, taskId);
+      const hasStart = events.some((event) => event && event.type === 'TASK_EXECUTE_STARTED');
       const hasFinish = events.some((event) => event && event.type === 'TASK_EXECUTE_FINISHED');
       return hasStart && !hasFinish;
     });
@@ -41,39 +86,117 @@ export function getExecutionMissingFinishTasks(indexedWorld) {
 export function getDuplicateAckTasks(indexedWorld) {
   return allTaskIds(indexedWorld)
     .filter((taskId) => {
-      const events = getTaskEvents(indexedWorld, taskId);
-      const ackCount = events.filter((event) => event && event.type === 'TASK_ACKED').length;
+      const events = getLifecycleTaskEvents(indexedWorld, taskId);
+      const ackCount = taskEventsForType(events, 'TASK_ACKED').length;
       return ackCount > 1;
     });
+}
+
+export function getNotificationSkippedTasks(indexedWorld) {
+  return allTaskIds(indexedWorld)
+    .filter((taskId) => {
+      const events = getSystemTaskEvents(indexedWorld, taskId);
+      return events.some((event) => event && event.type === 'TASK_NOTIFICATION_SKIPPED');
+    });
+}
+
+export function getNotificationFailedTasks(indexedWorld) {
+  return allTaskIds(indexedWorld)
+    .filter((taskId) => {
+      const events = getSystemTaskEvents(indexedWorld, taskId);
+      return events.some((event) => event && event.type === 'TASK_NOTIFICATION_FAILED');
+    });
+}
+
+export function getNotificationSkipReason(indexedWorld, taskId) {
+  const events = getSystemTaskEvents(indexedWorld, taskId);
+  const skipEvent = events.find((event) => event && event.type === 'TASK_NOTIFICATION_SKIPPED');
+  return skipEvent && skipEvent.payload && typeof skipEvent.payload.reason === 'string'
+    ? skipEvent.payload.reason
+    : null;
+}
+
+export function getNotificationFailReason(indexedWorld, taskId) {
+  const events = getSystemTaskEvents(indexedWorld, taskId);
+  const failEvent = [...events].reverse().find((event) => event && event.type === 'TASK_NOTIFICATION_FAILED');
+  return failEvent && failEvent.payload && typeof failEvent.payload.reason === 'string'
+    ? failEvent.payload.reason
+    : null;
 }
 
 export function getIncidentClusters(indexedWorld, options = {}) {
   const thresholdMs = Number.isFinite(options.thresholdMs) ? Number(options.thresholdMs) : 15000;
   const now = Number.isFinite(options.now) ? Number(options.now) : Date.now();
+  const includeSystemEvents = options.includeSystemEvents !== false;
 
-  const stalled = getStalledAckTasks(indexedWorld, thresholdMs, now).map((taskId) => ({
-    id: `stalled-${taskId}`,
-    severity: 'medium',
-    category: 'Stalled Awaiting ACK',
-    taskId,
-    summary: 'Execution finished but ACK is missing beyond threshold.'
-  }));
+  const taskIds = allTaskIds(indexedWorld);
+  const failedAckEvents = [];
+  const notificationIssueEvents = [];
+  const stalledTaskIds = getStalledAckTasks(indexedWorld, thresholdMs, now).map((taskId) => normalizeTaskId(taskId));
 
-  const missingFinish = getExecutionMissingFinishTasks(indexedWorld).map((taskId) => ({
-    id: `missing-finish-${taskId}`,
-    severity: 'low',
-    category: 'Execution Missing Finish',
-    taskId,
-    summary: 'Execution start observed without execution finish event.'
-  }));
+  taskIds.forEach((taskId) => {
+    const lifecycleEvents = getLifecycleTaskEvents(indexedWorld, taskId);
+    const systemEvents = includeSystemEvents ? getSystemTaskEvents(indexedWorld, taskId) : [];
 
-  const duplicateAck = getDuplicateAckTasks(indexedWorld).map((taskId) => ({
-    id: `duplicate-ack-${taskId}`,
-    severity: 'high',
-    category: 'Duplicate ACK',
-    taskId,
-    summary: 'Multiple TASK_ACKED events observed for one task.'
-  }));
+    taskEventsForType(lifecycleEvents, 'TASK_ACKED').forEach((event) => {
+      const payload = event && typeof event.payload === 'object' ? event.payload : {};
+      if (payload.status === 'failed') {
+        failedAckEvents.push(event);
+      }
+    });
 
-  return [...duplicateAck, ...stalled, ...missingFinish];
+    taskEventsForType(systemEvents, 'TASK_NOTIFICATION_FAILED').forEach((event) => {
+      notificationIssueEvents.push(event);
+    });
+
+    taskEventsForType(systemEvents, 'TASK_NOTIFICATION_SKIPPED').forEach((event) => {
+      notificationIssueEvents.push(event);
+    });
+  });
+
+  const executionFailureTaskIds = Array.from(new Set(failedAckEvents
+    .map((event) => normalizeTaskId(event && event.taskId))
+    .filter(Boolean)));
+
+  const notificationIssueTaskIds = Array.from(new Set(notificationIssueEvents
+    .map((event) => normalizeTaskId(event && event.taskId))
+    .filter(Boolean)));
+
+  const clusters = [
+    {
+      type: 'execution_failures',
+      severity: executionFailureTaskIds.length > 0 ? 'high' : 'low',
+      taskIds: executionFailureTaskIds,
+      summary: executionFailureTaskIds.length
+        ? `${executionFailureTaskIds.length} tasks acknowledged as failed.`
+        : 'No failed acknowledgements detected.',
+      representativeEvents: firstByTimestampDesc(failedAckEvents, 5)
+    },
+    {
+      type: 'stalled_tasks',
+      severity: stalledTaskIds.length > 0 ? 'medium' : 'low',
+      taskIds: stalledTaskIds,
+      summary: stalledTaskIds.length
+        ? `${stalledTaskIds.length} tasks are stalled awaiting ACK beyond threshold.`
+        : 'No stalled tasks detected.',
+      representativeEvents: firstByTimestampDesc(
+        stalledTaskIds.flatMap((taskId) => taskEventsForType(getLifecycleTaskEvents(indexedWorld, taskId), 'TASK_EXECUTE_FINISHED')),
+        5
+      )
+    }
+  ];
+
+  if (includeSystemEvents) {
+    clusters.splice(1, 0, {
+      type: 'notification_issues',
+      severity: notificationIssueTaskIds.length > 0 ? 'medium' : 'low',
+      taskIds: notificationIssueTaskIds,
+      summary: notificationIssueTaskIds.length
+        ? `${notificationIssueTaskIds.length} tasks have skipped or failed notifications.`
+        : 'No notification issues detected.',
+      representativeEvents: firstByTimestampDesc(notificationIssueEvents, 5)
+    });
+  }
+
+  return clusters;
 }

--- a/ui/selectors/eventTaxonomyInvariant.js
+++ b/ui/selectors/eventTaxonomyInvariant.js
@@ -1,0 +1,26 @@
+import { isSystemEvent } from '../../core/world/eventTaxonomy.js';
+
+function isDevMode() {
+  if (typeof process !== 'undefined' && process && process.env && process.env.NODE_ENV) {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  if (typeof window !== 'undefined' && window && window.location) {
+    return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+  }
+
+  return true;
+}
+
+export function assertNoSystemEventInLifecycleDerivation(events, context) {
+  if (!isDevMode() || !Array.isArray(events)) {
+    return;
+  }
+
+  const offending = events.find((event) => isSystemEvent(event && event.type));
+  if (!offending) {
+    return;
+  }
+
+  throw new Error(`SYSTEM_EVENT_USED_IN_LIFECYCLE_DERIVATION:${context}:${offending.type}`);
+}

--- a/ui/selectors/metricsSelectors.js
+++ b/ui/selectors/metricsSelectors.js
@@ -1,5 +1,6 @@
-import { getTaskEvents } from './taskSelectors.js';
+import { getTaskEvents, getLifecycleEvents } from './taskSelectors.js';
 import { getAllTasks } from './taskSelectors.js';
+import { assertNoSystemEventInLifecycleDerivation } from './eventTaxonomyInvariant.js';
 
 function firstTimestamp(events, type) {
   const match = events.find((event) => event && event.type === type);
@@ -7,9 +8,10 @@ function firstTimestamp(events, type) {
 }
 
 export function getQueueTime(indexedWorld, taskId) {
-  const events = getTaskEvents(indexedWorld, taskId);
+  const events = getLifecycleEvents(getTaskEvents(indexedWorld, taskId));
+  assertNoSystemEventInLifecycleDerivation(events, 'metrics:getQueueTime');
   const createdAt = firstTimestamp(events, 'TASK_CREATED');
-  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED') || firstTimestamp(events, 'TASK_STARTED');
+  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED');
 
   if (!Number.isFinite(createdAt) || !Number.isFinite(startedAt)) {
     return null;
@@ -19,8 +21,9 @@ export function getQueueTime(indexedWorld, taskId) {
 }
 
 export function getExecutionDuration(indexedWorld, taskId) {
-  const events = getTaskEvents(indexedWorld, taskId);
-  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED') || firstTimestamp(events, 'TASK_STARTED');
+  const events = getLifecycleEvents(getTaskEvents(indexedWorld, taskId));
+  assertNoSystemEventInLifecycleDerivation(events, 'metrics:getExecutionDuration');
+  const startedAt = firstTimestamp(events, 'TASK_EXECUTE_STARTED');
   const finishedAt = firstTimestamp(events, 'TASK_EXECUTE_FINISHED');
 
   if (!Number.isFinite(startedAt) || !Number.isFinite(finishedAt)) {
@@ -31,7 +34,8 @@ export function getExecutionDuration(indexedWorld, taskId) {
 }
 
 export function getAckLatency(indexedWorld, taskId) {
-  const events = getTaskEvents(indexedWorld, taskId);
+  const events = getLifecycleEvents(getTaskEvents(indexedWorld, taskId));
+  assertNoSystemEventInLifecycleDerivation(events, 'metrics:getAckLatency');
   const finishedAt = firstTimestamp(events, 'TASK_EXECUTE_FINISHED');
   const ackedAt = firstTimestamp(events, 'TASK_ACKED');
 

--- a/ui/selectors/taskSelectors.js
+++ b/ui/selectors/taskSelectors.js
@@ -1,3 +1,7 @@
+import { officeLayout } from '../config/officeLayout.js';
+import { isLifecycleEvent } from '../../core/world/eventTaxonomy.js';
+import { assertNoSystemEventInLifecycleDerivation } from './eventTaxonomyInvariant.js';
+
 function normalizeTaskId(taskId) {
   return taskId === null || taskId === undefined ? null : String(taskId);
 }
@@ -56,15 +60,7 @@ export function isActiveTaskStatus(status) {
   return status === 'claimed' || status === 'executing' || status === 'awaiting_ack';
 }
 
-export function getTaskIds(indexedWorld) {
-  if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
-    return [];
-  }
-
-  return Array.from(indexedWorld.eventsByTaskId.keys());
-}
-
-export function getTaskEvents(indexedWorld, taskId) {
+function getRawTaskEvents(indexedWorld, taskId) {
   const id = normalizeTaskId(taskId);
   if (!id || !indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
     return [];
@@ -74,8 +70,36 @@ export function getTaskEvents(indexedWorld, taskId) {
   return Array.isArray(events) ? events : [];
 }
 
+export function getLifecycleEvents(events) {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  return events.filter((event) => isLifecycleEvent(event && event.type));
+}
+
+function getLifecycleTaskEvents(indexedWorld, taskId, context) {
+  const rawEvents = getRawTaskEvents(indexedWorld, taskId);
+  const lifecycleEvents = getLifecycleEvents(rawEvents);
+  assertNoSystemEventInLifecycleDerivation(lifecycleEvents, context);
+  return lifecycleEvents;
+}
+
+export function getTaskIds(indexedWorld) {
+  if (!indexedWorld || !(indexedWorld.eventsByTaskId instanceof Map)) {
+    return [];
+  }
+
+  return Array.from(indexedWorld.eventsByTaskId.keys())
+    .filter((taskId) => getLifecycleTaskEvents(indexedWorld, taskId, 'getTaskIds').length > 0);
+}
+
+export function getTaskEvents(indexedWorld, taskId) {
+  return getLifecycleTaskEvents(indexedWorld, taskId, 'getTaskEvents');
+}
+
 export function getTaskStatus(indexedWorld, taskId) {
-  const events = getTaskEvents(indexedWorld, taskId);
+  const events = getLifecycleTaskEvents(indexedWorld, taskId, 'getTaskStatus');
   let status = 'unknown';
 
   for (const event of events) {
@@ -85,7 +109,7 @@ export function getTaskStatus(indexedWorld, taskId) {
       continue;
     }
 
-    if (type === 'TASK_ENQUEUED' || type === 'TASK_QUEUED') {
+    if (type === 'TASK_ENQUEUED') {
       status = 'queued';
       continue;
     }
@@ -95,7 +119,7 @@ export function getTaskStatus(indexedWorld, taskId) {
       continue;
     }
 
-    if (type === 'TASK_EXECUTE_STARTED' || type === 'TASK_STARTED') {
+    if (type === 'TASK_EXECUTE_STARTED') {
       status = 'executing';
       continue;
     }
@@ -119,7 +143,7 @@ export function getTaskStatus(indexedWorld, taskId) {
 }
 
 export function getTaskTimeline(indexedWorld, taskId) {
-  const events = getTaskEvents(indexedWorld, taskId);
+  const events = getLifecycleTaskEvents(indexedWorld, taskId, 'getTaskTimeline');
   let previousTimestamp = null;
 
   return events
@@ -148,7 +172,7 @@ export function getTaskSnapshot(indexedWorld, taskId) {
     return null;
   }
 
-  const events = getTaskEvents(indexedWorld, id);
+  const events = getLifecycleTaskEvents(indexedWorld, id, 'getTaskSnapshot');
   if (!events.length) {
     return null;
   }
@@ -288,7 +312,48 @@ export function getTaskById(indexedWorld, taskId) {
   return getTaskSnapshot(indexedWorld, id);
 }
 
-export function getDeskIndexForTask(task, deskCount = 6) {
+function resolveOfficePoint(value, fallback) {
+  if (!value || typeof value !== 'object') {
+    return { ...fallback };
+  }
+
+  const x = Number.isFinite(value.x) ? Number(value.x) : fallback.x;
+  const y = Number.isFinite(value.y) ? Number(value.y) : fallback.y;
+  return { x, y };
+}
+
+function resolveWorkerDeskPositions() {
+  const fallback = [
+    { x: 208, y: 220 },
+    { x: 348, y: 220 },
+    { x: 488, y: 220 },
+    { x: 208, y: 360 },
+    { x: 348, y: 360 },
+    { x: 488, y: 360 }
+  ];
+
+  const configured = officeLayout && Array.isArray(officeLayout.workerDesks)
+    ? officeLayout.workerDesks
+    : [];
+
+  if (!configured.length) {
+    return fallback;
+  }
+
+  return configured.map((desk, index) => resolveOfficePoint(desk, fallback[index % fallback.length]));
+}
+
+export function getOfficeLayoutSnapshot() {
+  const workerDesks = resolveWorkerDeskPositions();
+  return {
+    intakeDesk: resolveOfficePoint(officeLayout && officeLayout.intakeDesk, { x: 120, y: 220 }),
+    workerDesks,
+    executionZone: resolveOfficePoint(officeLayout && officeLayout.executionZone, { x: 640, y: 220 }),
+    deliveryZone: resolveOfficePoint(officeLayout && officeLayout.deliveryZone, { x: 640, y: 360 })
+  };
+}
+
+export function getDeskIndexForTask(task, deskCount = resolveWorkerDeskPositions().length) {
   const safeDeskCount = Math.max(1, Number.isFinite(deskCount) ? Number(deskCount) : 6);
   const fallbackTaskId = task && task.id ? String(task.id) : 'task';
   const rawDeskId = task && task.deskId ? String(task.deskId) : `desk-${hashString(fallbackTaskId) % safeDeskCount}`;
@@ -300,20 +365,111 @@ export function getDeskIndexForTask(task, deskCount = 6) {
   return hashString(rawDeskId) % safeDeskCount;
 }
 
-export function getDeskPosition(index, deskCount = 6) {
-  const cols = [208, 348, 488];
-  const rows = [220, 360];
+export function getDeskPosition(index, deskCount = resolveWorkerDeskPositions().length) {
+  const workerDesks = resolveWorkerDeskPositions();
   const safeDeskCount = Math.max(1, Number.isFinite(deskCount) ? Number(deskCount) : 6);
   const i = Math.max(0, Number.isFinite(index) ? Number(index) : 0) % safeDeskCount;
+  const fallback = workerDesks[Math.min(i, workerDesks.length - 1)] || { x: 208, y: 220 };
+  const desk = workerDesks[i] || fallback;
 
   return {
-    x: cols[i % cols.length],
-    y: rows[Math.floor(i / cols.length)]
+    x: desk.x,
+    y: desk.y
   };
 }
 
+export function getTaskOfficeRoute(task, options = {}) {
+  const layout = getOfficeLayoutSnapshot();
+  const deskCount = Math.max(1, Number.isFinite(options && options.deskCount) ? Number(options.deskCount) : layout.workerDesks.length || 1);
+  const deskIndex = getDeskIndexForTask(task, deskCount);
+  const workerDesk = getDeskPosition(deskIndex, deskCount);
+
+  return {
+    intakeDesk: layout.intakeDesk,
+    workerDesk,
+    executionZone: layout.executionZone,
+    deliveryZone: layout.deliveryZone,
+    deskIndex
+  };
+}
+
+export function getTaskVisualTarget(task, options = {}) {
+  const route = getTaskOfficeRoute(task, options);
+  const status = task && typeof task.status === 'string' ? task.status : 'unknown';
+
+  if (status === 'queued' || status === 'created' || status === 'unknown') {
+    return route.intakeDesk;
+  }
+
+  if (status === 'claimed') {
+    return route.workerDesk;
+  }
+
+  if (status === 'executing') {
+    return route.executionZone;
+  }
+
+  if (status === 'awaiting_ack' || status === 'completed' || status === 'acknowledged' || status === 'failed') {
+    return route.deliveryZone;
+  }
+
+  return route.workerDesk;
+}
+
+export function getTaskTransitionTimestamps(indexedWorld, taskId) {
+  const events = getLifecycleTaskEvents(indexedWorld, taskId, 'getTaskTransitionTimestamps');
+  const transitions = {
+    createdAt: null,
+    queuedAt: null,
+    claimedAt: null,
+    executingAt: null,
+    awaitingAckAt: null,
+    ackedAt: null
+  };
+
+  for (const event of events) {
+    const type = typeof event.type === 'string' ? event.type : null;
+    const ts = Number.isFinite(event && event.timestamp) ? Number(event.timestamp) : null;
+    if (!Number.isFinite(ts) || !type) {
+      continue;
+    }
+
+    if (type === 'TASK_CREATED' && !Number.isFinite(transitions.createdAt)) {
+      transitions.createdAt = ts;
+      continue;
+    }
+
+    if (type === 'TASK_ENQUEUED' && !Number.isFinite(transitions.queuedAt)) {
+      transitions.queuedAt = ts;
+      continue;
+    }
+
+    if (type === 'TASK_CLAIMED' && !Number.isFinite(transitions.claimedAt)) {
+      transitions.claimedAt = ts;
+      continue;
+    }
+
+    if (type === 'TASK_EXECUTE_STARTED' && !Number.isFinite(transitions.executingAt)) {
+      transitions.executingAt = ts;
+      continue;
+    }
+
+    if (type === 'TASK_EXECUTE_FINISHED' && !Number.isFinite(transitions.awaitingAckAt)) {
+      transitions.awaitingAckAt = ts;
+      continue;
+    }
+
+    if (type === 'TASK_ACKED' && !Number.isFinite(transitions.ackedAt)) {
+      transitions.ackedAt = ts;
+    }
+  }
+
+  return transitions;
+}
+
 export function getAllDesks(indexedWorld, options = {}) {
-  const deskCount = Math.max(1, Number.isFinite(options && options.deskCount) ? Number(options.deskCount) : 6);
+  const layout = getOfficeLayoutSnapshot();
+  const deskCount = Math.max(1, Number.isFinite(options && options.deskCount) ? Number(options.deskCount) : layout.workerDesks.length || 1);
   const tasks = getAllTasks(indexedWorld);
   const buckets = Array.from({ length: deskCount }, (_, idx) => ({
     id: `desk-${idx}`,
@@ -345,7 +501,9 @@ export function getAllDesks(indexedWorld, options = {}) {
 
 export function getRecentEvents(indexedWorld, limit = 100) {
   const events = indexedWorld && Array.isArray(indexedWorld.events) ? indexedWorld.events : [];
-  const capped = events.slice(-Math.max(1, Number(limit) || 100));
+  const lifecycleOnly = getLifecycleEvents(events);
+  const capped = lifecycleOnly.slice(-Math.max(1, Number(limit) || 100));
+  assertNoSystemEventInLifecycleDerivation(capped, 'getRecentEvents');
 
   return capped.map((event) => ({
     id: Number.isFinite(event && event.id) ? Number(event.id) : null,

--- a/ui/task-creator-panel.js
+++ b/ui/task-creator-panel.js
@@ -197,14 +197,16 @@ export function initTaskCreatorPanel() {
       };
 
       if (type === 'discord') {
-        taskPayload.action = 'reply_to_message';
+        taskPayload.intent = 'discord_message';
         taskPayload.payload = {
+          source: 'task_creator_panel',
           channelId,
-          content: content || 'Task created from UI'
+          content
         };
       } else if (type === 'shopify') {
-        taskPayload.action = 'process_order';
+        taskPayload.intent = 'shopify_process_order';
         taskPayload.payload = {
+          source: 'task_creator_panel',
           note: content
         };
       }
@@ -258,7 +260,10 @@ export function initTaskCreatorPanel() {
         return;
       }
 
-      const result = await window.createTestProduct({ promptText });
+      const result = await window.createTestProduct({
+        promptText,
+        channelId: FIXED_DISCORD_CHANNEL_ID
+      });
       if (result && result.result && result.result.success) {
         statusDiv.textContent = `✓ Product render task created: ${result.productId}`;
         statusDiv.className = 'tcp-status tcp-success';

--- a/ui/window-api.js
+++ b/ui/window-api.js
@@ -1,47 +1,33 @@
 import { controlAPI, dispatchCommand } from './control-api.js';
 
+const FIXED_DISCORD_CHANNEL_ID = '1491500223288184964';
+
 async function createTestProduct(options = {}) {
   const promptText = typeof options === 'string'
     ? options.trim()
     : (options && typeof options.promptText === 'string' ? options.promptText.trim() : '');
+  const channelId = options && typeof options.channelId === 'string' && options.channelId.trim()
+    ? options.channelId.trim()
+    : FIXED_DISCORD_CHANNEL_ID;
 
   if (!promptText) {
     throw new Error('missing_prompt');
   }
 
-  const productId = `product_${Date.now()}`;
-  const designIntent = {
-    product_name: promptText,
-    style: (options && options.style) || 'modern scandinavian',
-    mood: (options && options.mood) || 'cozy ambient lighting',
-    colors: Array.isArray(options && options.colors) && options.colors.length > 0
-      ? options.colors
-      : ['warm white', 'soft beige'],
-    composition: (options && options.composition) || 'studio product shot',
-    camera: (options && options.camera) || '85mm lens',
-    background: (options && options.background) || 'neutral gradient',
-    prompt: promptText,
-    prompt_hint: promptText
-  };
-
   const result = await controlAPI.injectTask({
     type: 'image_render',
     title: 'Generate Product Image',
-    productId,
-    provider: 'openai',
-    designIntent,
+    intent: 'render_product_image',
     payload: {
       source: 'create_product_button',
-      productId,
-      provider: 'openai',
-      designIntent
+      prompt: promptText,
+      channelId
     }
   });
 
   return {
-    productId,
     promptText,
-    designIntent,
+    productId: result && result.data && result.data.productId ? result.data.productId : null,
     result
   };
 }


### PR DESCRIPTION
… and observability hardening

- convert deriveWorldState into pure indexing layer (no semantic logic)
- introduce strict lifecycle vs system event taxonomy
- enforce selector-only architecture across UI and renderer
- remove all raw event.type / payload.status checks from UI layer
- implement selector modules (task, agent, metrics, anomaly)
- add anomaly clustering (Raccoon Feeder) with incident groups
- exclude system events from lifecycle derivation and canvas renderer
- include system events in anomaly selectors for observability
- harden discordNotificationWorker with structured logs and event emission:
  - TASK_NOTIFICATION_SENT
  - TASK_NOTIFICATION_SKIPPED
  - TASK_NOTIFICATION_FAILED
- unify event emission via emitBridgeEvent
- add dev invariant to prevent lifecycle contamination by system events
- add strict taxonomy guard (optional fail-fast mode)
- refactor renderer to be fully selector-driven and deterministic
- add contract tests:
  - event taxonomy validation
  - selector invariants
  - anomaly cluster shape
- update legacy tests to align with v2 architecture

Result:
UI is now a deterministic, read-only projection of event truth. All lifecycle meaning is centralized in selectors. System is self-protecting against architectural drift.