### PR TITLE
chore: repo housekeeping — improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,28 @@
+# Environment variables
 .env
+.env.*
+!.env.example
 
 # Runtime state and generated assets
 bridge-store.json
 assets/generated/
+
+# Node.js dependencies — never commit these
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Windows metadata files (Zone.Identifier etc.)
+*:Zone.Identifier
+
+# VS Code workspace and settings
+*.code-workspace
+.vscode/
+
+# macOS
+.DS_Store
+
+# Build output (if applicable)
+dist/
+build/


### PR DESCRIPTION
## 🧹 Repo Housekeeping

This PR improves the `.gitignore` to prevent unwanted files from being tracked in future commits.

### Changes

- **`node_modules/`** — excluded; should never be committed (install via `npm install`)
- **`*:Zone.Identifier`** — excludes Windows metadata files (e.g. `main.js:Zone.Identifier`) that were accidentally committed
- **`*.code-workspace` / `.vscode/`** — excludes VS Code editor files that are personal/local
- **`.env.*`** — broader env file exclusion with `!.env.example` exception for safe template sharing
- **`.DS_Store`** — excludes macOS system files
- **`dist/` / `build/`** — pre-emptively excludes common build output folders
- **npm log files** — excludes `npm-debug.log*` etc.

### ⚠️ Note
This PR only fixes the `.gitignore` going forward. The already-committed `node_modules/` folder and `Zone.Identifier` files **will still exist in Git history**. To fully clean those up, a `git filter-branch` or `git filter-repo` operation would be needed — happy to help with that separately.