### PR TITLE
feat: World Map Renderer foundation — named zones, pure placement map…

### DIFF
--- a/rendering/world-scene.js
+++ b/rendering/world-scene.js
@@ -9,10 +9,11 @@
  *  - Output: scene description — { zones, entities, connections }
  *
  * RULES (enforced by architecture):
- *  - No mapping logic
  *  - No event usage
  *  - No lifecycle logic
+ *  - No selector imports
  *  - Pure structural projection only
+ *  - Entity positions are resolved via worldZoneMapper (selector-derived descriptors only)
  */
 
 /**
@@ -21,6 +22,8 @@
  * @typedef {{ id: string, position: { x: number, y: number }, size: { width: number, height: number } }} LifecycleZone
  * @typedef {{ id: string, kind: string, position: { x: number, y: number }, size: { width: number, height: number } }} EnvironmentElement
  */
+
+import { placeEntityInWorldZone } from '../ui/config/worldZoneMapper.js';
 
 // ---------------------------------------------------------------------------
 // Static environment — purely visual, data-independent
@@ -227,15 +230,21 @@ export function buildWorldScene(graph) {
   const entities = nodes
     .filter((n) => n && n.type !== 'zone')
     .map((n) => {
-      const zoneId   = STATUS_ZONE_MAP[n.status] ?? null;
-      const zone     = zoneId ? _zoneById.get(zoneId) : null;
-      const position = zone
-        ? { x: zone.position.x, y: zone.position.y }
-        : { x: 0, y: 0 };
+      const meta = n.metadata && typeof n.metadata === 'object' ? n.metadata : {};
+
+      // Lifecycle zone — retained for backwards compatibility with existing consumers.
+      const zoneId = STATUS_ZONE_MAP[n.status] ?? null;
+
+      // World zone — named, semantically-meaningful placement via pure mapper.
+      // The descriptor contains only pre-computed selector fields; no raw events.
+      const placed = placeEntityInWorldZone({
+        type:     n.type,
+        status:   n.status,
+        taskType: meta.taskType ?? null,
+      });
 
       const visualState = VISUAL_STATE_MAP[n.status] ?? 'unknown';
 
-      const meta = n.metadata && typeof n.metadata === 'object' ? n.metadata : {};
       const metrics = {
         duration:  meta.duration  ?? null,
         queueTime: meta.queueTime ?? null,
@@ -258,7 +267,20 @@ export function buildWorldScene(graph) {
         : null;
       const uiAssets = Array.isArray(meta.uiAssets) ? meta.uiAssets : [];
 
-      return { id: n.id, type: n.type, zoneId, visualState, position, metrics, anomaly, deskId, currentTaskId, trendPanelState, uiAssets };
+      return {
+        id: n.id,
+        type: n.type,
+        zoneId,
+        worldZoneId: placed.zoneId,
+        visualState,
+        position: placed.position,
+        metrics,
+        anomaly,
+        deskId,
+        currentTaskId,
+        trendPanelState,
+        uiAssets,
+      };
     });
 
   const connections = edges.map((e) => ({ from: e.from, to: e.to, type: 'flow' }));

--- a/tests/world-zone-mapper.test.mjs
+++ b/tests/world-zone-mapper.test.mjs
@@ -149,13 +149,17 @@ test('placeEntityInWorldZone: position matches the declared zone coordinates', (
 test('placeEntityInWorldZone: same input always produces identical output (determinism)', () => {
   const cases = [
     { type: 'task',   status: 'created',       taskType: null },
-    { type: 'task',   status: 'claimed',        taskType: TASK_TYPE_TREND_RESEARCH },
-    { type: 'task',   status: 'executing',      taskType: TASK_TYPE_SHOPIFY },
-    { type: 'task',   status: 'awaiting_ack',   taskType: null },
-    { type: 'task',   status: 'failed',         taskType: null },
-    { type: 'worker', status: 'idle',           taskType: null },
-    { type: 'worker', status: 'working',        taskType: TASK_TYPE_IMAGE_RENDER },
-    { type: 'worker', status: 'delivering',     taskType: null },
+    { type: 'task',   status: 'queued',        taskType: null },
+    { type: 'task',   status: 'claimed',       taskType: TASK_TYPE_TREND_RESEARCH },
+    { type: 'task',   status: 'executing',     taskType: TASK_TYPE_SHOPIFY },
+    { type: 'task',   status: 'awaiting_ack',  taskType: null },
+    { type: 'task',   status: 'acknowledged',  taskType: null },
+    { type: 'task',   status: 'done',          taskType: null },
+    { type: 'task',   status: 'completed',     taskType: null },
+    { type: 'task',   status: 'failed',        taskType: null },
+    { type: 'worker', status: 'idle',          taskType: null },
+    { type: 'worker', status: 'working',       taskType: TASK_TYPE_IMAGE_RENDER },
+    { type: 'worker', status: 'delivering',    taskType: null },
   ];
   for (const entity of cases) {
     const first  = placeEntityInWorldZone(entity);
@@ -210,32 +214,46 @@ test('placeEntityInWorldZone: claimed task with null taskType falls back to engi
 });
 
 // ---------------------------------------------------------------------------
-// placeEntityInWorldZone — task lifecycle routing
+// placeEntityInWorldZone — exhaustive task lifecycle routing
+// Covers every status currently emitted by the engine/app.
 // ---------------------------------------------------------------------------
 
-test('placeEntityInWorldZone: created task → intakeDesk', () => {
-  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'created', taskType: null });
-  assert.strictEqual(zoneId, 'intakeDesk');
+const ALL_TASK_STATUS_ROUTES = [
+  // Intake / pre-execution
+  { status: 'created',      expectedZoneId: 'intakeDesk'    },
+  { status: 'queued',       expectedZoneId: 'intakeDesk'    },
+  // Active execution (type-neutral; type-specific routing is covered separately)
+  { status: 'claimed',      expectedZoneId: 'engineCrystal' },
+  { status: 'executing',    expectedZoneId: 'engineCrystal' },
+  // Awaiting acknowledgment
+  { status: 'awaiting_ack', expectedZoneId: 'approvalDesk'  },
+  // Terminal: archive
+  { status: 'acknowledged', expectedZoneId: 'archiveLibrary' },
+  { status: 'done',         expectedZoneId: 'archiveLibrary' },
+  { status: 'completed',    expectedZoneId: 'archiveLibrary' },
+  // Terminal: anomaly
+  { status: 'failed',       expectedZoneId: 'anomalyShelf'  },
+];
+
+test('placeEntityInWorldZone: all engine task statuses route to the correct zone (null taskType)', () => {
+  for (const { status, expectedZoneId } of ALL_TASK_STATUS_ROUTES) {
+    const { zoneId } = placeEntityInWorldZone({ type: 'task', status, taskType: null });
+    assert.strictEqual(zoneId, expectedZoneId,
+      `task status '${status}' must route to '${expectedZoneId}', got '${zoneId}'`);
+  }
 });
 
-test('placeEntityInWorldZone: queued task → intakeDesk', () => {
-  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'queued', taskType: null });
-  assert.strictEqual(zoneId, 'intakeDesk');
-});
-
-test('placeEntityInWorldZone: awaiting_ack task → approvalDesk', () => {
-  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'awaiting_ack', taskType: null });
-  assert.strictEqual(zoneId, 'approvalDesk');
-});
-
-test('placeEntityInWorldZone: completed task → archiveLibrary', () => {
-  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'completed', taskType: null });
+test('placeEntityInWorldZone: task status "done" → archiveLibrary', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'done', taskType: null });
   assert.strictEqual(zoneId, 'archiveLibrary');
 });
 
-test('placeEntityInWorldZone: failed task → anomalyShelf', () => {
-  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'failed', taskType: null });
-  assert.strictEqual(zoneId, 'anomalyShelf');
+test('placeEntityInWorldZone: terminal archive statuses (acknowledged, done, completed) all map to archiveLibrary', () => {
+  for (const status of ['acknowledged', 'done', 'completed']) {
+    const { zoneId } = placeEntityInWorldZone({ type: 'task', status, taskType: null });
+    assert.strictEqual(zoneId, 'archiveLibrary',
+      `status '${status}' must map to archiveLibrary`);
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/world-zone-mapper.test.mjs
+++ b/tests/world-zone-mapper.test.mjs
@@ -1,0 +1,379 @@
+/**
+ * world-zone-mapper.test.mjs
+ *
+ * Tests for:
+ *  - WORLD_ZONES config completeness and immutability
+ *  - placeEntityInWorldZone determinism
+ *  - Projection boundary: mapper never inspects raw event payloads or world indexes
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { WORLD_ZONES, WORLD_ZONE_IDS } from '../ui/config/worldZones.js';
+import { placeEntityInWorldZone } from '../ui/config/worldZoneMapper.js';
+import {
+  TASK_TYPE_DISCORD,
+  TASK_TYPE_SHOPIFY,
+  TASK_TYPE_IMAGE_RENDER,
+  TASK_TYPE_TREND_RESEARCH,
+} from '../core/constants.js';
+
+// ---------------------------------------------------------------------------
+// WORLD_ZONES config
+// ---------------------------------------------------------------------------
+
+test('WORLD_ZONES: all 9 required named zones are present', () => {
+  const required = [
+    'intakeDesk', 'engineCrystal', 'researchDesk', 'shopifyDesk',
+    'renderDesk', 'supportDesk', 'approvalDesk', 'anomalyShelf', 'archiveLibrary',
+  ];
+  for (const id of required) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(WORLD_ZONES, id),
+      `WORLD_ZONES must contain zone '${id}'`
+    );
+  }
+});
+
+test('WORLD_ZONES: WORLD_ZONE_IDS enumerates all zone ids', () => {
+  assert.deepStrictEqual(
+    [...WORLD_ZONE_IDS].sort(),
+    Object.keys(WORLD_ZONES).sort()
+  );
+});
+
+test('WORLD_ZONES: every zone has a string id matching its key', () => {
+  for (const [key, zone] of Object.entries(WORLD_ZONES)) {
+    assert.strictEqual(typeof zone.id, 'string', `zone '${key}' must have string id`);
+    assert.strictEqual(zone.id, key, `zone id must match its key ('${key}')`);
+  }
+});
+
+test('WORLD_ZONES: every zone has finite numeric position coordinates', () => {
+  for (const [key, zone] of Object.entries(WORLD_ZONES)) {
+    assert.ok(
+      Number.isFinite(zone.position.x) && Number.isFinite(zone.position.y),
+      `zone '${key}' must have finite x and y position`
+    );
+  }
+});
+
+test('WORLD_ZONES: every zone has positive numeric size', () => {
+  for (const [key, zone] of Object.entries(WORLD_ZONES)) {
+    assert.ok(
+      Number.isFinite(zone.size.width)  && zone.size.width  > 0 &&
+      Number.isFinite(zone.size.height) && zone.size.height > 0,
+      `zone '${key}' must have positive width and height`
+    );
+  }
+});
+
+test('WORLD_ZONES: config object is frozen (immutable)', () => {
+  assert.ok(Object.isFrozen(WORLD_ZONES), 'WORLD_ZONES must be frozen');
+  for (const [key, zone] of Object.entries(WORLD_ZONES)) {
+    assert.ok(Object.isFrozen(zone),          `zone '${key}' must be frozen`);
+    assert.ok(Object.isFrozen(zone.position), `zone '${key}'.position must be frozen`);
+    assert.ok(Object.isFrozen(zone.size),     `zone '${key}'.size must be frozen`);
+  }
+});
+
+test('WORLD_ZONES: mutation of config throws in strict mode', () => {
+  assert.throws(
+    () => { WORLD_ZONES.intakeDesk = {}; },
+    TypeError,
+    'assigning to a frozen property must throw TypeError'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — output contract
+// ---------------------------------------------------------------------------
+
+test('placeEntityInWorldZone: returns an object with zoneId string and position {x,y}', () => {
+  const result = placeEntityInWorldZone({ type: 'task', status: 'created', taskType: null });
+  assert.strictEqual(typeof result.zoneId, 'string');
+  assert.ok(Number.isFinite(result.position.x), 'position.x must be finite');
+  assert.ok(Number.isFinite(result.position.y), 'position.y must be finite');
+});
+
+test('placeEntityInWorldZone: zoneId always maps to a known WORLD_ZONES entry', () => {
+  const cases = [
+    { type: 'task',   status: 'created',       taskType: null },
+    { type: 'task',   status: 'queued',         taskType: TASK_TYPE_SHOPIFY },
+    { type: 'task',   status: 'claimed',        taskType: TASK_TYPE_TREND_RESEARCH },
+    { type: 'task',   status: 'executing',      taskType: TASK_TYPE_IMAGE_RENDER },
+    { type: 'task',   status: 'awaiting_ack',   taskType: null },
+    { type: 'task',   status: 'completed',      taskType: null },
+    { type: 'task',   status: 'failed',         taskType: null },
+    { type: 'worker', status: 'idle',           taskType: null },
+    { type: 'worker', status: 'working',        taskType: TASK_TYPE_DISCORD },
+    { type: 'worker', status: 'delivering',     taskType: null },
+    { type: 'worker', status: 'error',          taskType: null },
+  ];
+  for (const entity of cases) {
+    const { zoneId } = placeEntityInWorldZone(entity);
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(WORLD_ZONES, zoneId),
+      `zoneId '${zoneId}' for ${JSON.stringify(entity)} must exist in WORLD_ZONES`
+    );
+  }
+});
+
+test('placeEntityInWorldZone: position matches the declared zone coordinates', () => {
+  for (const [, zone] of Object.entries(WORLD_ZONES)) {
+    // Fabricate an entity that should land in this zone and verify position matches.
+    // We test all task statuses and all task types to cover every branch.
+    const taskStatusToZone = {
+      created:     'intakeDesk',
+      queued:      'intakeDesk',
+      unknown:     'intakeDesk',
+      awaiting_ack: 'approvalDesk',
+      completed:   'archiveLibrary',
+      acknowledged: 'archiveLibrary',
+      failed:      'anomalyShelf',
+    };
+    for (const [status, expectedZoneId] of Object.entries(taskStatusToZone)) {
+      if (expectedZoneId !== zone.id) continue;
+      const { position } = placeEntityInWorldZone({ type: 'task', status, taskType: null });
+      assert.strictEqual(position.x, zone.position.x, `x for status '${status}' must equal zone x`);
+      assert.strictEqual(position.y, zone.position.y, `y for status '${status}' must equal zone y`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — determinism
+// ---------------------------------------------------------------------------
+
+test('placeEntityInWorldZone: same input always produces identical output (determinism)', () => {
+  const cases = [
+    { type: 'task',   status: 'created',       taskType: null },
+    { type: 'task',   status: 'claimed',        taskType: TASK_TYPE_TREND_RESEARCH },
+    { type: 'task',   status: 'executing',      taskType: TASK_TYPE_SHOPIFY },
+    { type: 'task',   status: 'awaiting_ack',   taskType: null },
+    { type: 'task',   status: 'failed',         taskType: null },
+    { type: 'worker', status: 'idle',           taskType: null },
+    { type: 'worker', status: 'working',        taskType: TASK_TYPE_IMAGE_RENDER },
+    { type: 'worker', status: 'delivering',     taskType: null },
+  ];
+  for (const entity of cases) {
+    const first  = placeEntityInWorldZone(entity);
+    const second = placeEntityInWorldZone(entity);
+    assert.deepStrictEqual(first, second,
+      `placeEntityInWorldZone must return identical output for input ${JSON.stringify(entity)}`);
+  }
+});
+
+test('placeEntityInWorldZone: output does not share object references with WORLD_ZONES', () => {
+  const result = placeEntityInWorldZone({ type: 'task', status: 'created', taskType: null });
+  const zone   = WORLD_ZONES.intakeDesk;
+  assert.notStrictEqual(result.position, zone.position,
+    'returned position must be a new object, not the frozen zone reference');
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — task type routing
+// ---------------------------------------------------------------------------
+
+const TASK_TYPE_ZONE_PAIRS = [
+  [TASK_TYPE_TREND_RESEARCH, 'researchDesk'],
+  [TASK_TYPE_SHOPIFY,        'shopifyDesk'],
+  [TASK_TYPE_IMAGE_RENDER,   'renderDesk'],
+  [TASK_TYPE_DISCORD,        'supportDesk'],
+];
+
+test('placeEntityInWorldZone: claimed tasks route to the correct type-specific desk', () => {
+  for (const [taskType, expectedZoneId] of TASK_TYPE_ZONE_PAIRS) {
+    const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'claimed', taskType });
+    assert.strictEqual(zoneId, expectedZoneId,
+      `claimed task of type '${taskType}' must route to '${expectedZoneId}'`);
+  }
+});
+
+test('placeEntityInWorldZone: executing tasks route to same desk as claimed tasks', () => {
+  for (const [taskType, expectedZoneId] of TASK_TYPE_ZONE_PAIRS) {
+    const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'executing', taskType });
+    assert.strictEqual(zoneId, expectedZoneId,
+      `executing task of type '${taskType}' must route to '${expectedZoneId}'`);
+  }
+});
+
+test('placeEntityInWorldZone: claimed task with unknown type falls back to engineCrystal', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'claimed', taskType: 'UNKNOWN_TYPE' });
+  assert.strictEqual(zoneId, 'engineCrystal');
+});
+
+test('placeEntityInWorldZone: claimed task with null taskType falls back to engineCrystal', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'claimed', taskType: null });
+  assert.strictEqual(zoneId, 'engineCrystal');
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — task lifecycle routing
+// ---------------------------------------------------------------------------
+
+test('placeEntityInWorldZone: created task → intakeDesk', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'created', taskType: null });
+  assert.strictEqual(zoneId, 'intakeDesk');
+});
+
+test('placeEntityInWorldZone: queued task → intakeDesk', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'queued', taskType: null });
+  assert.strictEqual(zoneId, 'intakeDesk');
+});
+
+test('placeEntityInWorldZone: awaiting_ack task → approvalDesk', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'awaiting_ack', taskType: null });
+  assert.strictEqual(zoneId, 'approvalDesk');
+});
+
+test('placeEntityInWorldZone: completed task → archiveLibrary', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'completed', taskType: null });
+  assert.strictEqual(zoneId, 'archiveLibrary');
+});
+
+test('placeEntityInWorldZone: failed task → anomalyShelf', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'task', status: 'failed', taskType: null });
+  assert.strictEqual(zoneId, 'anomalyShelf');
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — worker routing
+// ---------------------------------------------------------------------------
+
+test('placeEntityInWorldZone: idle worker → engineCrystal', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'idle', taskType: null });
+  assert.strictEqual(zoneId, 'engineCrystal');
+});
+
+test('placeEntityInWorldZone: moving worker → engineCrystal', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'moving', taskType: null });
+  assert.strictEqual(zoneId, 'engineCrystal');
+});
+
+test('placeEntityInWorldZone: sitting worker → engineCrystal', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'sitting', taskType: null });
+  assert.strictEqual(zoneId, 'engineCrystal');
+});
+
+test('placeEntityInWorldZone: delivering worker → approvalDesk', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'delivering', taskType: null });
+  assert.strictEqual(zoneId, 'approvalDesk');
+});
+
+test('placeEntityInWorldZone: error worker → anomalyShelf', () => {
+  const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'error', taskType: null });
+  assert.strictEqual(zoneId, 'anomalyShelf');
+});
+
+test('placeEntityInWorldZone: working worker routes to task-type desk', () => {
+  for (const [taskType, expectedZoneId] of TASK_TYPE_ZONE_PAIRS) {
+    const { zoneId } = placeEntityInWorldZone({ type: 'worker', status: 'working', taskType });
+    assert.strictEqual(zoneId, expectedZoneId,
+      `working worker of type '${taskType}' must route to '${expectedZoneId}'`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// placeEntityInWorldZone — boundary: no raw event payload access
+// ---------------------------------------------------------------------------
+
+test('placeEntityInWorldZone: does not read .payload fields from the entity descriptor', () => {
+  // The descriptor must not need a payload field to resolve the zone.
+  // We pass an entity with an explicit payload-like field and verify it is ignored.
+  const withPayload = {
+    type: 'task',
+    status: 'created',
+    taskType: null,
+    payload: { status: 'completed', taskId: 'x', workerId: 'y', error: 'z' },
+  };
+  const { zoneId } = placeEntityInWorldZone(withPayload);
+  // Must resolve based on the descriptor's `status`, not the nested payload.
+  assert.strictEqual(zoneId, 'intakeDesk',
+    'mapper must use entity.status, not entity.payload.status');
+});
+
+test('placeEntityInWorldZone: does not read .events or .eventsByTaskId fields', () => {
+  // Pass a descriptor carrying spurious world-index fields; they must be ignored.
+  const withWorldIndex = {
+    type:    'task',
+    status:  'awaiting_ack',
+    taskType: null,
+    events:            [{ type: 'TASK_CREATED' }],
+    eventsByTaskId:    new Map([['t1', []]]),
+    eventsByWorkerId:  new Map(),
+  };
+  const { zoneId } = placeEntityInWorldZone(withWorldIndex);
+  assert.strictEqual(zoneId, 'approvalDesk',
+    'mapper must use descriptor fields only, ignoring world index structures');
+});
+
+test('placeEntityInWorldZone: gracefully handles null or missing entity', () => {
+  // Must return a valid default rather than throwing.
+  const fromNull = placeEntityInWorldZone(null);
+  assert.strictEqual(typeof fromNull.zoneId, 'string');
+  assert.ok(Number.isFinite(fromNull.position.x));
+  assert.ok(Number.isFinite(fromNull.position.y));
+
+  const fromEmpty = placeEntityInWorldZone({});
+  assert.strictEqual(typeof fromEmpty.zoneId, 'string');
+  assert.ok(Number.isFinite(fromEmpty.position.x));
+  assert.ok(Number.isFinite(fromEmpty.position.y));
+});
+
+// ---------------------------------------------------------------------------
+// Projection boundary: worldZoneMapper source must not reference forbidden APIs
+// ---------------------------------------------------------------------------
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const ROOT       = fileURLToPath(new URL('..', import.meta.url));
+const MAPPER_SRC = readFileSync(join(ROOT, 'ui/config/worldZoneMapper.js'), 'utf8');
+const ZONES_SRC  = readFileSync(join(ROOT, 'ui/config/worldZones.js'), 'utf8');
+
+function isComment(line) {
+  return /^\s*(\*|\/\/)/.test(line);
+}
+
+test('worldZoneMapper.js: does not import from ui/selectors/', () => {
+  const hits = MAPPER_SRC.split('\n')
+    .filter((line) => /import\s.*from\s+['"`][^'"`]*selectors[/\\][^'"`]*['"`]/.test(line) && !isComment(line));
+  assert.deepStrictEqual(hits, [],
+    'worldZoneMapper.js must not import from selectors — accepts pre-computed descriptors only');
+});
+
+test('worldZoneMapper.js: does not import deriveWorldState or getRawEvents', () => {
+  const hits = MAPPER_SRC.split('\n')
+    .filter((line) => /import.*\b(deriveWorldState|getRawEvents)\b/.test(line) && !isComment(line));
+  assert.deepStrictEqual(hits, [],
+    'worldZoneMapper.js must not import world-indexing helpers');
+});
+
+test('worldZoneMapper.js: does not access .eventsByTaskId or .eventsByWorkerId', () => {
+  const hits = MAPPER_SRC.split('\n')
+    .filter((line) => /\.\s*(eventsByTaskId|eventsByWorkerId)\b/.test(line) && !isComment(line));
+  assert.deepStrictEqual(hits, [],
+    'worldZoneMapper.js must not access raw world index structures');
+});
+
+test('worldZoneMapper.js: does not branch on canonical event type string literals', () => {
+  const CANONICAL = [
+    'TASK_CREATED', 'TASK_ENQUEUED', 'TASK_CLAIMED',
+    'TASK_EXECUTE_STARTED', 'TASK_EXECUTE_FINISHED', 'TASK_ACKED',
+  ];
+  const re = new RegExp(`['"\`](${CANONICAL.join('|')})['"\`]`);
+  const hits = MAPPER_SRC.split('\n')
+    .filter((line) => re.test(line) && !isComment(line));
+  assert.deepStrictEqual(hits, [],
+    'worldZoneMapper.js must not compare against canonical event type strings');
+});
+
+test('worldZones.js: does not import from rendering/ or selectors/', () => {
+  const hits = ZONES_SRC.split('\n')
+    .filter((line) => /import\s.*from\s+['"`][^'"`]*(rendering\/|selectors\/)[^'"`]*['"`]/.test(line) && !isComment(line));
+  assert.deepStrictEqual(hits, [],
+    'worldZones.js must not import from rendering/ or selectors/ — pure config only');
+});

--- a/ui/config/worldZoneMapper.js
+++ b/ui/config/worldZoneMapper.js
@@ -1,0 +1,119 @@
+/**
+ * worldZoneMapper.js
+ *
+ * Pure placement function: maps selector-derived entity descriptors to named
+ * Slothworld zones defined in worldZones.js.
+ *
+ * PROJECTION BOUNDARY (enforced by tests):
+ *  - Input MUST be a selector-derived entity descriptor — never raw events.
+ *  - The descriptor carries only pre-computed fields: { type, status, taskType }.
+ *  - This function MUST NOT read event payloads, event arrays, or world indexes.
+ *  - Output is always { zoneId: string, position: { x: number, y: number } }.
+ *  - The same input always produces the same output (pure / referentially transparent).
+ *
+ * Entity descriptor shapes:
+ *  Task:   { type: 'task',   status: string, taskType: string | null }
+ *  Worker: { type: 'worker', status: string, taskType: string | null }
+ *
+ *  status for tasks  — one of: created, queued, claimed, executing,
+ *                               awaiting_ack, completed, failed, unknown
+ *  status for workers — one of: idle, moving, sitting, working, delivering, error
+ *  taskType          — TASK_TYPE_* constant from core/constants.js, or null
+ */
+
+import { WORLD_ZONES } from './worldZones.js';
+import {
+  TASK_TYPE_DISCORD,
+  TASK_TYPE_SHOPIFY,
+  TASK_TYPE_IMAGE_RENDER,
+  TASK_TYPE_TREND_RESEARCH,
+} from '../../core/constants.js';
+
+// ---------------------------------------------------------------------------
+// Task type → claimed-state zone
+// One desk per work domain; unknown types fall back to engineCrystal.
+// ---------------------------------------------------------------------------
+
+const TASK_TYPE_ACTIVE_ZONE = Object.freeze({
+  [TASK_TYPE_TREND_RESEARCH]: 'researchDesk',
+  [TASK_TYPE_SHOPIFY]:        'shopifyDesk',
+  [TASK_TYPE_IMAGE_RENDER]:   'renderDesk',
+  [TASK_TYPE_DISCORD]:        'supportDesk',
+});
+
+// ---------------------------------------------------------------------------
+// Internal resolvers — no event access, no payload inspection
+// ---------------------------------------------------------------------------
+
+function resolveTaskZoneId(status, taskType) {
+  if (status === 'created' || status === 'queued' || status === 'unknown') {
+    return 'intakeDesk';
+  }
+
+  if (status === 'claimed' || status === 'executing') {
+    return TASK_TYPE_ACTIVE_ZONE[taskType] || 'engineCrystal';
+  }
+
+  if (status === 'awaiting_ack') {
+    return 'approvalDesk';
+  }
+
+  if (status === 'failed') {
+    return 'anomalyShelf';
+  }
+
+  if (status === 'completed' || status === 'acknowledged') {
+    return 'archiveLibrary';
+  }
+
+  return 'intakeDesk';
+}
+
+function resolveWorkerZoneId(status, taskType) {
+  if (status === 'working') {
+    return TASK_TYPE_ACTIVE_ZONE[taskType] || 'engineCrystal';
+  }
+
+  if (status === 'delivering') {
+    return 'approvalDesk';
+  }
+
+  if (status === 'error') {
+    return 'anomalyShelf';
+  }
+
+  // idle, moving, sitting → central hub
+  return 'engineCrystal';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a selector-derived entity descriptor to a named world zone and position.
+ *
+ * @param {{ type: string, status: string, taskType?: string | null }} entity
+ * @returns {{ zoneId: string, position: { x: number, y: number } }}
+ */
+export function placeEntityInWorldZone(entity) {
+  const type     = entity && typeof entity.type   === 'string' ? entity.type   : '';
+  const status   = entity && typeof entity.status === 'string' ? entity.status : '';
+  const taskType = entity && entity.taskType != null ? String(entity.taskType) : null;
+
+  let zoneId;
+  if (type === 'task') {
+    zoneId = resolveTaskZoneId(status, taskType);
+  } else if (type === 'worker') {
+    zoneId = resolveWorkerZoneId(status, taskType);
+  } else {
+    zoneId = 'intakeDesk';
+  }
+
+  const zone = WORLD_ZONES[zoneId] || WORLD_ZONES.intakeDesk;
+
+  return {
+    zoneId:   zone.id,
+    position: { x: zone.position.x, y: zone.position.y },
+  };
+}

--- a/ui/config/worldZoneMapper.js
+++ b/ui/config/worldZoneMapper.js
@@ -62,7 +62,7 @@ function resolveTaskZoneId(status, taskType) {
     return 'anomalyShelf';
   }
 
-  if (status === 'completed' || status === 'acknowledged') {
+  if (status === 'completed' || status === 'acknowledged' || status === 'done') {
     return 'archiveLibrary';
   }
 

--- a/ui/config/worldZones.js
+++ b/ui/config/worldZones.js
@@ -1,0 +1,140 @@
+/**
+ * worldZones.js
+ *
+ * Named semantic zones for the Slothworld treehouse command-center.
+ *
+ * PROJECTION BOUNDARY:
+ *  - This module is pure configuration: no events, no selectors, no lifecycle logic.
+ *  - All coordinates are absolute pixel positions on the 1060×520 canvas.
+ *  - Each zone declares which LIFECYCLE_ZONE (from rendering/world-scene.js) it
+ *    overlaps, for reference only — this module never imports from rendering/.
+ *  - Consumers MUST NOT read raw events to pick a zone; use worldZoneMapper.js
+ *    which accepts only selector-derived entity descriptors.
+ *
+ * Zone catalogue:
+ *  intakeDesk    — Newly-created tasks waiting to be enqueued (CREATED zone center)
+ *  engineCrystal — Central processing hub / the crystal tree (CENTRAL_STRUCTURE)
+ *  researchDesk  — TREND_RESEARCH task execution area (CLAIMED sub-slot)
+ *  shopifyDesk   — SHOPIFY task execution area (CLAIMED sub-slot)
+ *  renderDesk    — IMAGE_RENDER task execution area (CLAIMED sub-slot)
+ *  supportDesk   — DISCORD task execution area (ENQUEUED/CLAIMED transition)
+ *  approvalDesk  — Tasks awaiting acknowledgment (EXECUTE_FINISHED zone center)
+ *  anomalyShelf  — Failed tasks and incident indicators (upper ACKED zone)
+ *  archiveLibrary — Completed/acknowledged tasks (ACKED zone center)
+ *
+ * @typedef {{ id: string, label: string, position: { x: number, y: number }, size: { width: number, height: number }, lifecycleZoneId: string | null }} WorldZone
+ */
+
+/** @type {Readonly<Record<string, WorldZone>>} */
+export const WORLD_ZONES = Object.freeze({
+  /**
+   * Upper-left cozy alcove — tasks are placed here upon creation/enqueueing.
+   * Matches the center of the CREATED lifecycle zone (x:25–190, y:55–210).
+   */
+  intakeDesk: Object.freeze({
+    id:             'intakeDesk',
+    label:          'Intake Desk',
+    position:       Object.freeze({ x: 107, y: 133 }),
+    size:           Object.freeze({ width: 165, height: 155 }),
+    lifecycleZoneId: 'CREATED',
+  }),
+
+  /**
+   * Central tree / crystal hub — default anchor for the engine and idle workers.
+   * Centered on the CENTRAL_STRUCTURE (x:380–580, y:15–435).
+   */
+  engineCrystal: Object.freeze({
+    id:             'engineCrystal',
+    label:          'Engine Crystal',
+    position:       Object.freeze({ x: 480, y: 225 }),
+    size:           Object.freeze({ width: 200, height: 220 }),
+    lifecycleZoneId: null,
+  }),
+
+  /**
+   * Research station — TREND_RESEARCH tasks execute here.
+   * Upper sub-slot of the CLAIMED zone (x:218–376, y:140–360).
+   */
+  researchDesk: Object.freeze({
+    id:             'researchDesk',
+    label:          'Research Desk',
+    position:       Object.freeze({ x: 272, y: 185 }),
+    size:           Object.freeze({ width: 80, height: 70 }),
+    lifecycleZoneId: 'CLAIMED',
+  }),
+
+  /**
+   * Commerce station — SHOPIFY tasks execute here.
+   * Mid sub-slot of the CLAIMED zone.
+   */
+  shopifyDesk: Object.freeze({
+    id:             'shopifyDesk',
+    label:          'Shopify Desk',
+    position:       Object.freeze({ x: 310, y: 255 }),
+    size:           Object.freeze({ width: 80, height: 70 }),
+    lifecycleZoneId: 'CLAIMED',
+  }),
+
+  /**
+   * Rendering station — IMAGE_RENDER tasks execute here.
+   * Lower sub-slot of the CLAIMED zone.
+   */
+  renderDesk: Object.freeze({
+    id:             'renderDesk',
+    label:          'Render Desk',
+    position:       Object.freeze({ x: 272, y: 310 }),
+    size:           Object.freeze({ width: 80, height: 70 }),
+    lifecycleZoneId: 'CLAIMED',
+  }),
+
+  /**
+   * Support station — DISCORD tasks route through here.
+   * Lower-left area bridging ENQUEUED and CLAIMED (desk slot 3 position).
+   */
+  supportDesk: Object.freeze({
+    id:             'supportDesk',
+    label:          'Support Desk',
+    position:       Object.freeze({ x: 100, y: 355 }),
+    size:           Object.freeze({ width: 80, height: 70 }),
+    lifecycleZoneId: 'ENQUEUED',
+  }),
+
+  /**
+   * Approval station — tasks land here after execution, awaiting acknowledgment.
+   * Center of the EXECUTE_FINISHED lifecycle zone (x:578–736, y:140–360).
+   */
+  approvalDesk: Object.freeze({
+    id:             'approvalDesk',
+    label:          'Approval Desk',
+    position:       Object.freeze({ x: 657, y: 250 }),
+    size:           Object.freeze({ width: 158, height: 220 }),
+    lifecycleZoneId: 'EXECUTE_FINISHED',
+  }),
+
+  /**
+   * Anomaly shelf — failed tasks and incident cluster indicators live here.
+   * Upper portion of the ACKED vine-wall zone (x:806–1026, y:42–490).
+   */
+  anomalyShelf: Object.freeze({
+    id:             'anomalyShelf',
+    label:          'Anomaly Shelf',
+    position:       Object.freeze({ x: 860, y: 70 }),
+    size:           Object.freeze({ width: 110, height: 110 }),
+    lifecycleZoneId: 'ACKED',
+  }),
+
+  /**
+   * Archive library — successfully acknowledged tasks are shelved here.
+   * Center of the ACKED lifecycle zone (x:806–1026, y:42–490).
+   */
+  archiveLibrary: Object.freeze({
+    id:             'archiveLibrary',
+    label:          'Archive Library',
+    position:       Object.freeze({ x: 916, y: 266 }),
+    size:           Object.freeze({ width: 220, height: 338 }),
+    lifecycleZoneId: 'ACKED',
+  }),
+});
+
+/** All zone IDs in canonical order for enumeration. */
+export const WORLD_ZONE_IDS = Object.freeze(Object.keys(WORLD_ZONES));


### PR DESCRIPTION
…per, renderer integration

Introduces a semantic zone layer (WORLD_ZONES) over the existing lifecycle coordinate system so agents, tasks, incidents, and metrics are placed in named Slothworld zones rather than at ad hoc lifecycle-zone corner positions.

New files:
- ui/config/worldZones.js — 9 frozen named zones (intakeDesk, engineCrystal, researchDesk, shopifyDesk, renderDesk, supportDesk, approvalDesk, anomalyShelf, archiveLibrary) with absolute canvas coordinates and lifecycleZoneId references. No imports from rendering/ or selectors/.
- ui/config/worldZoneMapper.js — pure placeEntityInWorldZone({ type, status, taskType }) function. Input is selector-derived only; no event payloads, no world-index access, no canonical event-type string comparisons. Same input always returns same output (referentially transparent).
- tests/world-zone-mapper.test.mjs — 35 tests: zone completeness, freeze immutability, per-status and per-taskType routing, determinism, no shared references with config, no forbidden imports or payload access in source.

Modified:
- rendering/world-scene.js — buildWorldScene now calls placeEntityInWorldZone for each entity node. Entity position uses named zone center coordinates; entity gains worldZoneId field. Legacy zoneId (lifecycle zone) is retained for backwards compatibility. All renderer boundary tests continue to pass.

Architecture invariants preserved:
- TaskEngine lifecycle authority untouched
- deriveWorldState remains index-only
- UI consumes selector output only; mapper accepts pre-computed descriptors
- No raw event payload inspection anywhere in the new code