### PR TITLE
added tests

### DIFF
--- a/tests/derive-world-state-contract.test.mjs
+++ b/tests/derive-world-state-contract.test.mjs
@@ -1,0 +1,302 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveWorldState } from '../core/world/deriveWorldState.js';
+
+/**
+ * deriveWorldState Index-Only Contract Tests
+ *
+ * Strict guarantee: the function is a pure indexing layer.
+ *
+ * Must return exactly:
+ *   - events          — sorted, cloned flat array of all events
+ *   - eventsByTaskId  — Map<taskId, event[]>
+ *   - eventsByWorkerId — Map<workerId, event[]>
+ *
+ * Must NOT include:
+ *   - lifecycle derivation (status, transitions, snapshots)
+ *   - metrics (timings, durations, counts)
+ *   - anomaly processing (incidents, clusters, stalled tasks)
+ *   - any computed, inferred, or aggregated field
+ */
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function ev(type, taskId, timestamp = 1, extra = {}) {
+  return { type, taskId, timestamp, payload: {}, ...extra };
+}
+
+// All known lifecycle + system event types — used to verify no type inspection
+// is happening inside deriveWorldState.
+const ALL_EVENT_TYPES = [
+  'TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED',
+  'TASK_EXECUTE_STARTED', 'TASK_EXECUTE_FINISHED', 'TASK_ACKED',
+  'TASK_NOTIFICATION_SENT', 'TASK_NOTIFICATION_SKIPPED', 'TASK_NOTIFICATION_FAILED'
+];
+
+// ─── Exact output shape ───────────────────────────────────────────────────────
+
+test('deriveWorldState: output keys are exactly ["events", "eventsByTaskId", "eventsByWorkerId"]', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  assert.deepStrictEqual(
+    Object.keys(result).sort(),
+    ['events', 'eventsByTaskId', 'eventsByWorkerId'],
+    'Output must have exactly three keys — no extra fields of any kind'
+  );
+});
+
+test('deriveWorldState: no lifecycle fields present on output', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED', 't1', 1),
+    ev('TASK_ACKED',   't1', 2, { payload: { status: 'failed' } })
+  ]);
+  const forbidden = [
+    'status', 'taskStatus', 'lifecycle', 'state',
+    'failedTasks', 'completedTasks', 'activeTasks',
+    'transitions', 'snapshot', 'timeline'
+  ];
+  for (const key of forbidden) {
+    assert.ok(!(key in result), `Output must not contain lifecycle field "${key}"`);
+  }
+});
+
+test('deriveWorldState: no metrics fields present on output', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  const forbidden = [
+    'queueTime', 'executionDuration', 'ackLatency',
+    'metrics', 'timings', 'durations', 'counts',
+    'throughput', 'latency'
+  ];
+  for (const key of forbidden) {
+    assert.ok(!(key in result), `Output must not contain metrics field "${key}"`);
+  }
+});
+
+test('deriveWorldState: no anomaly fields present on output', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  const forbidden = [
+    'anomalies', 'incidents', 'clusters', 'stalledTasks',
+    'duplicateAcks', 'notificationIssues', 'executionFailures'
+  ];
+  for (const key of forbidden) {
+    assert.ok(!(key in result), `Output must not contain anomaly field "${key}"`);
+  }
+});
+
+// ─── events array contract ────────────────────────────────────────────────────
+
+test('deriveWorldState: events is an array', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  assert.ok(Array.isArray(result.events), 'events must be an array');
+});
+
+test('deriveWorldState: events length matches the number of valid input events', () => {
+  const input = [
+    ev('TASK_CREATED', 't1', 1),
+    ev('TASK_ENQUEUED', 't1', 2),
+    ev('TASK_CLAIMED',  't1', 3)
+  ];
+  const result = deriveWorldState(input);
+  assert.equal(result.events.length, 3,
+    'events array must contain exactly as many entries as valid input events');
+});
+
+test('deriveWorldState: events are sorted ascending by timestamp', () => {
+  const input = [
+    ev('TASK_CLAIMED',  't1', 300),
+    ev('TASK_CREATED',  't1', 100),
+    ev('TASK_ENQUEUED', 't1', 200)
+  ];
+  const result = deriveWorldState(input);
+  assert.equal(result.events[0].type, 'TASK_CREATED');
+  assert.equal(result.events[1].type, 'TASK_ENQUEUED');
+  assert.equal(result.events[2].type, 'TASK_CLAIMED');
+});
+
+test('deriveWorldState: events are deep-cloned (mutating input does not affect output)', () => {
+  const source = ev('TASK_CREATED', 't1', 1);
+  source.payload = { title: 'original' };
+  const result = deriveWorldState([source]);
+
+  source.payload.title = 'mutated';
+
+  assert.equal(result.events[0].payload.title, 'original',
+    'Mutating the input event must not affect the cloned event in result.events');
+});
+
+test('deriveWorldState: pushing to the input array after the call does not affect result.events', () => {
+  const input = [ev('TASK_CREATED', 't1', 1)];
+  const result = deriveWorldState(input);
+
+  input.push(ev('TASK_ENQUEUED', 't1', 2));
+
+  assert.equal(result.events.length, 1,
+    'Appending to the input array after the call must not affect result.events');
+  assert.equal(result.eventsByTaskId.get('t1').length, 1,
+    'Appending to the input array after the call must not affect eventsByTaskId');
+});
+
+// ─── eventsByTaskId contract ──────────────────────────────────────────────────
+
+test('deriveWorldState: eventsByTaskId is a Map', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  assert.ok(result.eventsByTaskId instanceof Map,
+    'eventsByTaskId must be a Map instance');
+});
+
+test('deriveWorldState: eventsByTaskId groups events by their taskId', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED',  'task-a', 1),
+    ev('TASK_ENQUEUED', 'task-a', 2),
+    ev('TASK_CREATED',  'task-b', 3)
+  ]);
+  assert.equal(result.eventsByTaskId.get('task-a').length, 2,
+    'task-a must have 2 grouped events');
+  assert.equal(result.eventsByTaskId.get('task-b').length, 1,
+    'task-b must have 1 grouped event');
+});
+
+test('deriveWorldState: eventsByTaskId keys are strings', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED', 'task-x', 1)
+  ]);
+  for (const key of result.eventsByTaskId.keys()) {
+    assert.equal(typeof key, 'string',
+      `eventsByTaskId key must be a string, got ${typeof key}`);
+  }
+});
+
+test('deriveWorldState: eventsByTaskId events preserve the original event data', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED', 'task-a', 42, { payload: { title: 'hello' } })
+  ]);
+  const grouped = result.eventsByTaskId.get('task-a');
+  assert.ok(Array.isArray(grouped) && grouped.length === 1);
+  assert.equal(grouped[0].type, 'TASK_CREATED');
+  assert.equal(grouped[0].taskId, 'task-a');
+  assert.equal(grouped[0].timestamp, 42);
+});
+
+test('deriveWorldState: eventsByTaskId accepts all canonical event types without filtering', () => {
+  // Every canonical event type — regardless of lifecycle vs system — must appear
+  // in the index. deriveWorldState must not filter by event type.
+  const input = ALL_EVENT_TYPES.map((type, i) =>
+    ev(type, 'task-all', i + 1)
+  );
+  const result = deriveWorldState(input);
+  assert.equal(
+    result.eventsByTaskId.get('task-all').length,
+    ALL_EVENT_TYPES.length,
+    'eventsByTaskId must index all event types, including system events — no type-based filtering'
+  );
+});
+
+test('deriveWorldState: system events are stored in eventsByTaskId without interpretation', () => {
+  const input = [
+    ev('TASK_CREATED',              'task-s', 1),
+    ev('TASK_NOTIFICATION_SENT',    'task-s', 2),
+    ev('TASK_NOTIFICATION_SKIPPED', 'task-s', 3, { payload: { reason: 'no_channel' } }),
+    ev('TASK_NOTIFICATION_FAILED',  'task-s', 4, { payload: { reason: 'send_error' } })
+  ];
+  const result = deriveWorldState(input);
+  const stored = result.eventsByTaskId.get('task-s');
+
+  assert.equal(stored.length, 4,
+    'System events must be stored in eventsByTaskId without being filtered or interpreted');
+
+  const types = stored.map((e) => e.type);
+  assert.ok(types.includes('TASK_NOTIFICATION_SENT'),    'NOTIFICATION_SENT must be indexed');
+  assert.ok(types.includes('TASK_NOTIFICATION_SKIPPED'), 'NOTIFICATION_SKIPPED must be indexed');
+  assert.ok(types.includes('TASK_NOTIFICATION_FAILED'),  'NOTIFICATION_FAILED must be indexed');
+});
+
+// ─── eventsByWorkerId contract ────────────────────────────────────────────────
+
+test('deriveWorldState: eventsByWorkerId is a Map', () => {
+  const result = deriveWorldState([ev('TASK_CREATED', 't1', 1)]);
+  assert.ok(result.eventsByWorkerId instanceof Map,
+    'eventsByWorkerId must be a Map instance');
+});
+
+test('deriveWorldState: eventsByWorkerId groups events by workerId from payload', () => {
+  const input = [
+    { type: 'TASK_CLAIMED', taskId: 't1', timestamp: 1, payload: { workerId: 'worker-1' } },
+    { type: 'TASK_CLAIMED', taskId: 't2', timestamp: 2, payload: { workerId: 'worker-1' } },
+    { type: 'TASK_CLAIMED', taskId: 't3', timestamp: 3, payload: { workerId: 'worker-2' } }
+  ];
+  const result = deriveWorldState(input);
+  assert.equal(result.eventsByWorkerId.get('worker-1').length, 2,
+    'worker-1 must have 2 grouped events');
+  assert.equal(result.eventsByWorkerId.get('worker-2').length, 1,
+    'worker-2 must have 1 grouped event');
+});
+
+test('deriveWorldState: eventsByWorkerId is empty when no events carry a workerId', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED',  't1', 1),
+    ev('TASK_ENQUEUED', 't1', 2)
+  ]);
+  assert.equal(result.eventsByWorkerId.size, 0,
+    'eventsByWorkerId must be empty when no events carry workerId or agentId');
+});
+
+// ─── No computation on event contents ────────────────────────────────────────
+
+test('deriveWorldState: TASK_ACKED with status "failed" is stored as-is, status field not propagated', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED', 't1', 1),
+    { type: 'TASK_ACKED', taskId: 't1', timestamp: 2, payload: { status: 'failed', error: 'timeout' } }
+  ]);
+  // The failure payload must be stored raw. No derived field on the output.
+  assert.ok(!('status' in result), 'status must not be a top-level field');
+  assert.ok(!('failedTasks' in result), 'failedTasks must not be computed on the output');
+
+  const ackedEvent = result.eventsByTaskId.get('t1').find((e) => e.type === 'TASK_ACKED');
+  assert.equal(ackedEvent.payload.status, 'failed',
+    'TASK_ACKED payload must be stored verbatim without transformation');
+});
+
+test('deriveWorldState: output does not vary based on payload content of any event type', () => {
+  // Two worlds: one where TASK_ACKED signals success, one where it signals failure.
+  // The shape of the deriveWorldState output must be structurally identical.
+  const success = deriveWorldState([
+    ev('TASK_CREATED', 'tx', 1),
+    { type: 'TASK_ACKED', taskId: 'tx', timestamp: 2, payload: { status: 'acknowledged' } }
+  ]);
+  const failure = deriveWorldState([
+    ev('TASK_CREATED', 'tx', 1),
+    { type: 'TASK_ACKED', taskId: 'tx', timestamp: 2, payload: { status: 'failed' } }
+  ]);
+
+  assert.deepStrictEqual(
+    Object.keys(success).sort(),
+    Object.keys(failure).sort(),
+    'Output shape must be identical regardless of payload content'
+  );
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+test('deriveWorldState: returns valid empty structure for empty input', () => {
+  const result = deriveWorldState([]);
+  assert.deepStrictEqual(Object.keys(result).sort(),
+    ['events', 'eventsByTaskId', 'eventsByWorkerId']);
+  assert.deepStrictEqual(result.events, []);
+  assert.equal(result.eventsByTaskId.size, 0);
+  assert.equal(result.eventsByWorkerId.size, 0);
+});
+
+test('deriveWorldState: returns valid empty structure for null input', () => {
+  const result = deriveWorldState(null);
+  assert.deepStrictEqual(Object.keys(result).sort(),
+    ['events', 'eventsByTaskId', 'eventsByWorkerId']);
+  assert.deepStrictEqual(result.events, []);
+});
+
+test('deriveWorldState: events with identical timestamps are both preserved', () => {
+  const result = deriveWorldState([
+    ev('TASK_CREATED',  't1', 100),
+    ev('TASK_ENQUEUED', 't1', 100)
+  ]);
+  assert.equal(result.events.length, 2,
+    'Both events at the same timestamp must be preserved — no deduplication');
+});

--- a/tests/e2e-determinism.test.mjs
+++ b/tests/e2e-determinism.test.mjs
@@ -1,0 +1,337 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deriveWorldState } from '../core/world/deriveWorldState.js';
+import { buildVisualWorldGraph } from '../core/world/buildVisualWorldGraph.js';
+
+/**
+ * End-to-End Determinism Tests
+ *
+ * Verifies that the complete pipeline
+ *
+ *   fixed events → deriveWorldState → buildVisualWorldGraph(world, { now })
+ *
+ * is fully deterministic:
+ *   - Same input produces byte-identical selector outputs on every run
+ *   - System events do not cause drift
+ *   - The renderView shape is stable and predictable
+ *   - No hidden mutable state accumulates across repeated invocations
+ *
+ * The renderer itself requires a real DOM/canvas; determinism is validated at
+ * the renderView level — the complete pre-computed object passed to render().
+ * That is the correct seam: render() is a stateless projection of renderView,
+ * so renderView stability ≡ render output stability.
+ */
+
+// ─── Fixed event sequence ─────────────────────────────────────────────────────
+
+const TASK_A = 'e2e-task-alpha';
+const TASK_B = 'e2e-task-beta';
+const WORKER = 'worker-w1';
+
+/**
+ * Fully deterministic event sequence.
+ * Timestamps are literal constants — no Date.now(), no tick counter.
+ */
+const FIXED_EVENTS = Object.freeze([
+  // TASK_A — full lifecycle, acknowledged success
+  { type: 'TASK_CREATED',          taskId: TASK_A, timestamp: 1000, payload: { title: 'Alpha Task', type: 'standard' } },
+  { type: 'TASK_ENQUEUED',         taskId: TASK_A, timestamp: 1100, payload: {} },
+  { type: 'TASK_CLAIMED',          taskId: TASK_A, timestamp: 1200, payload: { workerId: WORKER } },
+  { type: 'TASK_EXECUTE_STARTED',  taskId: TASK_A, timestamp: 1300, payload: { workerId: WORKER } },
+  { type: 'TASK_EXECUTE_FINISHED', taskId: TASK_A, timestamp: 1900, payload: { workerId: WORKER } },
+  { type: 'TASK_ACKED',            taskId: TASK_A, timestamp: 2000, payload: { status: 'acknowledged', success: true } },
+
+  // TASK_B — partial lifecycle, still queued
+  { type: 'TASK_CREATED',  taskId: TASK_B, timestamp: 1050, payload: { title: 'Beta Task', type: 'standard' } },
+  { type: 'TASK_ENQUEUED', taskId: TASK_B, timestamp: 1150, payload: {} }
+]);
+
+/** System events to interleave — must not affect selector outputs. */
+const SYSTEM_EVENTS = Object.freeze([
+  { type: 'TASK_NOTIFICATION_SENT',    taskId: TASK_A, timestamp: 2100, payload: {} },
+  { type: 'TASK_NOTIFICATION_SKIPPED', taskId: TASK_B, timestamp: 1160, payload: { reason: 'no_channel' } },
+  { type: 'TASK_NOTIFICATION_FAILED',  taskId: TASK_A, timestamp: 2050, payload: { reason: 'send_error' } }
+]);
+
+/** Fixed "now" — must never be Date.now() */
+const FIXED_NOW = 999_999_999;
+
+// ─── Pipeline helpers ─────────────────────────────────────────────────────────
+
+function runPipeline(events, now = FIXED_NOW) {
+  const world = deriveWorldState([...events]);
+  return buildVisualWorldGraph(world, { now });
+}
+
+/**
+ * Serialise a renderView to a comparable JSON string.
+ * Maps are converted to sorted arrays of [key, value] pairs so deepStrictEqual works.
+ */
+function serialise(view) {
+  return JSON.stringify(view, (_key, value) => {
+    if (value instanceof Map) {
+      return { __Map__: Array.from(value.entries()).sort(([a], [b]) => String(a).localeCompare(String(b))) };
+    }
+    return value;
+  });
+}
+
+// ─── renderView shape contract ────────────────────────────────────────────────
+
+test('E2E determinism: renderView has the expected top-level keys', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  const keys = Object.keys(view).sort();
+  assert.deepStrictEqual(keys, [
+    'agents',
+    'counts',
+    'desks',
+    'entities',
+    'incidents',
+    'officeLayout',
+    'taskRouteByTaskId',
+    'taskVisualTargetByTaskId',
+    'tasks',
+    'transitionByTaskId'
+  ], 'renderView must expose exactly the expected projection keys');
+});
+
+test('E2E determinism: entities array contains one entry per task', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  assert.equal(view.entities.length, 2,
+    'One entity per task in the fixed sequence');
+});
+
+test('E2E determinism: entity shape has id, type, ref, visualState, isActive', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  for (const entity of view.entities) {
+    assert.ok(typeof entity.id === 'string',          'entity.id must be a string');
+    assert.equal(entity.type, 'task',                  'entity.type must be "task"');
+    assert.ok(typeof entity.ref === 'string',          'entity.ref must be a string');
+    assert.ok(typeof entity.visualState === 'string',  'entity.visualState must be a string');
+    assert.ok(typeof entity.isActive === 'boolean',    'entity.isActive must be a boolean');
+  }
+});
+
+test('E2E determinism: TASK_A entity has visualState "completed" and isActive false', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  const entity = view.entities.find((e) => e.id === TASK_A);
+  assert.ok(entity, 'TASK_A entity must exist in the renderView');
+  assert.equal(entity.visualState, 'completed', 'Fully ACKed task must have visualState "completed"');
+  assert.equal(entity.isActive, false,           'Completed task must not be active');
+});
+
+test('E2E determinism: TASK_B entity has visualState "queued" and isActive false', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  const entity = view.entities.find((e) => e.id === TASK_B);
+  assert.ok(entity, 'TASK_B entity must exist in the renderView');
+  assert.equal(entity.visualState, 'queued', 'Enqueued-only task must have visualState "queued"');
+  assert.equal(entity.isActive, false,        'Queued task must not be active');
+});
+
+test('E2E determinism: counts reflect the two-task world correctly', () => {
+  const { counts } = runPipeline(FIXED_EVENTS);
+  assert.equal(counts.done,   1, 'TASK_A (completed) must be in the "done" bucket');
+  assert.equal(counts.queued, 1, 'TASK_B (queued) must be in the "queued" bucket');
+  assert.equal(counts.active, 0);
+  assert.equal(counts.failed, 0);
+});
+
+test('E2E determinism: transitionByTaskId Map contains an entry for every task', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  assert.ok(view.transitionByTaskId instanceof Map, 'transitionByTaskId must be a Map');
+  assert.ok(view.transitionByTaskId.has(TASK_A), 'Must have transitions for TASK_A');
+  assert.ok(view.transitionByTaskId.has(TASK_B), 'Must have transitions for TASK_B');
+});
+
+test('E2E determinism: TASK_A transition timestamps match the fixed event timestamps', () => {
+  const { transitionByTaskId } = runPipeline(FIXED_EVENTS);
+  const t = transitionByTaskId.get(TASK_A);
+  assert.equal(t.createdAt,    1000, 'createdAt must equal TASK_CREATED timestamp');
+  assert.equal(t.queuedAt,     1100, 'queuedAt must equal TASK_ENQUEUED timestamp');
+  assert.equal(t.claimedAt,    1200, 'claimedAt must equal TASK_CLAIMED timestamp');
+  assert.equal(t.executingAt,  1300, 'executingAt must equal TASK_EXECUTE_STARTED timestamp');
+  assert.equal(t.awaitingAckAt,1900, 'awaitingAckAt must equal TASK_EXECUTE_FINISHED timestamp');
+  assert.equal(t.ackedAt,      2000, 'ackedAt must equal TASK_ACKED timestamp');
+});
+
+// ─── Identical output across repeated invocations ─────────────────────────────
+
+test('E2E determinism: running the pipeline twice with the same input yields identical renderViews', () => {
+  const run1 = serialise(runPipeline(FIXED_EVENTS));
+  const run2 = serialise(runPipeline(FIXED_EVENTS));
+  assert.equal(run1, run2,
+    'renderView must be byte-identical on every invocation with the same input');
+});
+
+test('E2E determinism: running the pipeline ten times produces the same serialised output each time', () => {
+  const baseline = serialise(runPipeline(FIXED_EVENTS));
+  for (let i = 0; i < 9; i++) {
+    assert.equal(serialise(runPipeline(FIXED_EVENTS)), baseline,
+      `Run ${i + 2} diverged from the baseline renderView`);
+  }
+});
+
+test('E2E determinism: deriveWorldState is idempotent — same events produce the same indexed world', () => {
+  const w1 = deriveWorldState([...FIXED_EVENTS]);
+  const w2 = deriveWorldState([...FIXED_EVENTS]);
+
+  assert.deepStrictEqual(w1.events, w2.events,
+    'Sorted events array must be identical');
+  assert.deepStrictEqual(
+    Array.from(w1.eventsByTaskId.entries()),
+    Array.from(w2.eventsByTaskId.entries()),
+    'eventsByTaskId must be identical'
+  );
+  assert.deepStrictEqual(
+    Array.from(w1.eventsByWorkerId.entries()),
+    Array.from(w2.eventsByWorkerId.entries()),
+    'eventsByWorkerId must be identical'
+  );
+});
+
+// ─── System events do not cause drift ────────────────────────────────────────
+
+test('E2E determinism: adding system events does not change entities', () => {
+  const clean  = runPipeline(FIXED_EVENTS);
+  const mixed  = runPipeline([...FIXED_EVENTS, ...SYSTEM_EVENTS]);
+
+  assert.deepStrictEqual(
+    clean.entities.map((e) => ({ id: e.id, visualState: e.visualState, isActive: e.isActive })),
+    mixed.entities.map((e) => ({ id: e.id, visualState: e.visualState, isActive: e.isActive })),
+    'System events must not alter entity visualState or isActive'
+  );
+});
+
+test('E2E determinism: adding system events does not change counts', () => {
+  const clean = runPipeline(FIXED_EVENTS);
+  const mixed = runPipeline([...FIXED_EVENTS, ...SYSTEM_EVENTS]);
+  assert.deepStrictEqual(clean.counts, mixed.counts,
+    'System events must not affect task count buckets');
+});
+
+test('E2E determinism: adding system events does not change transition timestamps', () => {
+  const clean = runPipeline(FIXED_EVENTS);
+  const mixed = runPipeline([...FIXED_EVENTS, ...SYSTEM_EVENTS]);
+
+  for (const taskId of [TASK_A, TASK_B]) {
+    assert.deepStrictEqual(
+      clean.transitionByTaskId.get(taskId),
+      mixed.transitionByTaskId.get(taskId),
+      `System events must not alter transition timestamps for ${taskId}`
+    );
+  }
+});
+
+test('E2E determinism: adding system events does not change task routes or visual targets', () => {
+  const clean = runPipeline(FIXED_EVENTS);
+  const mixed = runPipeline([...FIXED_EVENTS, ...SYSTEM_EVENTS]);
+
+  assert.equal(serialise({ r: clean.taskRouteByTaskId }),
+               serialise({ r: mixed.taskRouteByTaskId }),
+    'System events must not alter taskRouteByTaskId');
+
+  assert.equal(serialise({ t: clean.taskVisualTargetByTaskId }),
+               serialise({ t: mixed.taskVisualTargetByTaskId }),
+    'System events must not alter taskVisualTargetByTaskId');
+});
+
+// ─── Input mutation isolation ─────────────────────────────────────────────────
+
+test('E2E determinism: pipeline does not mutate the input events array', () => {
+  const input = FIXED_EVENTS.map((e) => ({ ...e, payload: { ...e.payload } }));
+  const snapshot = JSON.stringify(input);
+
+  runPipeline(input);
+
+  assert.equal(JSON.stringify(input), snapshot,
+    'The pipeline must not mutate the caller\'s event array or event objects');
+});
+
+test('E2E determinism: running the pipeline does not affect a subsequent independent pipeline run', () => {
+  // First run with a partial sequence.
+  const partial = FIXED_EVENTS.filter((e) => e.taskId === TASK_A);
+  runPipeline(partial);
+
+  // Second run with the full sequence — must not be polluted by the first run.
+  const full = runPipeline(FIXED_EVENTS);
+  assert.equal(full.entities.length, 2,
+    'Full-sequence run after a partial run must still produce 2 entities — no state leakage');
+  assert.equal(full.counts.done, 1);
+  assert.equal(full.counts.queued, 1);
+});
+
+// ─── now parameter isolation ──────────────────────────────────────────────────
+
+test('E2E determinism: lifecycle-derived fields are identical regardless of the "now" value', () => {
+  // Lifecycle state (visualState, isActive, transitions) must not depend on `now`.
+  // Only stall detection in incidents uses `now`; entity state must be stable.
+  const view1 = runPipeline(FIXED_EVENTS, FIXED_NOW);
+  const view2 = runPipeline(FIXED_EVENTS, FIXED_NOW + 1_000_000);
+
+  for (const taskId of [TASK_A, TASK_B]) {
+    const e1 = view1.entities.find((e) => e.id === taskId);
+    const e2 = view2.entities.find((e) => e.id === taskId);
+    assert.equal(e1.visualState, e2.visualState,
+      `${taskId} visualState must not vary with "now"`);
+    assert.equal(e1.isActive, e2.isActive,
+      `${taskId} isActive must not vary with "now"`);
+    assert.deepStrictEqual(
+      view1.transitionByTaskId.get(taskId),
+      view2.transitionByTaskId.get(taskId),
+      `${taskId} transition timestamps must not vary with "now"`);
+  }
+
+  assert.deepStrictEqual(view1.counts, view2.counts,
+    'Task counts must not vary with "now"');
+});
+
+// ─── Render-layer stability (renderView as the render contract) ───────────────
+
+test('E2E determinism: renderView serialisation is stable — same hash each time', () => {
+  // A simple deterministic "hash": XOR-reduce the char codes of the JSON string.
+  function hashStr(s) {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) {
+      h = (h ^ s.charCodeAt(i)) >>> 0;
+    }
+    return h;
+  }
+
+  const h1 = hashStr(serialise(runPipeline(FIXED_EVENTS)));
+  const h2 = hashStr(serialise(runPipeline(FIXED_EVENTS)));
+  const h3 = hashStr(serialise(runPipeline(FIXED_EVENTS)));
+
+  assert.equal(h1, h2, 'renderView hash must be identical on run 2');
+  assert.equal(h1, h3, 'renderView hash must be identical on run 3');
+});
+
+test('E2E determinism: Map-typed fields in renderView contain the same keys as the tasks array', () => {
+  const view = runPipeline(FIXED_EVENTS);
+  const taskIds = new Set(view.tasks.map((t) => t.id));
+
+  for (const [key] of view.transitionByTaskId) {
+    assert.ok(taskIds.has(key),
+      `transitionByTaskId key "${key}" has no corresponding task`);
+  }
+  for (const [key] of view.taskRouteByTaskId) {
+    assert.ok(taskIds.has(key),
+      `taskRouteByTaskId key "${key}" has no corresponding task`);
+  }
+  for (const [key] of view.taskVisualTargetByTaskId) {
+    assert.ok(taskIds.has(key),
+      `taskVisualTargetByTaskId key "${key}" has no corresponding task`);
+  }
+});
+
+test('E2E determinism: incident clusters in renderView are arrays with valid schema', () => {
+  const { incidents } = runPipeline(FIXED_EVENTS);
+  assert.ok(Array.isArray(incidents), 'incidents must be an array');
+  for (const cluster of incidents) {
+    assert.ok(typeof cluster.type === 'string',       'cluster.type must be a string');
+    assert.ok(typeof cluster.severity === 'string',    'cluster.severity must be a string');
+    assert.ok(Array.isArray(cluster.taskIds),          'cluster.taskIds must be an array');
+    assert.ok(typeof cluster.summary === 'string',     'cluster.summary must be a string');
+    assert.ok(Array.isArray(cluster.representativeEvents), 'cluster.representativeEvents must be an array');
+  }
+});

--- a/tests/engine-lifecycle-immutability.test.mjs
+++ b/tests/engine-lifecycle-immutability.test.mjs
@@ -332,3 +332,73 @@ test('Worker: direct status mutation after execution does not skip ackTask requi
   const ackedEventsAfter = emittedEvents.filter((e) => e.type === 'TASK_ACKED');
   assert.equal(ackedEventsAfter.length, 1, 'TASK_ACKED must only be emitted by TaskEngine via ackTask');
 });
+
+// ─── ACK invalid without executionRecord ever being set ──────────────────────
+
+test('ACK prerequisite: ackTask rejects when awaiting_ack reached without executeTask (executionRecord never set)', async () => {
+  // Scenario: task is created and claimed, but executeTask is never called.
+  // A direct status mutation forces awaiting_ack, simulating a partial/skipped
+  // execution path. executionRecord remains null (its initial value).
+  const { engine } = makeEngine();
+  const taskId = 'test-ack-no-execute';
+
+  engine.createTask({ id: taskId, type: 'test' });
+  engine.enqueueTask(taskId);
+  engine.claimTask(taskId);
+
+  // Skip executeTask entirely — force the status without going through the engine.
+  const task = engine.getTask(taskId);
+  assert.equal(task.executionRecord, null, 'executionRecord must be null before executeTask is called');
+  task.status = 'awaiting_ack';
+
+  await assert.rejects(
+    () => engine.ackTask(taskId),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.equal(err.message, 'ENGINE_ENFORCEMENT_VIOLATION');
+      return true;
+    }
+  );
+});
+
+test('ACK prerequisite: no TASK_ACKED event emitted when executionRecord was never set', async () => {
+  const { engine, emittedEvents } = makeEngine();
+  const taskId = 'test-ack-no-execute-no-event';
+
+  engine.createTask({ id: taskId, type: 'test' });
+  engine.enqueueTask(taskId);
+  engine.claimTask(taskId);
+
+  engine.getTask(taskId).status = 'awaiting_ack';
+
+  try {
+    await engine.ackTask(taskId);
+  } catch (_err) {
+    // expected rejection
+  }
+
+  const ackedEvents = emittedEvents.filter((e) => e.type === 'TASK_ACKED' && e.taskId === taskId);
+  assert.equal(ackedEvents.length, 0, 'TASK_ACKED must not be emitted without a stored executionRecord');
+});
+
+test('ACK prerequisite: task status remains awaiting_ack after failed ack with no executionRecord', async () => {
+  const { engine } = makeEngine();
+  const taskId = 'test-ack-no-execute-status-preserved';
+
+  engine.createTask({ id: taskId, type: 'test' });
+  engine.enqueueTask(taskId);
+  engine.claimTask(taskId);
+
+  engine.getTask(taskId).status = 'awaiting_ack';
+
+  try {
+    await engine.ackTask(taskId);
+  } catch (_err) {
+    // expected rejection
+  }
+
+  // The engine must not have advanced the status; the task stays in awaiting_ack.
+  const task = engine.getTask(taskId);
+  assert.equal(task.status, 'awaiting_ack', 'Task status must remain awaiting_ack after a rejected ack attempt');
+  assert.equal(task.executionRecord, null, 'executionRecord must still be null after rejected ack');
+});

--- a/tests/event-taxonomy-strictness.test.mjs
+++ b/tests/event-taxonomy-strictness.test.mjs
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LIFECYCLE_EVENTS,
+  isLifecycleEvent
+} from '../core/world/eventTaxonomy.js';
+
+/**
+ * Event Taxonomy Strictness Tests
+ *
+ * Verifies that the canonical lifecycle event set is exactly the six
+ * defined events, and that any unknown or malformed type is never
+ * classified as a lifecycle event.
+ */
+
+const CANONICAL_LIFECYCLE_EVENTS = [
+  'TASK_CREATED',
+  'TASK_ENQUEUED',
+  'TASK_CLAIMED',
+  'TASK_EXECUTE_STARTED',
+  'TASK_EXECUTE_FINISHED',
+  'TASK_ACKED'
+];
+
+// ─── Canonical set completeness ───────────────────────────────────────────────
+
+test('Taxonomy: LIFECYCLE_EVENTS contains exactly the six canonical event types', () => {
+  assert.equal(
+    LIFECYCLE_EVENTS.length,
+    CANONICAL_LIFECYCLE_EVENTS.length,
+    `Expected ${CANONICAL_LIFECYCLE_EVENTS.length} lifecycle events, got ${LIFECYCLE_EVENTS.length}`
+  );
+
+  for (const type of CANONICAL_LIFECYCLE_EVENTS) {
+    assert.ok(
+      LIFECYCLE_EVENTS.includes(type),
+      `Canonical event ${type} must be present in LIFECYCLE_EVENTS`
+    );
+  }
+});
+
+test('Taxonomy: LIFECYCLE_EVENTS contains no extra entries beyond the canonical six', () => {
+  const canonical = new Set(CANONICAL_LIFECYCLE_EVENTS);
+  for (const type of LIFECYCLE_EVENTS) {
+    assert.ok(
+      canonical.has(type),
+      `Non-canonical event type "${type}" must not be present in LIFECYCLE_EVENTS`
+    );
+  }
+});
+
+test('Taxonomy: LIFECYCLE_EVENTS is frozen and cannot be extended', () => {
+  assert.ok(Object.isFrozen(LIFECYCLE_EVENTS), 'LIFECYCLE_EVENTS must be frozen');
+  assert.throws(
+    () => { LIFECYCLE_EVENTS.push('TASK_INJECTED'); },
+    'Pushing to a frozen array must throw in strict mode'
+  );
+  assert.equal(
+    LIFECYCLE_EVENTS.length,
+    CANONICAL_LIFECYCLE_EVENTS.length,
+    'LIFECYCLE_EVENTS length must not change after push attempt'
+  );
+});
+
+// ─── Unknown types rejected ───────────────────────────────────────────────────
+
+test('Taxonomy: unknown event type is not classified as a lifecycle event', () => {
+  assert.equal(isLifecycleEvent('TASK_HACKED'), false);
+});
+
+test('Taxonomy: fabricated lifecycle-looking type is not classified as a lifecycle event', () => {
+  const lookalikes = [
+    'TASK_EXECUTED',        // plausible but non-canonical
+    'TASK_COMPLETE',
+    'TASK_FAILED',
+    'TASK_REJECTED',
+    'TASK_ENQUEUED_AGAIN',
+    'TASK_CLAIMED_BY_WORKER',
+    'TASK_EXECUTE_SKIPPED_IDEMPOTENT', // engine-internal, not lifecycle
+    'TASK_REQUEUED',
+    'TASK_ACK_SIDE_EFFECT_FAILED'
+  ];
+
+  for (const type of lookalikes) {
+    assert.equal(
+      isLifecycleEvent(type),
+      false,
+      `"${type}" must not be classified as a lifecycle event`
+    );
+  }
+});
+
+test('Taxonomy: lowercase variants of canonical events are not lifecycle events', () => {
+  for (const type of CANONICAL_LIFECYCLE_EVENTS) {
+    assert.equal(
+      isLifecycleEvent(type.toLowerCase()),
+      false,
+      `Lowercase "${type.toLowerCase()}" must not be a lifecycle event`
+    );
+  }
+});
+
+test('Taxonomy: empty string is not a lifecycle event', () => {
+  assert.equal(isLifecycleEvent(''), false);
+});
+
+test('Taxonomy: null and undefined are not lifecycle events', () => {
+  assert.equal(isLifecycleEvent(null), false);
+  assert.equal(isLifecycleEvent(undefined), false);
+});
+
+test('Taxonomy: numeric and object inputs are not lifecycle events', () => {
+  assert.equal(isLifecycleEvent(42), false);
+  assert.equal(isLifecycleEvent({}), false);
+  assert.equal(isLifecycleEvent([]), false);
+});
+
+test('Taxonomy: whitespace-padded canonical names are not lifecycle events', () => {
+  for (const type of CANONICAL_LIFECYCLE_EVENTS) {
+    assert.equal(isLifecycleEvent(` ${type}`), false, `Leading-space variant of "${type}" must not match`);
+    assert.equal(isLifecycleEvent(`${type} `), false, `Trailing-space variant of "${type}" must not match`);
+  }
+});
+
+// ─── Canonical events each pass ───────────────────────────────────────────────
+
+test('Taxonomy: each canonical lifecycle event is recognised by isLifecycleEvent', () => {
+  for (const type of CANONICAL_LIFECYCLE_EVENTS) {
+    assert.equal(
+      isLifecycleEvent(type),
+      true,
+      `Canonical event "${type}" must be recognised as a lifecycle event`
+    );
+  }
+});

--- a/tests/incident-clusters-contract.test.mjs
+++ b/tests/incident-clusters-contract.test.mjs
@@ -1,0 +1,376 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getIncidentClusters } from '../ui/selectors/anomalySelectors.js';
+import { getTaskStatus } from '../ui/selectors/taskSelectors.js';
+
+/**
+ * getIncidentClusters Output-Contract Tests
+ *
+ * Verifies:
+ *   - Cluster schema: type, severity, taskIds, summary, representativeEvents
+ *   - Correct cluster types and fixed set
+ *   - Severity values are within the allowed vocabulary
+ *   - representativeEvents contains only canonical lifecycle events (no status inference)
+ *   - Clusters do not mutate the world or alter lifecycle state
+ */
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+let _ts = 1000;
+const tick = (step = 100) => (_ts += step);
+
+function makeEvent(type, taskId, extraPayload = {}) {
+  return { type, taskId, timestamp: tick(), payload: { ...extraPayload } };
+}
+
+function buildWorld(taskMap) {
+  const allEvents = Array.from(taskMap.values()).flat();
+  return {
+    events: allEvents,
+    eventsByTaskId: new Map(taskMap),
+    eventsByWorkerId: new Map()
+  };
+}
+
+// A task that was acknowledged as failed.
+const TASK_FAIL = 'task-fail-1';
+const failEvents = [
+  makeEvent('TASK_CREATED',          TASK_FAIL),
+  makeEvent('TASK_ENQUEUED',         TASK_FAIL),
+  makeEvent('TASK_CLAIMED',          TASK_FAIL),
+  makeEvent('TASK_EXECUTE_STARTED',  TASK_FAIL),
+  makeEvent('TASK_EXECUTE_FINISHED', TASK_FAIL),
+  makeEvent('TASK_ACKED',            TASK_FAIL, { status: 'failed', error: 'timeout' })
+];
+
+// A task that completed successfully.
+const TASK_OK = 'task-ok-1';
+const okEvents = [
+  makeEvent('TASK_CREATED',          TASK_OK),
+  makeEvent('TASK_ENQUEUED',         TASK_OK),
+  makeEvent('TASK_CLAIMED',          TASK_OK),
+  makeEvent('TASK_EXECUTE_STARTED',  TASK_OK),
+  makeEvent('TASK_EXECUTE_FINISHED', TASK_OK),
+  makeEvent('TASK_ACKED',            TASK_OK, { status: 'acknowledged' })
+];
+
+// A task that is stalled — has EXECUTE_FINISHED but no ACKED, and is old.
+const TASK_STALL = 'task-stall-1';
+const STALL_FINISH_TS = 100; // very old timestamp
+const stallEvents = [
+  { type: 'TASK_CREATED',          taskId: TASK_STALL, timestamp: 10,  payload: {} },
+  { type: 'TASK_ENQUEUED',         taskId: TASK_STALL, timestamp: 20,  payload: {} },
+  { type: 'TASK_CLAIMED',          taskId: TASK_STALL, timestamp: 30,  payload: {} },
+  { type: 'TASK_EXECUTE_STARTED',  taskId: TASK_STALL, timestamp: 40,  payload: {} },
+  { type: 'TASK_EXECUTE_FINISHED', taskId: TASK_STALL, timestamp: STALL_FINISH_TS, payload: {} }
+];
+
+const FIXED_NOW = 99_999_999; // far in the future so stalled task is always over threshold
+
+const worldWithAll = buildWorld(new Map([
+  [TASK_FAIL,  failEvents],
+  [TASK_OK,    okEvents],
+  [TASK_STALL, stallEvents]
+]));
+
+const worldClean = buildWorld(new Map([
+  [TASK_OK, okEvents]
+]));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ALLOWED_SEVERITY = new Set(['high', 'medium', 'low']);
+const ALLOWED_TYPES    = new Set(['execution_failures', 'notification_issues', 'stalled_tasks']);
+
+function assertClusterSchema(cluster, label) {
+  assert.ok(typeof cluster.type === 'string',
+    `${label}: cluster.type must be a string`);
+  assert.ok(ALLOWED_TYPES.has(cluster.type),
+    `${label}: cluster.type "${cluster.type}" is not in the allowed set`);
+
+  assert.ok(typeof cluster.severity === 'string',
+    `${label}: cluster.severity must be a string`);
+  assert.ok(ALLOWED_SEVERITY.has(cluster.severity),
+    `${label}: cluster.severity "${cluster.severity}" is not in the allowed vocabulary`);
+
+  assert.ok(Array.isArray(cluster.taskIds),
+    `${label}: cluster.taskIds must be an array`);
+  for (const id of cluster.taskIds) {
+    assert.ok(typeof id === 'string',
+      `${label}: every entry in taskIds must be a string, got ${typeof id}`);
+  }
+
+  assert.ok(typeof cluster.summary === 'string' && cluster.summary.length > 0,
+    `${label}: cluster.summary must be a non-empty string`);
+
+  assert.ok(Array.isArray(cluster.representativeEvents),
+    `${label}: cluster.representativeEvents must be an array`);
+}
+
+// ─── Schema contract ──────────────────────────────────────────────────────────
+
+test('getIncidentClusters: every cluster has the required schema fields', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  assert.ok(clusters.length > 0, 'Must return at least one cluster');
+  for (const cluster of clusters) {
+    assertClusterSchema(cluster, cluster.type);
+  }
+});
+
+test('getIncidentClusters: with includeSystemEvents false, returns exactly two clusters', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  assert.equal(clusters.length, 2,
+    'Must return exactly 2 clusters when includeSystemEvents is false');
+});
+
+test('getIncidentClusters: with includeSystemEvents true, returns exactly three clusters', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: true });
+  assert.equal(clusters.length, 3,
+    'Must return exactly 3 clusters when includeSystemEvents is true');
+});
+
+test('getIncidentClusters: cluster types are exactly the canonical set (no extras, no missing)', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: true });
+  const types = clusters.map((c) => c.type).sort();
+  assert.deepStrictEqual(
+    types,
+    ['execution_failures', 'notification_issues', 'stalled_tasks'],
+    'Cluster types must be exactly the three canonical types'
+  );
+});
+
+test('getIncidentClusters: without includeSystemEvents, notification_issues cluster is absent', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  assert.ok(
+    !clusters.some((c) => c.type === 'notification_issues'),
+    'notification_issues must not appear when includeSystemEvents is false'
+  );
+});
+
+// ─── severity field contract ──────────────────────────────────────────────────
+
+test('getIncidentClusters: execution_failures severity is "high" when failed tasks exist', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'execution_failures');
+  assert.equal(cluster.severity, 'high',
+    'execution_failures must be "high" severity when at least one task failed');
+});
+
+test('getIncidentClusters: execution_failures severity is "low" when no failed tasks exist', () => {
+  const clusters = getIncidentClusters(worldClean, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'execution_failures');
+  assert.equal(cluster.severity, 'low',
+    'execution_failures must be "low" severity when no tasks failed');
+});
+
+test('getIncidentClusters: stalled_tasks severity is "medium" when stalled tasks exist', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'stalled_tasks');
+  assert.equal(cluster.severity, 'medium',
+    'stalled_tasks must be "medium" severity when at least one task is stalled');
+});
+
+test('getIncidentClusters: stalled_tasks severity is "low" when no stalled tasks exist', () => {
+  const clusters = getIncidentClusters(worldClean, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'stalled_tasks');
+  assert.equal(cluster.severity, 'low',
+    'stalled_tasks must be "low" severity when no tasks are stalled');
+});
+
+// ─── taskIds field contract ───────────────────────────────────────────────────
+
+test('getIncidentClusters: execution_failures taskIds contains the failed task', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'execution_failures');
+  assert.ok(cluster.taskIds.includes(TASK_FAIL),
+    'execution_failures taskIds must include the task acknowledged as failed');
+});
+
+test('getIncidentClusters: execution_failures taskIds does not include a successfully completed task', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'execution_failures');
+  assert.ok(!cluster.taskIds.includes(TASK_OK),
+    'execution_failures taskIds must not include a successfully completed task');
+});
+
+test('getIncidentClusters: stalled_tasks taskIds contains the stalled task', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'stalled_tasks');
+  assert.ok(cluster.taskIds.includes(TASK_STALL),
+    'stalled_tasks taskIds must include the task that is stalled waiting for ACK');
+});
+
+test('getIncidentClusters: taskIds entries are all strings', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: true });
+  for (const cluster of clusters) {
+    for (const id of cluster.taskIds) {
+      assert.equal(typeof id, 'string',
+        `taskIds entry in "${cluster.type}" must be a string, got ${typeof id}`);
+    }
+  }
+});
+
+// ─── summary field contract ───────────────────────────────────────────────────
+
+test('getIncidentClusters: summary is non-empty string for every cluster', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: true });
+  for (const cluster of clusters) {
+    assert.ok(typeof cluster.summary === 'string' && cluster.summary.trim().length > 0,
+      `"${cluster.type}" summary must be a non-empty string`);
+  }
+});
+
+test('getIncidentClusters: summary reflects detected count for execution_failures', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const cluster = clusters.find((c) => c.type === 'execution_failures');
+  assert.ok(cluster.summary.includes('1'),
+    'execution_failures summary must mention the count of failed tasks');
+});
+
+test('getIncidentClusters: summary is a "none detected" message when no anomaly exists', () => {
+  const clusters = getIncidentClusters(worldClean, { now: FIXED_NOW, includeSystemEvents: false });
+  const ef = clusters.find((c) => c.type === 'execution_failures');
+  const st = clusters.find((c) => c.type === 'stalled_tasks');
+  assert.ok(ef.summary.length > 0, 'execution_failures summary must still be set when empty');
+  assert.ok(st.summary.length > 0, 'stalled_tasks summary must still be set when empty');
+  // Summaries must not claim a count they don't have.
+  assert.ok(!ef.summary.includes('1'), 'execution_failures summary must not claim count when empty');
+});
+
+// ─── representativeEvents field contract ──────────────────────────────────────
+
+test('getIncidentClusters: representativeEvents is an array for every cluster', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: true });
+  for (const cluster of clusters) {
+    assert.ok(Array.isArray(cluster.representativeEvents),
+      `"${cluster.type}" representativeEvents must be an array`);
+  }
+});
+
+test('getIncidentClusters: representativeEvents contains at most 5 entries per cluster', () => {
+  // Build a world with 10 failed tasks to exercise the cap.
+  const taskMap = new Map();
+  for (let i = 0; i < 10; i++) {
+    const id = `task-fail-many-${i}`;
+    taskMap.set(id, [
+      { type: 'TASK_CREATED',          taskId: id, timestamp: i * 10 + 1,  payload: {} },
+      { type: 'TASK_ENQUEUED',         taskId: id, timestamp: i * 10 + 2,  payload: {} },
+      { type: 'TASK_CLAIMED',          taskId: id, timestamp: i * 10 + 3,  payload: {} },
+      { type: 'TASK_EXECUTE_STARTED',  taskId: id, timestamp: i * 10 + 4,  payload: {} },
+      { type: 'TASK_EXECUTE_FINISHED', taskId: id, timestamp: i * 10 + 5,  payload: {} },
+      { type: 'TASK_ACKED',            taskId: id, timestamp: i * 10 + 6,  payload: { status: 'failed' } }
+    ]);
+  }
+  const world = buildWorld(taskMap);
+  const clusters = getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: false });
+  const ef = clusters.find((c) => c.type === 'execution_failures');
+  assert.ok(ef.representativeEvents.length <= 5,
+    'representativeEvents must contain at most 5 entries');
+});
+
+test('getIncidentClusters: representativeEvents are sorted descending by timestamp', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  for (const cluster of clusters) {
+    const events = cluster.representativeEvents;
+    if (events.length < 2) continue;
+    for (let i = 1; i < events.length; i++) {
+      assert.ok(
+        (events[i - 1].timestamp || 0) >= (events[i].timestamp || 0),
+        `"${cluster.type}" representativeEvents must be sorted descending by timestamp`
+      );
+    }
+  }
+});
+
+test('getIncidentClusters: execution_failures representativeEvents contain only TASK_ACKED events', () => {
+  const clusters = getIncidentClusters(worldWithAll, { now: FIXED_NOW, includeSystemEvents: false });
+  const ef = clusters.find((c) => c.type === 'execution_failures');
+  for (const event of ef.representativeEvents) {
+    assert.equal(event.type, 'TASK_ACKED',
+      'execution_failures representativeEvents must only contain TASK_ACKED events');
+  }
+});
+
+test('getIncidentClusters: representativeEvents for empty cluster is an empty array', () => {
+  const clusters = getIncidentClusters(worldClean, { now: FIXED_NOW, includeSystemEvents: false });
+  const ef = clusters.find((c) => c.type === 'execution_failures');
+  assert.deepStrictEqual(ef.representativeEvents, [],
+    'representativeEvents must be [] when the cluster has no matching tasks');
+});
+
+// ─── Clusters do not modify lifecycle state ───────────────────────────────────
+
+test('getIncidentClusters: does not mutate world.events', () => {
+  const world = buildWorld(new Map([
+    [TASK_FAIL,  [...failEvents]],
+    [TASK_OK,    [...okEvents]],
+    [TASK_STALL, [...stallEvents]]
+  ]));
+  const eventsBefore = JSON.stringify(world.events);
+
+  getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: true });
+
+  assert.equal(JSON.stringify(world.events), eventsBefore,
+    'world.events must not be mutated by getIncidentClusters');
+});
+
+test('getIncidentClusters: does not mutate eventsByTaskId entries', () => {
+  const world = buildWorld(new Map([
+    [TASK_FAIL,  [...failEvents]],
+    [TASK_OK,    [...okEvents]],
+    [TASK_STALL, [...stallEvents]]
+  ]));
+  const before = new Map(
+    Array.from(world.eventsByTaskId.entries()).map(([k, v]) => [k, JSON.stringify(v)])
+  );
+
+  getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: true });
+
+  for (const [taskId, snapshot] of before) {
+    assert.equal(
+      JSON.stringify(world.eventsByTaskId.get(taskId)),
+      snapshot,
+      `eventsByTaskId[${taskId}] must not be mutated by getIncidentClusters`
+    );
+  }
+});
+
+test('getIncidentClusters: calling it does not change getTaskStatus for any task', () => {
+  const world = buildWorld(new Map([
+    [TASK_FAIL,  [...failEvents]],
+    [TASK_OK,    [...okEvents]],
+    [TASK_STALL, [...stallEvents]]
+  ]));
+
+  const statusBefore = {
+    [TASK_FAIL]:  getTaskStatus(world, TASK_FAIL),
+    [TASK_OK]:    getTaskStatus(world, TASK_OK),
+    [TASK_STALL]: getTaskStatus(world, TASK_STALL)
+  };
+
+  getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: true });
+
+  assert.equal(getTaskStatus(world, TASK_FAIL),  statusBefore[TASK_FAIL],
+    'TASK_FAIL lifecycle status must be unchanged after getIncidentClusters');
+  assert.equal(getTaskStatus(world, TASK_OK),    statusBefore[TASK_OK],
+    'TASK_OK lifecycle status must be unchanged after getIncidentClusters');
+  assert.equal(getTaskStatus(world, TASK_STALL), statusBefore[TASK_STALL],
+    'TASK_STALL lifecycle status must be unchanged after getIncidentClusters');
+});
+
+test('getIncidentClusters: result object fields are not live references into the world', () => {
+  const world = buildWorld(new Map([
+    [TASK_FAIL, [...failEvents]]
+  ]));
+
+  const clusters = getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: false });
+  const ef = clusters.find((c) => c.type === 'execution_failures');
+
+  // Push a new task id into the returned taskIds array and verify the world is unaffected.
+  const lengthBefore = world.eventsByTaskId.size;
+  ef.taskIds.push('injected-id');
+
+  assert.equal(world.eventsByTaskId.size, lengthBefore,
+    'Mutating cluster.taskIds must not affect the world\'s eventsByTaskId');
+});

--- a/tests/metrics-aggregation.test.mjs
+++ b/tests/metrics-aggregation.test.mjs
@@ -1,0 +1,338 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getQueueTime,
+  getExecutionDuration,
+  getAckLatency,
+  getTaskCounts
+} from '../ui/selectors/metricsSelectors.js';
+
+/**
+ * metricsSelectors Aggregation Tests
+ *
+ * Verifies that metrics selectors:
+ *   - aggregate only lifecycle-safe data (timestamp deltas from canonical events)
+ *   - do not infer task status from payloads or external state
+ *   - do not interpret system events semantically
+ *   - produce deterministic results from the same input
+ */
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const T_CREATED          = 1000;
+const T_ENQUEUED         = 1100;
+const T_CLAIMED          = 1200;
+const T_EXECUTE_STARTED  = 1500;
+const T_EXECUTE_FINISHED = 2000;
+const T_ACKED            = 2200;
+
+const TASK_ID = 'metrics-test-task';
+
+function makeEvent(type, timestamp, payload = {}) {
+  return Object.freeze({ type, taskId: TASK_ID, timestamp, payload: Object.freeze(payload) });
+}
+
+const LIFECYCLE_EVENTS = Object.freeze([
+  makeEvent('TASK_CREATED',          T_CREATED),
+  makeEvent('TASK_ENQUEUED',         T_ENQUEUED),
+  makeEvent('TASK_CLAIMED',          T_CLAIMED),
+  makeEvent('TASK_EXECUTE_STARTED',  T_EXECUTE_STARTED),
+  makeEvent('TASK_EXECUTE_FINISHED', T_EXECUTE_FINISHED),
+  makeEvent('TASK_ACKED',            T_ACKED, { status: 'acknowledged' })
+]);
+
+const SYSTEM_EVENTS = Object.freeze([
+  makeEvent('TASK_NOTIFICATION_SENT',    T_CREATED    + 50),
+  makeEvent('TASK_NOTIFICATION_SKIPPED', T_ENQUEUED   + 50),
+  makeEvent('TASK_NOTIFICATION_FAILED',  T_CLAIMED    + 50)
+]);
+
+function buildWorld(taskId, events) {
+  return {
+    events: [...events],
+    eventsByTaskId: new Map([[taskId, [...events]]]),
+    eventsByWorkerId: new Map()
+  };
+}
+
+/** World with the full lifecycle and no system events. */
+const cleanWorld = buildWorld(TASK_ID, LIFECYCLE_EVENTS);
+
+/** World with system events interleaved throughout. */
+const mixedWorld = buildWorld(TASK_ID, [
+  ...LIFECYCLE_EVENTS,
+  ...SYSTEM_EVENTS
+]);
+
+// ─── getQueueTime ─────────────────────────────────────────────────────────────
+
+test('getQueueTime: returns EXECUTE_STARTED minus CREATED timestamp', () => {
+  const result = getQueueTime(cleanWorld, TASK_ID);
+  assert.equal(result, T_EXECUTE_STARTED - T_CREATED,
+    'Queue time must equal the delta between EXECUTE_STARTED and CREATED timestamps');
+});
+
+test('getQueueTime: returns null when EXECUTE_STARTED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',  T_CREATED),
+    makeEvent('TASK_ENQUEUED', T_ENQUEUED)
+  ]);
+  assert.equal(getQueueTime(partial, TASK_ID), null,
+    'Queue time must be null when EXECUTE_STARTED has not occurred');
+});
+
+test('getQueueTime: returns null when CREATED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_EXECUTE_STARTED', T_EXECUTE_STARTED)
+  ]);
+  assert.equal(getQueueTime(partial, TASK_ID), null,
+    'Queue time must be null when CREATED timestamp is unavailable');
+});
+
+test('getQueueTime: is unaffected by TASK_NOTIFICATION_SENT', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_SENT', T_CREATED + 50)
+  ]);
+  assert.equal(getQueueTime(world, TASK_ID), getQueueTime(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_SENT must not alter queue time');
+});
+
+test('getQueueTime: is unaffected by TASK_NOTIFICATION_FAILED', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_FAILED', T_CLAIMED + 50)
+  ]);
+  assert.equal(getQueueTime(world, TASK_ID), getQueueTime(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_FAILED must not alter queue time');
+});
+
+test('getQueueTime: is unaffected by all three system events combined', () => {
+  assert.equal(getQueueTime(mixedWorld, TASK_ID), getQueueTime(cleanWorld, TASK_ID),
+    'Any combination of system events must not alter queue time');
+});
+
+// ─── getExecutionDuration ─────────────────────────────────────────────────────
+
+test('getExecutionDuration: returns EXECUTE_FINISHED minus EXECUTE_STARTED timestamp', () => {
+  const result = getExecutionDuration(cleanWorld, TASK_ID);
+  assert.equal(result, T_EXECUTE_FINISHED - T_EXECUTE_STARTED,
+    'Execution duration must equal the delta between EXECUTE_FINISHED and EXECUTE_STARTED');
+});
+
+test('getExecutionDuration: returns null when EXECUTE_STARTED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',          T_CREATED),
+    makeEvent('TASK_EXECUTE_FINISHED', T_EXECUTE_FINISHED)
+  ]);
+  assert.equal(getExecutionDuration(partial, TASK_ID), null,
+    'Execution duration must be null without EXECUTE_STARTED');
+});
+
+test('getExecutionDuration: returns null when EXECUTE_FINISHED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',         T_CREATED),
+    makeEvent('TASK_EXECUTE_STARTED', T_EXECUTE_STARTED)
+  ]);
+  assert.equal(getExecutionDuration(partial, TASK_ID), null,
+    'Execution duration must be null without EXECUTE_FINISHED');
+});
+
+test('getExecutionDuration: is unaffected by TASK_NOTIFICATION_SENT', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_SENT', T_EXECUTE_STARTED + 50)
+  ]);
+  assert.equal(getExecutionDuration(world, TASK_ID), getExecutionDuration(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_SENT must not alter execution duration');
+});
+
+test('getExecutionDuration: is unaffected by TASK_NOTIFICATION_FAILED', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_FAILED', T_EXECUTE_STARTED + 50)
+  ]);
+  assert.equal(getExecutionDuration(world, TASK_ID), getExecutionDuration(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_FAILED must not alter execution duration');
+});
+
+test('getExecutionDuration: is unaffected by all three system events combined', () => {
+  assert.equal(getExecutionDuration(mixedWorld, TASK_ID), getExecutionDuration(cleanWorld, TASK_ID),
+    'Any combination of system events must not alter execution duration');
+});
+
+// ─── getAckLatency ────────────────────────────────────────────────────────────
+
+test('getAckLatency: returns TASK_ACKED minus EXECUTE_FINISHED timestamp', () => {
+  const result = getAckLatency(cleanWorld, TASK_ID);
+  assert.equal(result, T_ACKED - T_EXECUTE_FINISHED,
+    'Ack latency must equal the delta between TASK_ACKED and EXECUTE_FINISHED timestamps');
+});
+
+test('getAckLatency: returns null when TASK_ACKED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',          T_CREATED),
+    makeEvent('TASK_EXECUTE_FINISHED', T_EXECUTE_FINISHED)
+  ]);
+  assert.equal(getAckLatency(partial, TASK_ID), null,
+    'Ack latency must be null without TASK_ACKED');
+});
+
+test('getAckLatency: returns null when EXECUTE_FINISHED is absent', () => {
+  const partial = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED', T_CREATED),
+    makeEvent('TASK_ACKED',   T_ACKED, { status: 'acknowledged' })
+  ]);
+  assert.equal(getAckLatency(partial, TASK_ID), null,
+    'Ack latency must be null without EXECUTE_FINISHED');
+});
+
+test('getAckLatency: is unaffected by TASK_NOTIFICATION_SENT', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_SENT', T_EXECUTE_FINISHED + 50)
+  ]);
+  assert.equal(getAckLatency(world, TASK_ID), getAckLatency(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_SENT must not alter ack latency');
+});
+
+test('getAckLatency: is unaffected by TASK_NOTIFICATION_FAILED', () => {
+  const world = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS,
+    makeEvent('TASK_NOTIFICATION_FAILED', T_EXECUTE_FINISHED + 50)
+  ]);
+  assert.equal(getAckLatency(world, TASK_ID), getAckLatency(cleanWorld, TASK_ID),
+    'TASK_NOTIFICATION_FAILED must not alter ack latency');
+});
+
+test('getAckLatency: is unaffected by all three system events combined', () => {
+  assert.equal(getAckLatency(mixedWorld, TASK_ID), getAckLatency(cleanWorld, TASK_ID),
+    'Any combination of system events must not alter ack latency');
+});
+
+// ─── Metrics do not interpret TASK_ACKED payload semantics ───────────────────
+// getQueueTime / getExecutionDuration / getAckLatency are timestamp-delta functions.
+// They must return the same value regardless of what payload.status says —
+// interpreting 'failed' vs 'acknowledged' is strictly status derivation territory.
+
+test('getQueueTime: result is identical whether TASK_ACKED payload.status is "failed" or "acknowledged"', () => {
+  const worldFailed = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS.slice(0, -1),
+    makeEvent('TASK_ACKED', T_ACKED, { status: 'failed', error: 'timeout' })
+  ]);
+  assert.equal(getQueueTime(worldFailed, TASK_ID), getQueueTime(cleanWorld, TASK_ID),
+    'getQueueTime must not vary based on TASK_ACKED payload.status');
+});
+
+test('getExecutionDuration: result is identical whether TASK_ACKED payload.status is "failed" or "acknowledged"', () => {
+  const worldFailed = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS.slice(0, -1),
+    makeEvent('TASK_ACKED', T_ACKED, { status: 'failed', error: 'timeout' })
+  ]);
+  assert.equal(getExecutionDuration(worldFailed, TASK_ID), getExecutionDuration(cleanWorld, TASK_ID),
+    'getExecutionDuration must not vary based on TASK_ACKED payload.status');
+});
+
+test('getAckLatency: result is identical whether TASK_ACKED payload.status is "failed" or "acknowledged"', () => {
+  const worldFailed = buildWorld(TASK_ID, [
+    ...LIFECYCLE_EVENTS.slice(0, -1),
+    makeEvent('TASK_ACKED', T_ACKED, { status: 'failed', error: 'timeout' })
+  ]);
+  assert.equal(getAckLatency(worldFailed, TASK_ID), getAckLatency(cleanWorld, TASK_ID),
+    'getAckLatency must not vary based on TASK_ACKED payload.status');
+});
+
+// ─── getTaskCounts ────────────────────────────────────────────────────────────
+
+test('getTaskCounts: counts a fully-acked task in the "done" bucket', () => {
+  const counts = getTaskCounts(cleanWorld);
+  assert.equal(counts.done, 1, 'Completed task must be counted in the "done" bucket');
+  assert.equal(counts.active, 0);
+  assert.equal(counts.queued, 0);
+  assert.equal(counts.failed, 0);
+});
+
+test('getTaskCounts: counts a queued task in the "queued" bucket', () => {
+  const world = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',  T_CREATED),
+    makeEvent('TASK_ENQUEUED', T_ENQUEUED)
+  ]);
+  const counts = getTaskCounts(world);
+  assert.equal(counts.queued, 1, 'Enqueued task must be counted in the "queued" bucket');
+  assert.equal(counts.active, 0);
+  assert.equal(counts.done,   0);
+  assert.equal(counts.failed, 0);
+});
+
+test('getTaskCounts: counts an executing task in the "active" bucket', () => {
+  const world = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',         T_CREATED),
+    makeEvent('TASK_ENQUEUED',        T_ENQUEUED),
+    makeEvent('TASK_CLAIMED',         T_CLAIMED),
+    makeEvent('TASK_EXECUTE_STARTED', T_EXECUTE_STARTED)
+  ]);
+  const counts = getTaskCounts(world);
+  assert.equal(counts.active, 1, 'Executing task must be counted in the "active" bucket');
+  assert.equal(counts.queued, 0);
+  assert.equal(counts.done,   0);
+  assert.equal(counts.failed, 0);
+});
+
+test('getTaskCounts: counts a failed task in the "failed" bucket', () => {
+  const world = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',          T_CREATED),
+    makeEvent('TASK_ENQUEUED',         T_ENQUEUED),
+    makeEvent('TASK_CLAIMED',          T_CLAIMED),
+    makeEvent('TASK_EXECUTE_STARTED',  T_EXECUTE_STARTED),
+    makeEvent('TASK_EXECUTE_FINISHED', T_EXECUTE_FINISHED),
+    makeEvent('TASK_ACKED',            T_ACKED, { status: 'failed', error: 'timeout' })
+  ]);
+  const counts = getTaskCounts(world);
+  assert.equal(counts.failed, 1, 'Failed task must be counted in the "failed" bucket');
+  assert.equal(counts.active, 0);
+  assert.equal(counts.queued, 0);
+  assert.equal(counts.done,   0);
+});
+
+test('getTaskCounts: is unaffected by system events mixed into the world', () => {
+  const countClean = getTaskCounts(cleanWorld);
+  const countMixed = getTaskCounts(mixedWorld);
+  assert.deepStrictEqual(countMixed, countClean,
+    'System events must not alter task count buckets');
+});
+
+test('getTaskCounts: result keys are always queued, active, done, failed and nothing else', () => {
+  const counts = getTaskCounts(cleanWorld);
+  assert.deepStrictEqual(
+    Object.keys(counts).sort(),
+    ['active', 'done', 'failed', 'queued'],
+    'getTaskCounts must only expose the four defined buckets'
+  );
+});
+
+// ─── Deterministic aggregation ────────────────────────────────────────────────
+
+test('Determinism: all metrics return identical values on repeated calls with the same world', () => {
+  assert.equal(getQueueTime(cleanWorld, TASK_ID),        getQueueTime(cleanWorld, TASK_ID));
+  assert.equal(getExecutionDuration(cleanWorld, TASK_ID), getExecutionDuration(cleanWorld, TASK_ID));
+  assert.equal(getAckLatency(cleanWorld, TASK_ID),       getAckLatency(cleanWorld, TASK_ID));
+  assert.deepStrictEqual(getTaskCounts(cleanWorld),      getTaskCounts(cleanWorld));
+});
+
+test('Determinism: event order within the same type does not affect timestamp-based metrics', () => {
+  // A world where events arrive out of wall-clock order but canonical type order is intact.
+  // Selectors use firstTimestamp(), which finds the first matching type — order of *types*
+  // in the array is what matters, not the timestamp values being monotone.
+  const world = buildWorld(TASK_ID, [
+    makeEvent('TASK_CREATED',          100),
+    makeEvent('TASK_ENQUEUED',         200),
+    makeEvent('TASK_CLAIMED',          300),
+    makeEvent('TASK_EXECUTE_STARTED',  400),
+    makeEvent('TASK_EXECUTE_FINISHED', 500),
+    makeEvent('TASK_ACKED',            600, { status: 'acknowledged' })
+  ]);
+  assert.equal(getQueueTime(world, TASK_ID),         400 - 100);
+  assert.equal(getExecutionDuration(world, TASK_ID), 500 - 400);
+  assert.equal(getAckLatency(world, TASK_ID),        600 - 500);
+});

--- a/tests/renderer-boundary.test.mjs
+++ b/tests/renderer-boundary.test.mjs
@@ -1,0 +1,351 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Renderer Boundary Contract Tests
+ *
+ * Verifies that all files under rendering/ are stateless projection layers:
+ *
+ *   1. Do NOT branch on canonical event type semantics
+ *      (no TASK_CREATED / TASK_ACKED / … string comparisons)
+ *
+ *   2. Do NOT import selector modules, event taxonomy, or world indexers
+ *      (no direct event processing — only accepts pre-computed renderView)
+ *
+ *   3. Do NOT access raw world index structures
+ *      (.events, .eventsByTaskId, .eventsByWorkerId)
+ *
+ *   4. Do NOT return state from the render entry point
+ *      (render() is a pure side-effect call — stateless per-call contract)
+ *
+ *   5. Do NOT accumulate lifecycle-derived state across frames
+ *      (no module-level data structures keyed by taskId or built from events)
+ */
+
+const ROOT   = fileURLToPath(new URL('..', import.meta.url));
+const RENDER_DIR = join(ROOT, 'rendering');
+
+// ─── File collection ──────────────────────────────────────────────────────────
+
+function collectJs(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...collectJs(full));
+    } else if (entry.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const RENDER_FILES = collectJs(RENDER_DIR);
+
+function label(filePath) {
+  return relative(ROOT, filePath);
+}
+
+function lines(filePath) {
+  return readFileSync(filePath, 'utf8').split('\n');
+}
+
+function src(filePath) {
+  return readFileSync(filePath, 'utf8');
+}
+
+function isComment(line) {
+  return /^\s*\*|^\s*\/\//.test(line);
+}
+
+// ─── Violation definitions ────────────────────────────────────────────────────
+
+const CANONICAL_EVENT_TYPES = [
+  'TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED',
+  'TASK_EXECUTE_STARTED', 'TASK_EXECUTE_FINISHED', 'TASK_ACKED',
+  'TASK_NOTIFICATION_SENT', 'TASK_NOTIFICATION_SKIPPED', 'TASK_NOTIFICATION_FAILED'
+];
+
+const VIOLATIONS = [
+  {
+    name: 'canonical event type string literal',
+    // Any quoted occurrence of a TASK_* canonical event name.
+    re: new RegExp(`['"\`](${CANONICAL_EVENT_TYPES.join('|')})['"\`]`),
+    except: isComment
+  },
+  {
+    name: 'import from ui/selectors',
+    re: /import\s.*from\s+['"`][^'"`]*\/ui\/selectors\//,
+    except: isComment
+  },
+  {
+    name: 'import from selectors (relative)',
+    re: /import\s.*from\s+['"`][^'"`]*selectors[/\\][^'"`]*['"`]/,
+    except: isComment
+  },
+  {
+    name: 'import of eventTaxonomy',
+    re: /import\s.*from\s+['"`][^'"`]*eventTaxonomy[^'"`]*['"`]/,
+    except: isComment
+  },
+  {
+    name: 'import of deriveWorldState',
+    re: /import\s.*\bderiveWorldState\b/,
+    except: isComment
+  },
+  {
+    name: 'import of getRawEvents',
+    re: /import\s.*\bgetRawEvents\b/,
+    except: isComment
+  },
+  {
+    name: 'direct .eventsByTaskId access',
+    re: /\.\s*eventsByTaskId\b/,
+    except: isComment
+  },
+  {
+    name: 'direct .eventsByWorkerId access',
+    re: /\.\s*eventsByWorkerId\b/,
+    except: isComment
+  },
+  {
+    name: 'direct world .events array access',
+    // Match .events[ or .events. but not .representativeEvents or similar composed names.
+    re: /(?<!\w)\.events\s*[\[.]/,
+    except: isComment
+  }
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function findViolations(filePath, violation) {
+  const hits = [];
+  const fileLines = lines(filePath);
+  for (let i = 0; i < fileLines.length; i++) {
+    const line = fileLines[i];
+    if (violation.re.test(line) && !violation.except(line)) {
+      hits.push({ lineNumber: i + 1, text: line.trim() });
+    }
+  }
+  return hits;
+}
+
+function reportHits(filePath, hits) {
+  return hits.map((h) => `  ${label(filePath)}:${h.lineNumber}: ${h.text}`).join('\n');
+}
+
+// ─── Sanity: file list is non-empty ──────────────────────────────────────────
+
+test('Renderer boundary: rendering/ directory contains JS files (infra sanity)', () => {
+  assert.ok(RENDER_FILES.length > 0,
+    'Expected JS files in rendering/ — check RENDER_DIR path');
+});
+
+// ─── 1. No canonical event type string literals ───────────────────────────────
+
+test('Renderer boundary: no rendering file compares against canonical event type strings', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'canonical event type string literal');
+  const allHits = [];
+
+  for (const f of RENDER_FILES) {
+    const hits = findViolations(f, violation);
+    if (hits.length) allHits.push(reportHits(f, hits));
+  }
+
+  assert.equal(allHits.length, 0,
+    `Rendering files must not branch on event type names:\n${allHits.join('\n')}`);
+});
+
+// ─── 2. No selector or event-processing imports ───────────────────────────────
+
+test('Renderer boundary: no rendering file imports from ui/selectors/', () => {
+  for (const violation of VIOLATIONS.filter((v) =>
+    v.name === 'import from ui/selectors' || v.name === 'import from selectors (relative)'
+  )) {
+    const allHits = [];
+    for (const f of RENDER_FILES) {
+      const hits = findViolations(f, violation);
+      if (hits.length) allHits.push(reportHits(f, hits));
+    }
+    assert.equal(allHits.length, 0,
+      `Violation "${violation.name}" — rendering must not import selectors directly:\n${allHits.join('\n')}`);
+  }
+});
+
+test('Renderer boundary: no rendering file imports eventTaxonomy', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'import of eventTaxonomy');
+  const allHits = [];
+  for (const f of RENDER_FILES) {
+    const hits = findViolations(f, violation);
+    if (hits.length) allHits.push(reportHits(f, hits));
+  }
+  assert.equal(allHits.length, 0,
+    `Rendering files must not import eventTaxonomy:\n${allHits.join('\n')}`);
+});
+
+test('Renderer boundary: no rendering file imports deriveWorldState or getRawEvents', () => {
+  for (const violation of VIOLATIONS.filter((v) =>
+    v.name === 'import of deriveWorldState' || v.name === 'import of getRawEvents'
+  )) {
+    const allHits = [];
+    for (const f of RENDER_FILES) {
+      const hits = findViolations(f, violation);
+      if (hits.length) allHits.push(reportHits(f, hits));
+    }
+    assert.equal(allHits.length, 0,
+      `Violation "${violation.name}" in rendering files:\n${allHits.join('\n')}`);
+  }
+});
+
+// ─── 3. No raw world index access ─────────────────────────────────────────────
+
+test('Renderer boundary: no rendering file accesses .eventsByTaskId directly', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'direct .eventsByTaskId access');
+  const allHits = [];
+  for (const f of RENDER_FILES) {
+    const hits = findViolations(f, violation);
+    if (hits.length) allHits.push(reportHits(f, hits));
+  }
+  assert.equal(allHits.length, 0,
+    `Rendering must not access .eventsByTaskId — use selector outputs only:\n${allHits.join('\n')}`);
+});
+
+test('Renderer boundary: no rendering file accesses .eventsByWorkerId directly', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'direct .eventsByWorkerId access');
+  const allHits = [];
+  for (const f of RENDER_FILES) {
+    const hits = findViolations(f, violation);
+    if (hits.length) allHits.push(reportHits(f, hits));
+  }
+  assert.equal(allHits.length, 0,
+    `Rendering must not access .eventsByWorkerId — use selector outputs only:\n${allHits.join('\n')}`);
+});
+
+test('Renderer boundary: no rendering file indexes into a .events array directly', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'direct world .events array access');
+  const allHits = [];
+  for (const f of RENDER_FILES) {
+    const hits = findViolations(f, violation);
+    if (hits.length) allHits.push(reportHits(f, hits));
+  }
+  assert.equal(allHits.length, 0,
+    `Rendering must not traverse raw .events arrays — use selector outputs only:\n${allHits.join('\n')}`);
+});
+
+// ─── 4. render() is a void function (stateless per-call contract) ─────────────
+
+test('Renderer boundary: render() in canvas-renderer.js does not return a value', () => {
+  const canvasRenderer = RENDER_FILES.find((f) => f.endsWith('canvas-renderer.js'));
+  assert.ok(canvasRenderer, 'canvas-renderer.js must exist in rendering/');
+
+  const source = src(canvasRenderer);
+  // Extract the body of the exported `render` function.
+  // Strategy: find `export function render(` and scan until the matching closing brace.
+  const exportStart = source.indexOf('export function render(');
+  assert.ok(exportStart !== -1, 'canvas-renderer.js must export a `render` function');
+
+  // Find the opening brace of the function body.
+  let depth = 0;
+  let bodyStart = -1;
+  let bodyEnd = -1;
+  for (let i = exportStart; i < source.length; i++) {
+    if (source[i] === '{') {
+      if (depth === 0) bodyStart = i;
+      depth++;
+    } else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        bodyEnd = i;
+        break;
+      }
+    }
+  }
+
+  assert.ok(bodyStart !== -1 && bodyEnd !== -1, 'Could not locate render() function body');
+
+  const body = source.slice(bodyStart, bodyEnd + 1);
+
+  // A value-returning render() would have `return <expr>;` (not bare `return;`).
+  const returnWithValue = /\breturn\s+(?!;)[^\n;]+/;
+  assert.ok(!returnWithValue.test(body),
+    'render() must not return a value — it is a stateless projection, not a data-producing function');
+});
+
+// ─── 5. No lifecycle-derived accumulation state ───────────────────────────────
+
+test('Renderer boundary: rendering files do not declare module-level Maps keyed by taskId', () => {
+  // Pattern: `new Map()` assigned to a module-level `const/let/var` in rendering files,
+  // where the variable name suggests task or event keying.
+  const taskKeyedMapRe = /^(?:const|let|var)\s+\w*(?:task|event|lifecycle)\w*\s*=\s*new Map\(\)/im;
+
+  for (const f of RENDER_FILES) {
+    const source = src(f);
+    // Only look at module-level declarations (not inside function bodies).
+    // Heuristic: lines that are not indented with more than one level.
+    const moduleLines = source.split('\n').filter(
+      (line) => /^(?:const|let|var)\s+/.test(line)
+    );
+    for (const line of moduleLines) {
+      const isTaskKeyedMap = taskKeyedMapRe.test(line);
+      assert.ok(!isTaskKeyedMap,
+        `${label(f)}: module-level Map named after task/event/lifecycle detected — ` +
+        `rendering must not accumulate lifecycle-derived state:\n  ${line.trim()}`);
+    }
+  }
+});
+
+test('Renderer boundary: rendering files do not derive state from event payloads', () => {
+  // Payload fields that belong to lifecycle/status derivation — accessing these
+  // in rendering means the renderer is inferring state rather than consuming it.
+  const lifecyclePayloadRe = /\bpayload\s*\.\s*(?:status|taskId|workerId|error|agentId)\b/;
+
+  for (const f of RENDER_FILES) {
+    const fileLines = lines(f);
+    const hits = [];
+    for (let i = 0; i < fileLines.length; i++) {
+      const line = fileLines[i];
+      if (lifecyclePayloadRe.test(line) && !isComment(line)) {
+        hits.push({ lineNumber: i + 1, text: line.trim() });
+      }
+    }
+    assert.equal(hits.length, 0,
+      `${label(f)}: rendering files must not read lifecycle fields from event payloads —` +
+      ` those must be resolved by selectors before rendering:\n${reportHits(f, hits)}`);
+  }
+});
+
+// ─── Regression: detectors are non-trivial ────────────────────────────────────
+
+test('Renderer boundary: event type literal detector fires on synthetic source', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'canonical event type string literal');
+  const fakeLines = [
+    '// TASK_CREATED is a lifecycle event',
+    "if (event.type === 'TASK_CREATED') { draw(); }",
+    'const type = status;'
+  ];
+  const hits = fakeLines
+    .map((line, i) => ({ line, i }))
+    .filter(({ line }) => violation.re.test(line) && !violation.except(line))
+    .map(({ i }) => i + 1);
+
+  assert.deepStrictEqual(hits, [2],
+    'Detector must flag the executable line and ignore the comment');
+});
+
+test('Renderer boundary: selector import detector fires on synthetic source', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'import from selectors (relative)');
+  const fakeLines = [
+    "import { getTaskStatus } from '../ui/selectors/taskSelectors.js';",
+    "import { render } from './canvas-renderer.js';"
+  ];
+  const hits = fakeLines
+    .map((line, i) => ({ line, i }))
+    .filter(({ line }) => violation.re.test(line) && !violation.except(line))
+    .map(({ i }) => i + 1);
+
+  assert.deepStrictEqual(hits, [1],
+    'Detector must flag a selector import and not flag a rendering import');
+});

--- a/tests/selector-purity.test.mjs
+++ b/tests/selector-purity.test.mjs
@@ -1,0 +1,291 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getTaskStatus,
+  getTaskEvents,
+  getLifecycleEvents,
+  getTaskSnapshot,
+  getTaskIds,
+  getAllTasks,
+  filterTasks,
+  getTaskBuckets,
+  getTaskById,
+  getTaskTransitionTimestamps,
+  getRecentEvents,
+  isActiveTaskStatus
+} from '../ui/selectors/taskSelectors.js';
+
+import {
+  getQueueTime,
+  getExecutionDuration,
+  getAckLatency,
+  getTaskCounts
+} from '../ui/selectors/metricsSelectors.js';
+
+import {
+  getStalledAckTasks,
+  getExecutionMissingFinishTasks,
+  getDuplicateAckTasks,
+  getNotificationSkippedTasks,
+  getNotificationFailedTasks,
+  getNotificationSkipReason,
+  getNotificationFailReason,
+  getIncidentClusters
+} from '../ui/selectors/anomalySelectors.js';
+
+/**
+ * Selector Purity Tests
+ *
+ * Verifies that selectors from taskSelectors, metricsSelectors and
+ * anomalySelectors are pure functions:
+ *   - same input → identical output
+ *   - no mutation of input
+ *   - no hidden external state dependency (world input is the sole source)
+ */
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let _ts = 1_000_000;
+const tick = (step = 100) => (_ts += step);
+
+function makeEvent(type, taskId, extraPayload = {}) {
+  return Object.freeze({ type, taskId, timestamp: tick(), payload: Object.freeze({ ...extraPayload }) });
+}
+
+const TASK_A = 'task-pure-a';
+const TASK_B = 'task-pure-b';
+
+/** Full lifecycle for TASK_A, partial for TASK_B. */
+function buildWorld() {
+  const aEvents = [
+    makeEvent('TASK_CREATED', TASK_A),
+    makeEvent('TASK_ENQUEUED', TASK_A),
+    makeEvent('TASK_CLAIMED', TASK_A),
+    makeEvent('TASK_EXECUTE_STARTED', TASK_A),
+    makeEvent('TASK_EXECUTE_FINISHED', TASK_A),
+    makeEvent('TASK_ACKED', TASK_A, { status: 'acknowledged', success: true })
+  ];
+  const bEvents = [
+    makeEvent('TASK_CREATED', TASK_B),
+    makeEvent('TASK_ENQUEUED', TASK_B)
+  ];
+
+  const allEvents = [...aEvents, ...bEvents];
+
+  return Object.freeze({
+    events: Object.freeze([...allEvents]),
+    eventsByTaskId: new Map([
+      [TASK_A, Object.freeze([...aEvents])],
+      [TASK_B, Object.freeze([...bEvents])]
+    ]),
+    eventsByWorkerId: new Map()
+  });
+}
+
+/** Deep-equal check using JSON round-trip (sufficient for plain data). */
+function deepEqual(a, b) {
+  assert.deepStrictEqual(a, b);
+}
+
+// ─── taskSelectors — idempotency ──────────────────────────────────────────────
+
+test('Purity taskSelectors: getTaskStatus returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskStatus(world, TASK_A), getTaskStatus(world, TASK_A));
+  deepEqual(getTaskStatus(world, TASK_B), getTaskStatus(world, TASK_B));
+});
+
+test('Purity taskSelectors: getTaskEvents returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskEvents(world, TASK_A), getTaskEvents(world, TASK_A));
+});
+
+test('Purity taskSelectors: getLifecycleEvents returns same value on repeated calls', () => {
+  const world = buildWorld();
+  const raw = Array.from(world.eventsByTaskId.get(TASK_A));
+  deepEqual(getLifecycleEvents(raw), getLifecycleEvents(raw));
+});
+
+test('Purity taskSelectors: getTaskIds returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskIds(world), getTaskIds(world));
+});
+
+test('Purity taskSelectors: getAllTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getAllTasks(world), getAllTasks(world));
+});
+
+test('Purity taskSelectors: getTaskSnapshot returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskSnapshot(world, TASK_A), getTaskSnapshot(world, TASK_A));
+});
+
+test('Purity taskSelectors: getTaskById returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskById(world, TASK_A), getTaskById(world, TASK_A));
+});
+
+test('Purity taskSelectors: getTaskTransitionTimestamps returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskTransitionTimestamps(world, TASK_A), getTaskTransitionTimestamps(world, TASK_A));
+});
+
+test('Purity taskSelectors: filterTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(filterTasks(world, { status: 'queued' }), filterTasks(world, { status: 'queued' }));
+});
+
+test('Purity taskSelectors: getTaskBuckets returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskBuckets(world), getTaskBuckets(world));
+});
+
+test('Purity taskSelectors: isActiveTaskStatus is referentially stable', () => {
+  assert.equal(isActiveTaskStatus('claimed'), isActiveTaskStatus('claimed'));
+  assert.equal(isActiveTaskStatus('idle'), isActiveTaskStatus('idle'));
+});
+
+// ─── metricsSelectors — idempotency ──────────────────────────────────────────
+
+test('Purity metricsSelectors: getQueueTime returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getQueueTime(world, TASK_A), getQueueTime(world, TASK_A));
+});
+
+test('Purity metricsSelectors: getExecutionDuration returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getExecutionDuration(world, TASK_A), getExecutionDuration(world, TASK_A));
+});
+
+test('Purity metricsSelectors: getAckLatency returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getAckLatency(world, TASK_A), getAckLatency(world, TASK_A));
+});
+
+test('Purity metricsSelectors: getTaskCounts returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getTaskCounts(world), getTaskCounts(world));
+});
+
+// ─── anomalySelectors — idempotency ──────────────────────────────────────────
+
+const FIXED_NOW = 9_999_999_999;
+
+test('Purity anomalySelectors: getStalledAckTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getStalledAckTasks(world, 15000, FIXED_NOW), getStalledAckTasks(world, 15000, FIXED_NOW));
+});
+
+test('Purity anomalySelectors: getExecutionMissingFinishTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getExecutionMissingFinishTasks(world), getExecutionMissingFinishTasks(world));
+});
+
+test('Purity anomalySelectors: getDuplicateAckTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getDuplicateAckTasks(world), getDuplicateAckTasks(world));
+});
+
+test('Purity anomalySelectors: getNotificationSkippedTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getNotificationSkippedTasks(world), getNotificationSkippedTasks(world));
+});
+
+test('Purity anomalySelectors: getNotificationFailedTasks returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getNotificationFailedTasks(world), getNotificationFailedTasks(world));
+});
+
+test('Purity anomalySelectors: getNotificationSkipReason returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getNotificationSkipReason(world, TASK_A), getNotificationSkipReason(world, TASK_A));
+});
+
+test('Purity anomalySelectors: getNotificationFailReason returns same value on repeated calls', () => {
+  const world = buildWorld();
+  deepEqual(getNotificationFailReason(world, TASK_A), getNotificationFailReason(world, TASK_A));
+});
+
+test('Purity anomalySelectors: getIncidentClusters returns same value on repeated calls', () => {
+  const world = buildWorld();
+  const opts = { now: FIXED_NOW, includeSystemEvents: false };
+  deepEqual(getIncidentClusters(world, opts), getIncidentClusters(world, opts));
+});
+
+// ─── No mutation of input ─────────────────────────────────────────────────────
+
+test('Purity: selectors do not mutate the events array in eventsByTaskId', () => {
+  const world = buildWorld();
+  const eventsBefore = JSON.stringify(Array.from(world.eventsByTaskId.get(TASK_A)));
+
+  getTaskStatus(world, TASK_A);
+  getTaskEvents(world, TASK_A);
+  getTaskSnapshot(world, TASK_A);
+  getTaskTransitionTimestamps(world, TASK_A);
+  getQueueTime(world, TASK_A);
+  getExecutionDuration(world, TASK_A);
+  getAckLatency(world, TASK_A);
+
+  const eventsAfter = JSON.stringify(Array.from(world.eventsByTaskId.get(TASK_A)));
+  assert.equal(eventsAfter, eventsBefore, 'eventsByTaskId entries must not be mutated by selectors');
+});
+
+test('Purity: selectors do not mutate the top-level events array', () => {
+  const world = buildWorld();
+  const before = JSON.stringify(world.events);
+
+  getAllTasks(world);
+  getTaskIds(world);
+  getTaskCounts(world);
+  getExecutionMissingFinishTasks(world);
+  getDuplicateAckTasks(world);
+  getIncidentClusters(world, { now: FIXED_NOW, includeSystemEvents: false });
+
+  const after = JSON.stringify(world.events);
+  assert.equal(after, before, 'world.events must not be mutated by selectors');
+});
+
+test('Purity: selectors do not mutate the eventsByWorkerId map', () => {
+  const world = buildWorld();
+  const keysBefore = Array.from(world.eventsByWorkerId.keys()).join(',');
+
+  getTaskIds(world);
+  getAllTasks(world);
+  getTaskCounts(world);
+
+  const keysAfter = Array.from(world.eventsByWorkerId.keys()).join(',');
+  assert.equal(keysAfter, keysBefore, 'eventsByWorkerId must not be mutated by selectors');
+});
+
+// ─── Isolation from unrelated world changes ───────────────────────────────────
+
+test('Purity: selector result for TASK_A is unaffected by changes to TASK_B events', () => {
+  const worldOriginal = buildWorld();
+  const statusBefore = getTaskStatus(worldOriginal, TASK_A);
+  const countsBefore = getTaskCounts(worldOriginal);
+
+  // Build a new world where TASK_B has progressed further — TASK_A is unchanged.
+  const aEvents = Array.from(worldOriginal.eventsByTaskId.get(TASK_A));
+  const bEventsExtended = [
+    ...Array.from(worldOriginal.eventsByTaskId.get(TASK_B)),
+    makeEvent('TASK_CLAIMED', TASK_B),
+    makeEvent('TASK_EXECUTE_STARTED', TASK_B)
+  ];
+  const worldUpdated = {
+    events: [...aEvents, ...bEventsExtended],
+    eventsByTaskId: new Map([
+      [TASK_A, aEvents],
+      [TASK_B, bEventsExtended]
+    ]),
+    eventsByWorkerId: new Map()
+  };
+
+  const statusAfter = getTaskStatus(worldUpdated, TASK_A);
+  assert.equal(statusAfter, statusBefore, 'TASK_A status must be unaffected by changes to TASK_B');
+
+  // Counts will change (TASK_B moved) but TASK_A's contribution is stable.
+  const countsDoneAfter = getTaskCounts(worldUpdated).done;
+  assert.equal(countsDoneAfter, countsBefore.done, 'done count must not change when only TASK_B progresses');
+});

--- a/tests/system-event-isolation.test.mjs
+++ b/tests/system-event-isolation.test.mjs
@@ -1,0 +1,314 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SYSTEM_EVENTS } from '../core/world/eventTaxonomy.js';
+import {
+  getTaskStatus,
+  getLifecycleEvents,
+  getTaskTransitionTimestamps,
+  getTaskTimeline
+} from '../ui/selectors/taskSelectors.js';
+import { assertNoSystemEventInLifecycleDerivation } from '../ui/selectors/eventTaxonomyInvariant.js';
+
+/**
+ * System Event Isolation Tests
+ *
+ * Verifies that system events (TASK_NOTIFICATION_SENT, TASK_NOTIFICATION_SKIPPED,
+ * TASK_NOTIFICATION_FAILED) are completely excluded from lifecycle derivation and
+ * do not alter the derived task status in any way.
+ */
+
+const TASK_ID = 'test-system-isolation-task';
+let ts = 1000;
+const tick = () => (ts += 100);
+
+function makeEvent(type, taskId = TASK_ID) {
+  return { type, taskId, timestamp: tick(), payload: {} };
+}
+
+/** Build an indexedWorld with a fixed lifecycle sequence + optional extra events. */
+function buildIndexedWorld(taskId, lifecycleTypes, extraEvents = []) {
+  const lifecycleEvents = lifecycleTypes.map((type) => makeEvent(type, taskId));
+  const allEvents = [...lifecycleEvents, ...extraEvents];
+  return {
+    events: allEvents,
+    eventsByTaskId: new Map([[taskId, allEvents]]),
+    eventsByWorkerId: new Map()
+  };
+}
+
+// ─── System events excluded from getLifecycleEvents ──────────────────────────
+
+test('System events: getLifecycleEvents filters out all three system event types', () => {
+  const events = [
+    makeEvent('TASK_CREATED'),
+    makeEvent('TASK_NOTIFICATION_SENT'),
+    makeEvent('TASK_ENQUEUED'),
+    makeEvent('TASK_NOTIFICATION_SKIPPED'),
+    makeEvent('TASK_CLAIMED'),
+    makeEvent('TASK_NOTIFICATION_FAILED')
+  ];
+
+  const lifecycle = getLifecycleEvents(events);
+
+  assert.equal(lifecycle.length, 3, 'Only lifecycle events must be returned');
+  for (const event of lifecycle) {
+    assert.ok(
+      !SYSTEM_EVENTS.includes(event.type),
+      `System event "${event.type}" must not appear in lifecycle events`
+    );
+  }
+});
+
+test('System events: getLifecycleEvents with only system events returns empty array', () => {
+  const events = SYSTEM_EVENTS.map((type) => makeEvent(type));
+  const lifecycle = getLifecycleEvents(events);
+  assert.equal(lifecycle.length, 0, 'All-system event list must yield no lifecycle events');
+});
+
+// ─── Lifecycle status unaffected by system events ─────────────────────────────
+
+test('System events: TASK_NOTIFICATION_SENT does not change derived task status', () => {
+  const world = buildIndexedWorld(TASK_ID, ['TASK_CREATED', 'TASK_ENQUEUED'], [
+    makeEvent('TASK_NOTIFICATION_SENT')
+  ]);
+  const status = getTaskStatus(world, TASK_ID);
+  assert.equal(status, 'queued', 'TASK_NOTIFICATION_SENT must not alter derived status');
+});
+
+test('System events: TASK_NOTIFICATION_SKIPPED does not change derived task status', () => {
+  const world = buildIndexedWorld(TASK_ID, ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED'], [
+    makeEvent('TASK_NOTIFICATION_SKIPPED')
+  ]);
+  const status = getTaskStatus(world, TASK_ID);
+  assert.equal(status, 'claimed', 'TASK_NOTIFICATION_SKIPPED must not alter derived status');
+});
+
+test('System events: TASK_NOTIFICATION_FAILED does not change derived task status', () => {
+  const world = buildIndexedWorld(
+    TASK_ID,
+    ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED', 'TASK_EXECUTE_STARTED', 'TASK_EXECUTE_FINISHED'],
+    [makeEvent('TASK_NOTIFICATION_FAILED')]
+  );
+  const status = getTaskStatus(world, TASK_ID);
+  assert.equal(status, 'awaiting_ack', 'TASK_NOTIFICATION_FAILED must not alter derived status');
+});
+
+test('System events: all three system events together do not change derived task status', () => {
+  const systemEvents = SYSTEM_EVENTS.map((type) => makeEvent(type));
+  const world = buildIndexedWorld(
+    TASK_ID,
+    ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED'],
+    systemEvents
+  );
+  const status = getTaskStatus(world, TASK_ID);
+  assert.equal(status, 'claimed', 'Mixed system events must not alter derived status');
+});
+
+test('System events: status derived from lifecycle-only events matches status with system events mixed in', () => {
+  const lifecycleTypes = ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED', 'TASK_EXECUTE_STARTED'];
+  const taskIdClean = 'test-clean';
+  const taskIdMixed = 'test-mixed';
+
+  ts = 2000;
+  const worldClean = buildIndexedWorld(taskIdClean, lifecycleTypes);
+  ts = 2000; // reset so timestamps are comparable
+  const worldMixed = buildIndexedWorld(taskIdMixed, lifecycleTypes, SYSTEM_EVENTS.map((type) => makeEvent(type, taskIdMixed)));
+
+  const statusClean = getTaskStatus(worldClean, taskIdClean);
+  const statusMixed = getTaskStatus(worldMixed, taskIdMixed);
+
+  assert.equal(statusMixed, statusClean, 'Derived status must be identical with or without system events in event list');
+});
+
+// ─── assertNoSystemEventInLifecycleDerivation invariant ──────────────────────
+
+test('System events: assertNoSystemEventInLifecycleDerivation throws when a system event is present', () => {
+  for (const type of SYSTEM_EVENTS) {
+    const events = [makeEvent('TASK_CREATED'), makeEvent(type)];
+    assert.throws(
+      () => assertNoSystemEventInLifecycleDerivation(events, 'test-context'),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /SYSTEM_EVENT_USED_IN_LIFECYCLE_DERIVATION/);
+        assert.match(err.message, new RegExp(type));
+        return true;
+      },
+      `assertNoSystemEventInLifecycleDerivation must throw for system event "${type}"`
+    );
+  }
+});
+
+test('System events: assertNoSystemEventInLifecycleDerivation does not throw for pure lifecycle events', () => {
+  const events = ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED'].map((type) => makeEvent(type));
+  assert.doesNotThrow(
+    () => assertNoSystemEventInLifecycleDerivation(events, 'test-context'),
+    'assertNoSystemEventInLifecycleDerivation must not throw for lifecycle-only events'
+  );
+});
+
+// ─── Specific scenario: CREATED → ENQUEUED → CLAIMED → EXECUTE_FINISHED → ACKED ──
+
+const TASK_SCENARIO = 'test-scenario-no-execute-started';
+
+test('Scenario: CREATED→ENQUEUED→CLAIMED→EXECUTE_FINISHED→ACKED derives status "completed"', () => {
+  // EXECUTE_STARTED is intentionally absent; the engine may ACK after EXECUTE_FINISHED
+  // regardless. The selector must derive status solely from the events present.
+  const world = buildIndexedWorld(TASK_SCENARIO, [
+    'TASK_CREATED',
+    'TASK_ENQUEUED',
+    'TASK_CLAIMED',
+    'TASK_EXECUTE_FINISHED',
+    'TASK_ACKED'
+  ]);
+  // Inject payload.status into the ACKED event so the derivation resolves to 'completed'.
+  world.eventsByTaskId.get(TASK_SCENARIO).at(-1).payload = { status: 'acknowledged' };
+
+  const status = getTaskStatus(world, TASK_SCENARIO);
+  assert.equal(status, 'completed', 'TASK_ACKED after EXECUTE_FINISHED must derive status "completed"');
+});
+
+test('Scenario: system events mixed into CREATED→ENQUEUED→CLAIMED→EXECUTE_FINISHED→ACKED do not change status', () => {
+  const systemEvents = SYSTEM_EVENTS.map((type) => makeEvent(type, TASK_SCENARIO));
+  const world = buildIndexedWorld(
+    TASK_SCENARIO,
+    ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED', 'TASK_EXECUTE_FINISHED', 'TASK_ACKED'],
+    systemEvents
+  );
+  world.eventsByTaskId.get(TASK_SCENARIO)
+    .find((e) => e.type === 'TASK_ACKED').payload = { status: 'acknowledged' };
+
+  const status = getTaskStatus(world, TASK_SCENARIO);
+  assert.equal(status, 'completed', 'System events must not alter the final "completed" status in this scenario');
+});
+
+test('Scenario: getLifecycleEvents for CREATED→ENQUEUED→CLAIMED→EXECUTE_FINISHED→ACKED with system events returns only the five lifecycle events', () => {
+  const systemEvents = SYSTEM_EVENTS.map((type) => makeEvent(type, TASK_SCENARIO));
+  const lifecycleTypes = ['TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED', 'TASK_EXECUTE_FINISHED', 'TASK_ACKED'];
+  const world = buildIndexedWorld(TASK_SCENARIO, lifecycleTypes, systemEvents);
+
+  const rawEvents = world.eventsByTaskId.get(TASK_SCENARIO);
+  const lifecycleEvents = getLifecycleEvents(rawEvents);
+
+  assert.equal(lifecycleEvents.length, 5, 'Must return exactly 5 lifecycle events (system events excluded)');
+  assert.deepStrictEqual(
+    lifecycleEvents.map((e) => e.type),
+    lifecycleTypes,
+    'Lifecycle event order and types must match the original sequence'
+  );
+});
+
+// ─── TASK_NOTIFICATION_SENT and TASK_NOTIFICATION_FAILED: no impact on status or transitions ───
+
+const TASK_NOTIF = 'test-notif-isolation';
+const FULL_LIFECYCLE = [
+  'TASK_CREATED',
+  'TASK_ENQUEUED',
+  'TASK_CLAIMED',
+  'TASK_EXECUTE_STARTED',
+  'TASK_EXECUTE_FINISHED',
+  'TASK_ACKED'
+];
+
+function buildBaseWorld(taskId, extraEvents = []) {
+  const world = buildIndexedWorld(taskId, FULL_LIFECYCLE, extraEvents);
+  // Inject a valid ack payload so status resolves to 'completed'.
+  world.eventsByTaskId.get(taskId)
+    .find((e) => e.type === 'TASK_ACKED').payload = { status: 'acknowledged' };
+  return world;
+}
+
+test('Notification events: TASK_NOTIFICATION_SENT does not change task status', () => {
+  const clean = buildBaseWorld(TASK_NOTIF);
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_SENT', TASK_NOTIF)]);
+
+  assert.equal(
+    getTaskStatus(mixed, TASK_NOTIF),
+    getTaskStatus(clean, TASK_NOTIF),
+    'TASK_NOTIFICATION_SENT must not alter derived task status'
+  );
+});
+
+test('Notification events: TASK_NOTIFICATION_FAILED does not change task status', () => {
+  const clean = buildBaseWorld(TASK_NOTIF);
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_FAILED', TASK_NOTIF)]);
+
+  assert.equal(
+    getTaskStatus(mixed, TASK_NOTIF),
+    getTaskStatus(clean, TASK_NOTIF),
+    'TASK_NOTIFICATION_FAILED must not alter derived task status'
+  );
+});
+
+function nonNullKeys(obj) {
+  return Object.keys(obj).filter((k) => obj[k] !== null).sort();
+}
+
+test('Notification events: TASK_NOTIFICATION_SENT does not appear in transition timestamps', () => {
+  const clean = buildBaseWorld(TASK_NOTIF);
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_SENT', TASK_NOTIF)]);
+
+  // Timestamps differ between worlds (shared tick counter) but the set of
+  // populated transition slots must be identical — system events must not
+  // cause any extra slot to become non-null.
+  assert.deepStrictEqual(
+    nonNullKeys(getTaskTransitionTimestamps(mixed, TASK_NOTIF)),
+    nonNullKeys(getTaskTransitionTimestamps(clean, TASK_NOTIF)),
+    'TASK_NOTIFICATION_SENT must not populate additional transition slots'
+  );
+});
+
+test('Notification events: TASK_NOTIFICATION_FAILED does not appear in transition timestamps', () => {
+  const clean = buildBaseWorld(TASK_NOTIF);
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_FAILED', TASK_NOTIF)]);
+
+  assert.deepStrictEqual(
+    nonNullKeys(getTaskTransitionTimestamps(mixed, TASK_NOTIF)),
+    nonNullKeys(getTaskTransitionTimestamps(clean, TASK_NOTIF)),
+    'TASK_NOTIFICATION_FAILED must not populate additional transition slots'
+  );
+});
+
+test('Notification events: TASK_NOTIFICATION_SENT does not appear in task timeline entries', () => {
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_SENT', TASK_NOTIF)]);
+
+  const timeline = getTaskTimeline(mixed, TASK_NOTIF);
+  const types = timeline.map((e) => e.type);
+
+  assert.ok(
+    !types.includes('TASK_NOTIFICATION_SENT'),
+    'TASK_NOTIFICATION_SENT must not appear in the task timeline'
+  );
+  assert.equal(timeline.length, FULL_LIFECYCLE.length, 'Timeline must contain only the lifecycle events');
+});
+
+test('Notification events: TASK_NOTIFICATION_FAILED does not appear in task timeline entries', () => {
+  const mixed = buildBaseWorld(TASK_NOTIF, [makeEvent('TASK_NOTIFICATION_FAILED', TASK_NOTIF)]);
+
+  const timeline = getTaskTimeline(mixed, TASK_NOTIF);
+  const types = timeline.map((e) => e.type);
+
+  assert.ok(
+    !types.includes('TASK_NOTIFICATION_FAILED'),
+    'TASK_NOTIFICATION_FAILED must not appear in the task timeline'
+  );
+  assert.equal(timeline.length, FULL_LIFECYCLE.length, 'Timeline must contain only the lifecycle events');
+});
+
+test('Notification events: both TASK_NOTIFICATION_SENT and TASK_NOTIFICATION_FAILED together leave status and transition slots unchanged', () => {
+  const clean = buildBaseWorld(TASK_NOTIF);
+  const mixed = buildBaseWorld(TASK_NOTIF, [
+    makeEvent('TASK_NOTIFICATION_SENT', TASK_NOTIF),
+    makeEvent('TASK_NOTIFICATION_FAILED', TASK_NOTIF)
+  ]);
+
+  assert.equal(
+    getTaskStatus(mixed, TASK_NOTIF),
+    getTaskStatus(clean, TASK_NOTIF),
+    'Status must be identical with or without both notification events'
+  );
+  assert.deepStrictEqual(
+    nonNullKeys(getTaskTransitionTimestamps(mixed, TASK_NOTIF)),
+    nonNullKeys(getTaskTransitionTimestamps(clean, TASK_NOTIF)),
+    'Populated transition slots must be identical with or without both notification events'
+  );
+});

--- a/tests/ui-event-boundary.test.mjs
+++ b/tests/ui-event-boundary.test.mjs
@@ -1,0 +1,205 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * UI Layer Event-Parsing Boundary Tests
+ *
+ * Verifies that non-selector UI modules:
+ *   - do NOT access raw events directly (world.events, indexedWorld.events)
+ *   - do NOT inspect event.type (string comparisons on event types)
+ *   - do NOT access indexedWorld.eventsByTaskId or indexedWorld.eventsByWorkerId directly
+ *   - do NOT import deriveWorldState or getRawEvents
+ *
+ * All event interpretation must happen inside ui/selectors/.
+ *
+ * Method: static source analysis via regex on each non-selector JS file in ui/.
+ */
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const UI_DIR = join(ROOT, 'ui');
+const SELECTORS_DIR = join(UI_DIR, 'selectors');
+
+// ─── File collection ──────────────────────────────────────────────────────────
+
+/** Recursively collect .js files under a directory. */
+function collectJs(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...collectJs(full));
+    } else if (entry.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/** All JS files in ui/ that are NOT inside ui/selectors/. */
+const UI_PANEL_FILES = collectJs(UI_DIR).filter(
+  (f) => !f.startsWith(SELECTORS_DIR + '/')
+);
+
+/** All JS files in ui/selectors/ — these are ALLOWED to parse events. */
+const SELECTOR_FILES = collectJs(SELECTORS_DIR);
+
+function label(filePath) {
+  return relative(ROOT, filePath);
+}
+
+function src(filePath) {
+  return readFileSync(filePath, 'utf8');
+}
+
+// ─── Violation patterns ───────────────────────────────────────────────────────
+//
+// Each pattern has:
+//   re        — regex to detect the violation in source
+//   name      — human-readable violation name
+//   except    — optional function(line) returning true when the match is allowed
+//               (e.g. a comment, a string literal stub construction)
+
+const VIOLATIONS = [
+  {
+    name: 'direct event.type access',
+    re: /\bevent\.type\b/,
+    // A line that is purely a comment is not executable code.
+    except: (line) => /^\s*\*|^\s*\/\//.test(line)
+  },
+  {
+    name: 'direct indexedWorld.events access',
+    // Accessing the raw flat events array on a world/indexedWorld object.
+    re: /(?:indexedWorld|worldState|world)\s*(?:\?\.)?\s*\.events\b/,
+    except: (line) => /^\s*\*|^\s*\/\//.test(line)
+  },
+  {
+    name: 'direct indexedWorld.eventsByTaskId access',
+    // Reading FROM the map — constructing a stub `{ eventsByTaskId: new Map() }` is allowed.
+    re: /(?:indexedWorld|worldState|world)\s*(?:\?\.)?\s*\.eventsByTaskId\b/,
+    except: (line) => /^\s*\*|^\s*\/\//.test(line)
+  },
+  {
+    name: 'direct indexedWorld.eventsByWorkerId access',
+    re: /(?:indexedWorld|worldState|world)\s*(?:\?\.)?\s*\.eventsByWorkerId\b/,
+    except: (line) => /^\s*\*|^\s*\/\//.test(line)
+  },
+  {
+    name: 'import of deriveWorldState',
+    re: /import\s.*\bderiveWorldState\b/,
+    except: () => false
+  },
+  {
+    name: 'import of getRawEvents',
+    re: /import\s.*\bgetRawEvents\b/,
+    except: () => false
+  }
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function findViolations(filePath, violation) {
+  const lines = src(filePath).split('\n');
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (violation.re.test(line) && !violation.except(line)) {
+      hits.push({ lineNumber: i + 1, text: line.trim() });
+    }
+  }
+  return hits;
+}
+
+// ─── Sanity: panel file list is non-empty ─────────────────────────────────────
+
+test('UI boundary: panel file list is non-empty (test infra sanity)', () => {
+  assert.ok(UI_PANEL_FILES.length > 0,
+    'Expected to find at least one non-selector JS file in ui/ — check the path');
+});
+
+test('UI boundary: selector file list is non-empty (test infra sanity)', () => {
+  assert.ok(SELECTOR_FILES.length > 0,
+    'Expected to find at least one selector JS file in ui/selectors/ — check the path');
+});
+
+// ─── Panel files must not contain violation patterns ─────────────────────────
+
+for (const violation of VIOLATIONS) {
+  test(`UI boundary: no panel file contains "${violation.name}"`, () => {
+    const allHits = [];
+
+    for (const filePath of UI_PANEL_FILES) {
+      const hits = findViolations(filePath, violation);
+      for (const hit of hits) {
+        allHits.push(`  ${label(filePath)}:${hit.lineNumber}: ${hit.text}`);
+      }
+    }
+
+    assert.equal(allHits.length, 0,
+      `Violation "${violation.name}" detected in UI panel files:\n${allHits.join('\n')}`
+    );
+  });
+}
+
+// ─── Selector files ARE allowed to use these patterns ─────────────────────────
+// Confirm the test would actually catch violations if they existed, by verifying
+// the selectors (the only allowed location) do use these patterns.
+
+test('UI boundary: selectors do use event.type (confirms regex is not trivially empty)', () => {
+  const pattern = /\bevent\.type\b/;
+  const anySelector = SELECTOR_FILES.some((f) => pattern.test(src(f)));
+  assert.ok(anySelector,
+    'At least one selector must reference event.type — otherwise the detection regex is not meaningful');
+});
+
+test('UI boundary: selectors do access eventsByTaskId (confirms regex is not trivially empty)', () => {
+  const pattern = /\.eventsByTaskId\b/;
+  const anySelector = SELECTOR_FILES.some((f) => pattern.test(src(f)));
+  assert.ok(anySelector,
+    'At least one selector must access .eventsByTaskId — otherwise the detection regex is not meaningful');
+});
+
+// ─── Regression: adding a violation to a panel file must be caught ────────────
+
+test('UI boundary: violation detector catches event.type in synthetic source', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'direct event.type access');
+
+  // Simulate what findViolations would return for a file containing the pattern.
+  const fakeLines = [
+    'import { something } from "./selectors/taskSelectors.js";',
+    'if (event.type === "TASK_CREATED") { doSomething(); }',
+    '// event.type is allowed in comments',
+    '  * event.type docs',
+  ];
+  const hits = [];
+  for (let i = 0; i < fakeLines.length; i++) {
+    const line = fakeLines[i];
+    if (violation.re.test(line) && !violation.except(line)) {
+      hits.push(i + 1);
+    }
+  }
+
+  // Line 2 is a real violation; lines 3 and 4 are exempt (comments).
+  assert.deepStrictEqual(hits, [2],
+    'Detector must flag executable event.type access and ignore comment lines');
+});
+
+test('UI boundary: violation detector catches deriveWorldState import in synthetic source', () => {
+  const violation = VIOLATIONS.find((v) => v.name === 'import of deriveWorldState');
+  const fakeLines = [
+    'import { deriveWorldState } from "../core/world/deriveWorldState.js";',
+    'import { getTaskStatus } from "./selectors/taskSelectors.js";',
+    '// deriveWorldState is used in core, not here'
+  ];
+  const hits = [];
+  for (let i = 0; i < fakeLines.length; i++) {
+    const line = fakeLines[i];
+    if (violation.re.test(line) && !violation.except(line)) {
+      hits.push(i + 1);
+    }
+  }
+  assert.deepStrictEqual(hits, [1],
+    'Detector must flag direct import of deriveWorldState');
+});


### PR DESCRIPTION
PR 1 — Engine lifecycle invariant: ACK is terminal state

PR 2 — Engine invariant: ACK requires executionRecord

PR 3 — Engine invariant: worker cannot mutate lifecycle state

PR 4 — Engine invariant: executionRecord is mandatory for ACK

PR 5 — Event taxonomy whitelist enforcement

PR 6 — System event isolation (engine + selectors)

PR 7 — Selector purity test (determinism)

PR 8 — taskSelectors lifecycle correctness

PR 9 — taskSelectors system event immunity

PR 10 — metricsSelectors isolation test

PR 11 — anomalySelectors contract test

PR 12 — deriveWorldState boundary enforcement

PR 13 — UI selector-only consumption enforcement

PR 14 — renderer purity test

PR 15 — full system determinism test (golden trace)