### PR TITLE
[UI] Themed World Projection pass — parchment cards, zone labels, ano…

### DIFF
--- a/rendering/agent-entity-renderer.js
+++ b/rendering/agent-entity-renderer.js
@@ -336,22 +336,66 @@ export function renderAgentEntity(ctx, component, frameNow) {
     ctx.stroke();
   }
 
-  // Name tag — always shown above the sprite.
+  // Nameplate badge — warm parchment plaque above the sprite.
+  // Visual convention (Themed World Projection): rounded badge with amber border
+  // and warm cream text, replacing the plain debug-style dark rectangle.
   if (component.id) {
     const tagOffsetDx = offsets.dx;
     const tagOffsetDy = offsets.dy;
     const tagH  = sizes ? sizes.h : (spriteConfigs?.agent?.height ?? 54);
     const tagX  = x + tagOffsetDx;
-    const tagY  = y - tagH / 2 + tagOffsetDy - 4;
-    ctx.font         = 'bold 9px monospace';
+    const tagY  = y - tagH / 2 + tagOffsetDy - 6;
+
+    ctx.save();
+    ctx.font = 'bold 9px monospace';
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'bottom';
-    ctx.fillStyle    = 'rgba(0,0,0,0.55)';
-    const metrics    = ctx.measureText(component.id);
-    const pad        = 3;
-    ctx.fillRect(tagX - metrics.width / 2 - pad, tagY - 11, metrics.width + pad * 2, 13);
+
+    const textW = ctx.measureText(component.id).width;
+    const padX  = 4;
+    const padY  = 2;
+    const bw    = textW + padX * 2;
+    const bh    = 11 + padY * 2;
+    const bx    = tagX - bw / 2;
+    const by    = tagY - bh;
+    const cr    = 3;
+
+    // Badge background — warm dark parchment
+    ctx.beginPath();
+    ctx.moveTo(bx + cr, by);
+    ctx.lineTo(bx + bw - cr, by);
+    ctx.quadraticCurveTo(bx + bw, by, bx + bw, by + cr);
+    ctx.lineTo(bx + bw, by + bh - cr);
+    ctx.quadraticCurveTo(bx + bw, by + bh, bx + bw - cr, by + bh);
+    ctx.lineTo(bx + cr, by + bh);
+    ctx.quadraticCurveTo(bx, by + bh, bx, by + bh - cr);
+    ctx.lineTo(bx, by + cr);
+    ctx.quadraticCurveTo(bx, by, bx + cr, by);
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(26, 14, 4, 0.82)';
+    ctx.fill();
+
+    // Badge border — amber-brown accent
+    ctx.beginPath();
+    ctx.moveTo(bx + cr, by);
+    ctx.lineTo(bx + bw - cr, by);
+    ctx.quadraticCurveTo(bx + bw, by, bx + bw, by + cr);
+    ctx.lineTo(bx + bw, by + bh - cr);
+    ctx.quadraticCurveTo(bx + bw, by + bh, bx + bw - cr, by + bh);
+    ctx.lineTo(bx + cr, by + bh);
+    ctx.quadraticCurveTo(bx, by + bh, bx, by + bh - cr);
+    ctx.lineTo(bx, by + cr);
+    ctx.quadraticCurveTo(bx, by, bx + cr, by);
+    ctx.closePath();
+    ctx.strokeStyle = component.anomaly ? '#d07030' : '#8a6030';
+    ctx.lineWidth   = 0.8;
+    ctx.stroke();
+
+    // Agent ID text — warm cream
     ctx.fillStyle = '#e8d8b0';
     ctx.fillText(component.id, tagX, tagY);
+
+    ctx.restore();
   }
 }
 

--- a/rendering/task-chip-renderer.js
+++ b/rendering/task-chip-renderer.js
@@ -1,0 +1,275 @@
+/**
+ * task-chip-renderer.js
+ *
+ * Renders task-chip component descriptors as parchment/work-card style elements
+ * on a 2D canvas context.
+ *
+ * Visual conventions (Themed World Projection):
+ *  - work-card:    warm parchment card with a left-side state-colour bar
+ *  - anomaly badge: small warning triangle at the card's top-right corner
+ *  - ack-pulse:    soft amber ellipse ring pulsing around cards in 'processing' state
+ *
+ * CONTRACT:
+ *  - Input:  task-chip component descriptor from world-scene-adapter.js
+ *            { componentType, id, x, y, visualState, zoneId, metrics, anomaly }
+ *  - Output: canvas draw calls only — no return value, no state mutation
+ *
+ * RULES:
+ *  - All visual properties driven by visualState and anomaly fields only
+ *  - No lifecycle inference — visualState maps to colour/style, never to event type
+ *  - No selector or event access
+ *  - No Math.random — pulse animation uses Date.now() consistently with sibling renderers
+ *  - No DOM or asset dependencies — safe to import in headless test environments
+ */
+
+// ---------------------------------------------------------------------------
+// Card geometry constants
+// ---------------------------------------------------------------------------
+
+/** Card width in canvas pixels. */
+const CARD_W = 36;
+/** Card height in canvas pixels. */
+const CARD_H = 16;
+/** Left state-bar width in pixels. */
+const BAR_W  = 4;
+/** Card corner radius in pixels. */
+const CARD_R  = 2;
+
+// ---------------------------------------------------------------------------
+// Visual style tables — pure visual data, no lifecycle meaning
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-visualState parchment card fill and left state-bar colour.
+ *
+ * fill:      card background — warm parchment tinted by visual state
+ * barColor:  left-edge accent bar — same hue as the matching agent entity
+ *
+ * @type {Readonly<Record<string, Readonly<{ fill: string, barColor: string }>>>}
+ */
+export const CHIP_STYLES = Object.freeze({
+  idle:       Object.freeze({ fill: 'rgba(243,232,198,0.90)', barColor: '#8fbc8f' }),
+  waiting:    Object.freeze({ fill: 'rgba(245,236,196,0.90)', barColor: '#d4a017' }),
+  working:    Object.freeze({ fill: 'rgba(232,248,244,0.90)', barColor: '#00b8a9' }),
+  processing: Object.freeze({ fill: 'rgba(228,244,250,0.92)', barColor: '#7ec8c8' }),
+  completed:  Object.freeze({ fill: 'rgba(230,248,232,0.88)', barColor: '#4caf50' }),
+  error:      Object.freeze({ fill: 'rgba(250,232,232,0.90)', barColor: '#e53935' }),
+  unknown:    Object.freeze({ fill: 'rgba(240,234,220,0.85)', barColor: '#8d7b68' }),
+});
+
+/** Fallback style for visualState values not listed in CHIP_STYLES. */
+const FALLBACK_CHIP_STYLE = CHIP_STYLES.unknown;
+
+/** Card border — dark warm tone shared across all states. */
+const CARD_STROKE = '#7a5030';
+
+/** Task ID text colour — dark ink on parchment. */
+const CARD_TEXT_COLOR = '#3a1c08';
+
+/**
+ * Anomaly badge fill colours by severity level.
+ * Derives from component.anomaly.severity — no event field reading.
+ *
+ * @type {Readonly<{ high: string, default: string }>}
+ */
+export const ANOMALY_BADGE_COLORS = Object.freeze({
+  high:    '#d32f2f',
+  default: '#f57c00',
+});
+
+/** Ack-pulse ring colour for cards in the 'processing' visual state. */
+export const ACK_PULSE_COLOR = '#ffb300';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Trace a rounded rectangle path. Does not fill or stroke — caller does that.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @param {number} r  Corner radius
+ */
+function roundRect(ctx, x, y, w, h, r) {
+  const cr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + cr, y);
+  ctx.lineTo(x + w - cr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + cr);
+  ctx.lineTo(x + w, y + h - cr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - cr, y + h);
+  ctx.lineTo(x + cr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - cr);
+  ctx.lineTo(x, y + cr);
+  ctx.quadraticCurveTo(x, y, x + cr, y);
+  ctx.closePath();
+}
+
+// ---------------------------------------------------------------------------
+// Visual element drawers
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw a parchment work-card for one task entity.
+ *
+ * Card anatomy (left → right):
+ *   [ state bar | parchment body with short task ID ]
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} component  task-chip descriptor
+ * @param {number} x          canvas X (entity centre)
+ * @param {number} y          canvas Y (entity centre)
+ */
+function drawTaskCard(ctx, component, x, y) {
+  const chipStyle = CHIP_STYLES[component.visualState] ?? FALLBACK_CHIP_STYLE;
+  const cx = x - CARD_W / 2;
+  const cy = y - CARD_H / 2;
+
+  ctx.save();
+
+  // Card background
+  roundRect(ctx, cx, cy, CARD_W, CARD_H, CARD_R);
+  ctx.fillStyle = chipStyle.fill;
+  ctx.fill();
+
+  // Card border
+  roundRect(ctx, cx, cy, CARD_W, CARD_H, CARD_R);
+  ctx.strokeStyle = CARD_STROKE;
+  ctx.lineWidth   = 0.8;
+  ctx.stroke();
+
+  // Left state-colour bar (clipped to left rounded-corner shape)
+  roundRect(ctx, cx, cy, BAR_W + CARD_R, CARD_H, CARD_R);
+  ctx.fillStyle = chipStyle.barColor;
+  ctx.fill();
+  // Overwrite the right portion of the bar area with card fill to give clean edge
+  ctx.fillStyle = chipStyle.fill;
+  ctx.fillRect(cx + CARD_R, cy, BAR_W, CARD_H);
+
+  // Task ID label — last 6 chars of the id for brevity
+  if (component.id) {
+    const shortId = String(component.id).slice(-6);
+    ctx.font         = '7px monospace';
+    ctx.fillStyle    = CARD_TEXT_COLOR;
+    ctx.textAlign    = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(shortId, cx + BAR_W + (CARD_W - BAR_W) / 2, cy + CARD_H / 2);
+  }
+
+  ctx.restore();
+}
+
+/**
+ * Draw a pulsing amber ellipse ring around a card in the 'processing' state.
+ *
+ * The ring signals that the task has finished execution and is awaiting ACK.
+ * Pulse is sinusoidal, driven by Date.now() — consistent with renderUIOverlayLayer.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} x  Card centre X
+ * @param {number} y  Card centre Y
+ */
+function drawAckPulse(ctx, x, y) {
+  const now   = Date.now();
+  const phase = (now % 1600) / 1600;                         // 1.6 s cycle
+  const scale = 0.5 + 0.5 * Math.sin(phase * Math.PI * 2);
+  const alpha = 0.16 + 0.24 * scale;
+  const rX    = CARD_W / 2 + 3 + 2 * scale;
+  const rY    = CARD_H / 2 + 3 + 1 * scale;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.ellipse(x, y, rX, rY, 0, 0, Math.PI * 2);
+  ctx.strokeStyle = ACK_PULSE_COLOR;
+  ctx.lineWidth   = 1.5;
+  ctx.globalAlpha = alpha;
+  ctx.stroke();
+  ctx.restore();
+}
+
+/**
+ * Draw a small warning-triangle anomaly badge at the card's top-right corner.
+ *
+ * Badge colour derives from component.anomaly.severity — no event field reading.
+ * A white exclamation mark is drawn inside the triangle for readability.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} x       Card centre X
+ * @param {number} y       Card centre Y
+ * @param {object} anomaly { severity: string, type: string }
+ */
+function drawAnomalyBadge(ctx, x, y, anomaly) {
+  const color = anomaly.severity === 'high'
+    ? ANOMALY_BADGE_COLORS.high
+    : ANOMALY_BADGE_COLORS.default;
+
+  // Anchor at card top-right corner, offset outward slightly
+  const bx  = x + CARD_W / 2 + 1;
+  const by  = y - CARD_H / 2 - 1;
+  const ts  = 6;   // half-span of the triangle
+
+  ctx.save();
+
+  // Triangle fill
+  ctx.beginPath();
+  ctx.moveTo(bx,       by - ts);   // apex
+  ctx.lineTo(bx + ts,  by + ts);   // bottom-right
+  ctx.lineTo(bx - ts,  by + ts);   // bottom-left
+  ctx.closePath();
+  ctx.fillStyle   = color;
+  ctx.globalAlpha = 0.92;
+  ctx.fill();
+
+  // Exclamation mark (vertical stroke + dot)
+  ctx.globalAlpha = 0.96;
+  ctx.fillStyle   = '#ffffff';
+  ctx.fillRect(bx - 0.8, by - 0.5, 1.6, 4.5);   // vertical bar
+  ctx.fillRect(bx - 0.8, by + 4.8, 1.6, 1.6);   // dot
+
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Render all task-chip components as parchment work-cards.
+ *
+ * Draw order per entity (back → front):
+ *  1. Ack-pulse ring   (behind card; only for 'processing' visualState)
+ *  2. Parchment card   (background + state bar + ID label)
+ *  3. Anomaly badge    (top-right overlay; only when component.anomaly is set)
+ *
+ * @param {CanvasRenderingContext2D}           ctx
+ * @param {Array<object>}                      components       flat component list
+ * @param {Map<string, {x:number, y:number}>}  entityPositions  from buildEntityPositionMap()
+ */
+export function renderAllTaskChips(ctx, components, entityPositions) {
+  if (!ctx || !Array.isArray(components)) return;
+
+  for (const c of components) {
+    if (!c || c.componentType !== 'task-chip') continue;
+
+    const p = entityPositions && entityPositions.get(c.id);
+    const x = p ? p.x : (typeof c.x === 'number' ? c.x : 0);
+    const y = p ? p.y : (typeof c.y === 'number' ? c.y : 0);
+
+    // 1. Ack pulse — drawn first so it sits behind the card body
+    if (c.visualState === 'processing') {
+      drawAckPulse(ctx, x, y);
+    }
+
+    // 2. Card body
+    drawTaskCard(ctx, c, x, y);
+
+    // 3. Anomaly badge — drawn last so it overlays the card corner
+    if (c.anomaly) {
+      drawAnomalyBadge(ctx, x, y, c.anomaly);
+    }
+  }
+}

--- a/rendering/task-chip-renderer.js
+++ b/rendering/task-chip-renderer.js
@@ -7,7 +7,7 @@
  * Visual conventions (Themed World Projection):
  *  - work-card:    warm parchment card with a left-side state-colour bar
  *  - anomaly badge: small warning triangle at the card's top-right corner
- *  - ack-pulse:    soft amber ellipse ring pulsing around cards in 'processing' state
+ *  - processingPulse: soft amber ellipse ring pulsing around cards in 'processing' state
  *
  * CONTRACT:
  *  - Input:  task-chip component descriptor from world-scene-adapter.js
@@ -77,8 +77,8 @@ export const ANOMALY_BADGE_COLORS = Object.freeze({
   default: '#f57c00',
 });
 
-/** Ack-pulse ring colour for cards in the 'processing' visual state. */
-export const ACK_PULSE_COLOR = '#ffb300';
+/** Processing pulse ring colour for cards in the 'processing' visual state. */
+export const PROCESSING_PULSE_COLOR = '#ffb300';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -173,7 +173,7 @@ function drawTaskCard(ctx, component, x, y) {
  * @param {number} x  Card centre X
  * @param {number} y  Card centre Y
  */
-function drawAckPulse(ctx, x, y) {
+function drawProcessingPulse(ctx, x, y) {
   const now   = Date.now();
   const phase = (now % 1600) / 1600;                         // 1.6 s cycle
   const scale = 0.5 + 0.5 * Math.sin(phase * Math.PI * 2);
@@ -184,7 +184,7 @@ function drawAckPulse(ctx, x, y) {
   ctx.save();
   ctx.beginPath();
   ctx.ellipse(x, y, rX, rY, 0, 0, Math.PI * 2);
-  ctx.strokeStyle = ACK_PULSE_COLOR;
+  ctx.strokeStyle = PROCESSING_PULSE_COLOR;
   ctx.lineWidth   = 1.5;
   ctx.globalAlpha = alpha;
   ctx.stroke();
@@ -241,7 +241,7 @@ function drawAnomalyBadge(ctx, x, y, anomaly) {
  * Render all task-chip components as parchment work-cards.
  *
  * Draw order per entity (back → front):
- *  1. Ack-pulse ring   (behind card; only for 'processing' visualState)
+ *  1. Processing pulse ring (behind card; only for 'processing' visualState)
  *  2. Parchment card   (background + state bar + ID label)
  *  3. Anomaly badge    (top-right overlay; only when component.anomaly is set)
  *
@@ -259,9 +259,9 @@ export function renderAllTaskChips(ctx, components, entityPositions) {
     const x = p ? p.x : (typeof c.x === 'number' ? c.x : 0);
     const y = p ? p.y : (typeof c.y === 'number' ? c.y : 0);
 
-    // 1. Ack pulse — drawn first so it sits behind the card body
+    // 1. Processing pulse — drawn first so it sits behind the card body
     if (c.visualState === 'processing') {
-      drawAckPulse(ctx, x, y);
+      drawProcessingPulse(ctx, x, y);
     }
 
     // 2. Card body

--- a/rendering/world-scene-layer-renderer.js
+++ b/rendering/world-scene-layer-renderer.js
@@ -29,6 +29,8 @@ import { renderAllZones }          from './zone-renderer.js';
 import { renderAllConnections }     from './connection-renderer.js';
 import { renderAllAgentEntities }   from './agent-entity-renderer.js';
 import { buildEntityPositionMap }   from './zone-renderer.js';
+import { renderZoneLabels }         from './zone-label-renderer.js';
+import { renderAllTaskChips }       from './task-chip-renderer.js';
 import {
   renderBackgroundLayer,
   renderCoreLayer,
@@ -80,6 +82,12 @@ export function renderAllLayers(ctx, components, frame) {
   }
   renderZoneLayer(ctx, components);
 
+  // ── Layer 3.5: zone labels ──────────────────────────────────────────────
+  // Themed zone name badges (Intake Nook, Task Engine, …) drawn over the
+  // background image or procedural scene. Suppressed in debug mode since
+  // renderAllZones already shows raw zone IDs.
+  renderZoneLabels(ctx, components, isRenderDebug);
+
   // ── Layer 4: connection ─────────────────────────────────────────────────
   renderAllConnections(ctx, components, entityPositions, frame);
   renderConnectionLayer(ctx, components, entityPositions);
@@ -88,6 +96,12 @@ export function renderAllLayers(ctx, components, frame) {
   // Layer 5 agent rendering always runs and resolves positions through
   // entityPositions. Geometry fallback still applies while sprite assets load.
   renderAllAgentEntities(ctx, components, entityPositions, Date.now());
+
+  // ── Layer 5.5: task chips ───────────────────────────────────────────────
+  // Parchment work-cards for task entities: card body + ack-pulse + anomaly badge.
+  // Rendered after agents so cards appear in front of desk sprites.
+  renderAllTaskChips(ctx, components, entityPositions);
+
   // renderPropLayer remains suppressed in image mode. renderEffectLayer is a hard no-op.
   renderUIOverlayLayer(ctx, components, entityPositions);
 }

--- a/rendering/world-scene-layer-renderer.js
+++ b/rendering/world-scene-layer-renderer.js
@@ -98,7 +98,7 @@ export function renderAllLayers(ctx, components, frame) {
   renderAllAgentEntities(ctx, components, entityPositions, Date.now());
 
   // ── Layer 5.5: task chips ───────────────────────────────────────────────
-  // Parchment work-cards for task entities: card body + ack-pulse + anomaly badge.
+  // Parchment work-cards for task entities: card body + processing pulse + anomaly badge.
   // Rendered after agents so cards appear in front of desk sprites.
   renderAllTaskChips(ctx, components, entityPositions);
 

--- a/rendering/world-scene.js
+++ b/rendering/world-scene.js
@@ -203,6 +203,23 @@ export const VISUAL_STATE_MAP = Object.freeze({
   failed:           'error',
 });
 
+/**
+ * Themed zone labels for the Slothworld world projection.
+ *
+ * Maps each LIFECYCLE_ZONES id → themed display metadata used by
+ * zone-label-renderer.js. Pure visual data — no lifecycle meaning or
+ * event derivation.
+ *
+ * @type {Readonly<Record<string, Readonly<{ label: string, theme: string }>>>}
+ */
+export const WORLD_ZONES = Object.freeze({
+  CREATED:          Object.freeze({ label: 'Intake Nook',   theme: 'nook'    }),
+  ENQUEUED:         Object.freeze({ label: 'Task Engine',   theme: 'queue'   }),
+  CLAIMED:          Object.freeze({ label: 'Workshop',      theme: 'work'    }),
+  EXECUTE_FINISHED: Object.freeze({ label: 'Delivery Bay',  theme: 'deliver' }),
+  ACKED:            Object.freeze({ label: 'Archive Vault', theme: 'done'    }),
+});
+
 /** @type {Readonly<Map<string, LifecycleZone>>} */
 const _zoneById = new Map(LIFECYCLE_ZONES.map((z) => [z.id, z]));
 

--- a/rendering/world-scene.js
+++ b/rendering/world-scene.js
@@ -207,15 +207,15 @@ export const VISUAL_STATE_MAP = Object.freeze({
 });
 
 /**
- * Themed zone labels for the Slothworld world projection.
+ * Lifecycle zone display themes for the Slothworld world projection.
  *
  * Maps each LIFECYCLE_ZONES id → themed display metadata used by
- * zone-label-renderer.js. Pure visual data — no lifecycle meaning or
- * event derivation.
+ * zone-label-renderer.js. These are visual themes for lifecycle zones,
+ * distinct from semantic world zones in ui/config/worldZones.js.
  *
  * @type {Readonly<Record<string, Readonly<{ label: string, theme: string }>>>}
  */
-export const WORLD_ZONES = Object.freeze({
+export const LIFECYCLE_ZONE_THEMES = Object.freeze({
   CREATED:          Object.freeze({ label: 'Intake Nook',   theme: 'nook'    }),
   ENQUEUED:         Object.freeze({ label: 'Task Engine',   theme: 'queue'   }),
   CLAIMED:          Object.freeze({ label: 'Workshop',      theme: 'work'    }),

--- a/rendering/zone-label-renderer.js
+++ b/rendering/zone-label-renderer.js
@@ -5,7 +5,7 @@
  *
  * Visual convention (Themed World Projection):
  *  - Each lifecycle zone gets a small plaque/scroll label near its top edge
- *  - Labels use WORLD_ZONES themed names instead of raw zone IDs
+ *  - Labels use LIFECYCLE_ZONE_THEMES names instead of raw zone IDs
  *  - Hidden when debug mode is active (debug mode already shows raw IDs via renderAllZones)
  *
  * CONTRACT:
@@ -14,13 +14,13 @@
  *  - Output: canvas draw calls only — no return value, no state mutation
  *
  * RULES:
- *  - Only WORLD_ZONES data drives label content — no raw events, no selectors
+ *  - Only LIFECYCLE_ZONE_THEMES data drives label content — no raw events, no selectors
  *  - No lifecycle inference
  *  - No DOM or asset dependencies — safe to import in headless test environments
  *  - Pure structural projection: zone position/size fields are used directly
  */
 
-import { WORLD_ZONES } from './world-scene.js';
+import { LIFECYCLE_ZONE_THEMES } from './world-scene.js';
 
 // ---------------------------------------------------------------------------
 // Label badge visual style — parchment/plaque aesthetic
@@ -79,9 +79,9 @@ function roundRect(ctx, x, y, w, h, r) {
 /**
  * Draw a single themed zone label centred near the top edge of a zone.
  *
- * Label text is sourced exclusively from WORLD_ZONES[component.id].label —
+ * Label text is sourced exclusively from LIFECYCLE_ZONE_THEMES[component.id].label —
  * no raw event reading, no lifecycle inference.
- * Silently skipped when component.id is absent from WORLD_ZONES.
+ * Silently skipped when component.id is absent from LIFECYCLE_ZONE_THEMES.
  *
  * @param {CanvasRenderingContext2D} ctx
  * @param {object} component  zone-background descriptor { id, x, y, width, height }
@@ -89,7 +89,7 @@ function roundRect(ctx, x, y, w, h, r) {
 function renderZoneLabel(ctx, component) {
   if (!ctx || !component) return;
 
-  const zoneData = WORLD_ZONES[component.id];
+  const zoneData = LIFECYCLE_ZONE_THEMES[component.id];
   if (!zoneData) return;
 
   const label = zoneData.label;

--- a/rendering/zone-label-renderer.js
+++ b/rendering/zone-label-renderer.js
@@ -1,0 +1,153 @@
+/**
+ * zone-label-renderer.js
+ *
+ * Renders themed zone-name badges over lifecycle zone areas in the world canvas.
+ *
+ * Visual convention (Themed World Projection):
+ *  - Each lifecycle zone gets a small plaque/scroll label near its top edge
+ *  - Labels use WORLD_ZONES themed names instead of raw zone IDs
+ *  - Hidden when debug mode is active (debug mode already shows raw IDs via renderAllZones)
+ *
+ * CONTRACT:
+ *  - Input:  zone-background component descriptors from world-scene-adapter.js
+ *            { componentType, id, x, y, width, height }
+ *  - Output: canvas draw calls only — no return value, no state mutation
+ *
+ * RULES:
+ *  - Only WORLD_ZONES data drives label content — no raw events, no selectors
+ *  - No lifecycle inference
+ *  - No DOM or asset dependencies — safe to import in headless test environments
+ *  - Pure structural projection: zone position/size fields are used directly
+ */
+
+import { WORLD_ZONES } from './world-scene.js';
+
+// ---------------------------------------------------------------------------
+// Label badge visual style — parchment/plaque aesthetic
+// ---------------------------------------------------------------------------
+
+/**
+ * Zone label badge style constants.
+ * Warm dark background with amber border and cream text — treehouse palette.
+ *
+ * @type {Readonly<{ bgFill: string, bgStroke: string, textColor: string, font: string, cornerRadius: number, padX: number, padY: number, lineWidth: number }>}
+ */
+export const ZONE_LABEL_STYLE = Object.freeze({
+  bgFill:       'rgba(24, 14, 4, 0.78)',
+  bgStroke:     '#8a6230',
+  textColor:    '#e8d8b0',
+  font:         'bold 8px monospace',
+  cornerRadius: 3,
+  padX:         5,
+  padY:         3,
+  lineWidth:    1,
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Trace a rounded rectangle path. Does not fill or stroke — caller does that.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @param {number} r  Corner radius
+ */
+function roundRect(ctx, x, y, w, h, r) {
+  const cr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + cr, y);
+  ctx.lineTo(x + w - cr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + cr);
+  ctx.lineTo(x + w, y + h - cr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - cr, y + h);
+  ctx.lineTo(x + cr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - cr);
+  ctx.lineTo(x, y + cr);
+  ctx.quadraticCurveTo(x, y, x + cr, y);
+  ctx.closePath();
+}
+
+// ---------------------------------------------------------------------------
+// Per-zone label renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw a single themed zone label centred near the top edge of a zone.
+ *
+ * Label text is sourced exclusively from WORLD_ZONES[component.id].label —
+ * no raw event reading, no lifecycle inference.
+ * Silently skipped when component.id is absent from WORLD_ZONES.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} component  zone-background descriptor { id, x, y, width, height }
+ */
+function renderZoneLabel(ctx, component) {
+  if (!ctx || !component) return;
+
+  const zoneData = WORLD_ZONES[component.id];
+  if (!zoneData) return;
+
+  const label = zoneData.label;
+  const cx    = (typeof component.x     === 'number' ? component.x     : 0)
+              + (typeof component.width  === 'number' ? component.width  : 0) / 2;
+  const ty    = (typeof component.y     === 'number' ? component.y     : 0) + 8;
+
+  ctx.save();
+  ctx.font = ZONE_LABEL_STYLE.font;
+
+  const measured = ctx.measureText(label);
+  const tw = (measured && typeof measured.width === 'number') ? measured.width : label.length * 5;
+  const bw = tw + ZONE_LABEL_STYLE.padX * 2;
+  const bh = 8  + ZONE_LABEL_STYLE.padY * 2;  // 8px approximate cap-height
+  const bx = cx - bw / 2;
+  const by = ty;
+
+  // Badge background
+  roundRect(ctx, bx, by, bw, bh, ZONE_LABEL_STYLE.cornerRadius);
+  ctx.fillStyle = ZONE_LABEL_STYLE.bgFill;
+  ctx.fill();
+
+  // Badge border
+  roundRect(ctx, bx, by, bw, bh, ZONE_LABEL_STYLE.cornerRadius);
+  ctx.strokeStyle = ZONE_LABEL_STYLE.bgStroke;
+  ctx.lineWidth   = ZONE_LABEL_STYLE.lineWidth;
+  ctx.stroke();
+
+  // Label text
+  ctx.fillStyle    = ZONE_LABEL_STYLE.textColor;
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, cx, by + bh / 2);
+
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw themed zone labels for all zone-background components.
+ *
+ * When hideWhenDebug is true the function is a no-op — debug mode already
+ * renders raw zone IDs via renderAllZones(), so themed labels would compete.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {Array<object>}            components      flat component list from toRenderableComponents()
+ * @param {boolean}                  [hideWhenDebug] suppress rendering when debug overlay is active
+ */
+export function renderZoneLabels(ctx, components, hideWhenDebug) {
+  if (!ctx || !Array.isArray(components)) return;
+  if (hideWhenDebug) return;
+
+  for (const c of components) {
+    if (c && c.componentType === 'zone-background') {
+      renderZoneLabel(ctx, c);
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -681,6 +681,84 @@ canvas {
 }
 
 /* ─────────────────────────────────────────────────────────────────
+   Themed World Projection — sidebar visual enhancements
+   These classes augment existing .ocp-item and .rfp-item elements
+   with parchment card, zone label, anomaly badge, and ack-pulse styles.
+   All styles are purely cosmetic; no layout or behaviour changes.
+───────────────────────────────────────────────────────────────── */
+
+/* Zone label badge — small plaque shown next to section headers */
+.world-zone-label {
+  display: inline-block;
+  font: 700 8px/1 monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #e8d8b0;
+  background: rgba(24, 14, 4, 0.78);
+  border: 1px solid #8a6230;
+  border-radius: 3px;
+  padding: 2px 5px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* Parchment work-card — enhanced task item display */
+.ocp-item {
+  position: relative;
+  overflow: hidden;
+}
+
+/* Left state-bar accent on task items (mirrors canvas card bar) */
+.ocp-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--status-idle-neutral);
+  border-radius: 1px 0 0 1px;
+}
+
+.ocp-item.ocp-task-queued::before   { background: var(--status-idle-neutral); }
+.ocp-item.ocp-task-active::before,
+.ocp-item.ocp-task-pending::before  { background: var(--status-awaiting-ack-amber); }
+.ocp-item.ocp-task-done::before     { background: var(--status-delivering-green); }
+.ocp-item.ocp-task-failed::before   { background: var(--status-error-red); }
+
+/* Anomaly badge — small warning indicator on task/agent items */
+.anomaly-badge {
+  display: inline-block;
+  width: 14px;
+  height: 12px;
+  line-height: 12px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 700;
+  color: #fff;
+  background: var(--status-error-red);
+  border-radius: 2px;
+  margin-left: 4px;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.anomaly-badge.anomaly-warn {
+  background: #f57c00;
+}
+
+/* Ack-pulse animation — for items in awaiting_ack / processing state */
+@keyframes ackPulse {
+  0%   { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.20), 0 0 0 0 rgba(255, 179, 0, 0.00); }
+  40%  { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.55), 0 0 4px 2px rgba(255, 179, 0, 0.14); }
+  100% { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.20), 0 0 0 0 rgba(255, 179, 0, 0.00); }
+}
+
+.ocp-item.ocp-task-pending {
+  animation: ackPulse 1.8s ease-in-out infinite;
+}
+
+/* ─────────────────────────────────────────────────────────────────
    Responsive overrides — narrow viewport only
    Layout changes only; all color/type rules live in global scope above
 ───────────────────────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -683,7 +683,7 @@ canvas {
 /* ─────────────────────────────────────────────────────────────────
    Themed World Projection — sidebar visual enhancements
    These classes augment existing .ocp-item and .rfp-item elements
-   with parchment card, zone label, anomaly badge, and ack-pulse styles.
+   with parchment card, zone label, anomaly badge, and processing pulse styles.
    All styles are purely cosmetic; no layout or behaviour changes.
 ───────────────────────────────────────────────────────────────── */
 
@@ -747,15 +747,15 @@ canvas {
   background: #f57c00;
 }
 
-/* Ack-pulse animation — for items in awaiting_ack / processing state */
-@keyframes ackPulse {
+/* Processing pulse animation — for items in processing visual state */
+@keyframes processingPulse {
   0%   { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.20), 0 0 0 0 rgba(255, 179, 0, 0.00); }
   40%  { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.55), 0 0 4px 2px rgba(255, 179, 0, 0.14); }
   100% { box-shadow: inset 0 0 0 1px rgba(255, 179, 0, 0.20), 0 0 0 0 rgba(255, 179, 0, 0.00); }
 }
 
 .ocp-item.ocp-task-pending {
-  animation: ackPulse 1.8s ease-in-out infinite;
+  animation: processingPulse 1.8s ease-in-out infinite;
 }
 
 /* ─────────────────────────────────────────────────────────────────

--- a/tests/themed-world-projection.test.mjs
+++ b/tests/themed-world-projection.test.mjs
@@ -1,0 +1,481 @@
+/**
+ * themed-world-projection.test.mjs
+ *
+ * Contracts for the Themed World Projection pass:
+ *
+ *  1. WORLD_ZONES — structure and completeness
+ *  2. task-chip components — fields, visualState, zoneId, anomaly derivation
+ *  3. renderZoneLabels  — no raw event access; uses WORLD_ZONES only
+ *  4. renderAllTaskChips — no raw event access; uses visualState + anomaly only
+ *  5. Zone label / task chip renderers — safe on a mock canvas context
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  LIFECYCLE_ZONES,
+  VISUAL_STATE_MAP,
+  WORLD_ZONES,
+  buildWorldScene,
+} from '../rendering/world-scene.js';
+import { toRenderableComponents } from '../rendering/world-scene-adapter.js';
+import { buildEntityPositionMap }  from '../rendering/zone-renderer.js';
+import { renderZoneLabels, ZONE_LABEL_STYLE } from '../rendering/zone-label-renderer.js';
+import {
+  renderAllTaskChips,
+  CHIP_STYLES,
+  ANOMALY_BADGE_COLORS,
+  ACK_PULSE_COLOR,
+} from '../rendering/task-chip-renderer.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixture — a VisualWorldGraph with various task states
+// ---------------------------------------------------------------------------
+
+const GRAPH = Object.freeze({
+  nodes: [
+    { id: 't-created',   type: 'task', status: 'created',          metadata: { duration: null, queueTime: null, latency: null, incidents: [] } },
+    { id: 't-enqueued',  type: 'task', status: 'enqueued',         metadata: { duration: null, queueTime: 5,   latency: null, incidents: [] } },
+    { id: 't-claimed',   type: 'task', status: 'claimed',          metadata: { duration: null, queueTime: 3,   latency: null, incidents: [] } },
+    { id: 't-executing', type: 'task', status: 'executing',        metadata: { duration: null, queueTime: 4,   latency: null, incidents: [] } },
+    { id: 't-finished',  type: 'task', status: 'execute_finished', metadata: { duration: 200,  queueTime: 6,   latency: null, incidents: [] } },
+    { id: 't-completed', type: 'task', status: 'completed',        metadata: { duration: 310,  queueTime: 2,   latency: 1,    incidents: [] } },
+    { id: 't-failed',    type: 'task', status: 'failed',           metadata: { duration: 80,   queueTime: 3,   latency: null, incidents: [{ clusterType: 'timeout', severity: 'high' }] } },
+    { id: 'w-idle',      type: 'worker', status: 'idle',           metadata: {} },
+  ],
+  edges: [],
+  metadata: {},
+});
+
+function cloneGraph() { return JSON.parse(JSON.stringify(GRAPH)); }
+
+/** Run the pipeline up to component list. */
+function runComponents(graph) {
+  const scene = buildWorldScene(graph);
+  return toRenderableComponents(scene);
+}
+
+/** Build a minimal mock canvas context that records draw calls. */
+function makeMockCtx() {
+  const log  = [];
+  const store = {};
+  return new Proxy(store, {
+    get(t, p) {
+      if (p in t) return t[p];
+      return (...args) => { log.push({ method: String(p), args }); };
+    },
+    set(t, p, v) { t[p] = v; return true; },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. WORLD_ZONES structure
+// ---------------------------------------------------------------------------
+
+describe('WORLD_ZONES — structure and completeness', () => {
+
+  it('WORLD_ZONES exists and is frozen', () => {
+    assert.ok(WORLD_ZONES && typeof WORLD_ZONES === 'object', 'WORLD_ZONES must be an object');
+    assert.ok(Object.isFrozen(WORLD_ZONES), 'WORLD_ZONES must be frozen');
+  });
+
+  it('WORLD_ZONES has an entry for every LIFECYCLE_ZONES id', () => {
+    for (const zone of LIFECYCLE_ZONES) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(WORLD_ZONES, zone.id),
+        `WORLD_ZONES must have an entry for lifecycle zone "${zone.id}"`
+      );
+    }
+  });
+
+  it('each WORLD_ZONES entry has a non-empty label string', () => {
+    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
+      assert.ok(
+        typeof entry.label === 'string' && entry.label.length > 0,
+        `WORLD_ZONES["${id}"].label must be a non-empty string`
+      );
+    }
+  });
+
+  it('each WORLD_ZONES entry has a non-empty theme string', () => {
+    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
+      assert.ok(
+        typeof entry.theme === 'string' && entry.theme.length > 0,
+        `WORLD_ZONES["${id}"].theme must be a non-empty string`
+      );
+    }
+  });
+
+  it('all WORLD_ZONES entries are frozen', () => {
+    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
+      assert.ok(Object.isFrozen(entry), `WORLD_ZONES["${id}"] entry must be frozen`);
+    }
+  });
+
+  it('WORLD_ZONES covers exactly the same zone ids as LIFECYCLE_ZONES', () => {
+    const lifecycleIds = new Set(LIFECYCLE_ZONES.map((z) => z.id));
+    const worldIds     = new Set(Object.keys(WORLD_ZONES));
+    for (const id of lifecycleIds) {
+      assert.ok(worldIds.has(id), `WORLD_ZONES missing lifecycle zone id "${id}"`);
+    }
+    for (const id of worldIds) {
+      assert.ok(lifecycleIds.has(id), `WORLD_ZONES has unexpected zone id "${id}"`);
+    }
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 2. task-chip component contracts
+// ---------------------------------------------------------------------------
+
+describe('task-chip components — field contracts', () => {
+
+  it('every task node produces a task-chip component', () => {
+    const components = runComponents(cloneGraph());
+    const taskNodes  = GRAPH.nodes.filter((n) => n.type === 'task');
+    const chips      = components.filter((c) => c.componentType === 'task-chip');
+    assert.equal(chips.length, taskNodes.length,
+      'number of task-chip components must match number of task nodes');
+  });
+
+  it('task-chip components include id, x, y, visualState, zoneId, metrics, anomaly', () => {
+    const components = runComponents(cloneGraph());
+    const requiredKeys = ['id', 'x', 'y', 'visualState', 'zoneId', 'metrics', 'anomaly'];
+    for (const c of components.filter((c) => c.componentType === 'task-chip')) {
+      for (const key of requiredKeys) {
+        assert.ok(
+          Object.prototype.hasOwnProperty.call(c, key),
+          `task-chip "${c.id}" must have field "${key}"`
+        );
+      }
+    }
+  });
+
+  it('task-chip visualState is always a value from VISUAL_STATE_MAP or "unknown"', () => {
+    const components = runComponents(cloneGraph());
+    const allowed    = new Set([...Object.values(VISUAL_STATE_MAP), 'unknown']);
+    for (const c of components.filter((c) => c.componentType === 'task-chip')) {
+      assert.ok(
+        allowed.has(c.visualState),
+        `task-chip "${c.id}" has unexpected visualState "${c.visualState}"`
+      );
+    }
+  });
+
+  it('task-chip zoneId is always a LIFECYCLE_ZONES id or null', () => {
+    const components = runComponents(cloneGraph());
+    const allowed    = new Set([null, ...LIFECYCLE_ZONES.map((z) => z.id)]);
+    for (const c of components.filter((c) => c.componentType === 'task-chip')) {
+      assert.ok(
+        allowed.has(c.zoneId),
+        `task-chip "${c.id}" has unexpected zoneId "${c.zoneId}"`
+      );
+    }
+  });
+
+  it('anomaly badge derives from the anomaly field — not from raw events', () => {
+    const components = runComponents(cloneGraph());
+    const failedChip = components.find(
+      (c) => c.componentType === 'task-chip' && c.id === 't-failed'
+    );
+    assert.ok(failedChip, 'failed task must produce a task-chip component');
+    // anomaly derives from metadata.incidents via buildWorldScene — not from events
+    assert.ok(
+      failedChip.anomaly !== null && failedChip.anomaly !== undefined,
+      'failed task chip must have a non-null anomaly field'
+    );
+    assert.equal(typeof failedChip.anomaly.severity, 'string',
+      'anomaly.severity must be a string');
+  });
+
+  it('non-failed task chips have null anomaly', () => {
+    const components  = runComponents(cloneGraph());
+    const normalChips = components.filter(
+      (c) => c.componentType === 'task-chip' && c.id !== 't-failed'
+    );
+    for (const c of normalChips) {
+      assert.equal(c.anomaly, null,
+        `task-chip "${c.id}" without incidents must have null anomaly`);
+    }
+  });
+
+  it('processing visualState (execute_finished) is used for awaiting-ack marker', () => {
+    const components   = runComponents(cloneGraph());
+    const finishedChip = components.find(
+      (c) => c.componentType === 'task-chip' && c.id === 't-finished'
+    );
+    assert.ok(finishedChip, 'execute_finished task must produce a task-chip component');
+    assert.equal(finishedChip.visualState, 'processing',
+      'execute_finished task must map to "processing" visualState');
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 3. CHIP_STYLES and badge constants
+// ---------------------------------------------------------------------------
+
+describe('task-chip-renderer — visual style constants', () => {
+
+  it('CHIP_STYLES covers all visual states used by VISUAL_STATE_MAP', () => {
+    const usedStates = new Set(Object.values(VISUAL_STATE_MAP));
+    for (const state of usedStates) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(CHIP_STYLES, state),
+        `CHIP_STYLES must have an entry for visualState "${state}"`
+      );
+    }
+  });
+
+  it('every CHIP_STYLES entry has fill and barColor strings', () => {
+    for (const [state, style] of Object.entries(CHIP_STYLES)) {
+      assert.ok(typeof style.fill     === 'string', `CHIP_STYLES["${state}"].fill must be a string`);
+      assert.ok(typeof style.barColor === 'string', `CHIP_STYLES["${state}"].barColor must be a string`);
+    }
+  });
+
+  it('ANOMALY_BADGE_COLORS has high and default entries', () => {
+    assert.ok(typeof ANOMALY_BADGE_COLORS.high    === 'string', 'ANOMALY_BADGE_COLORS.high must be a string');
+    assert.ok(typeof ANOMALY_BADGE_COLORS.default === 'string', 'ANOMALY_BADGE_COLORS.default must be a string');
+  });
+
+  it('ACK_PULSE_COLOR is a non-empty string', () => {
+    assert.ok(typeof ACK_PULSE_COLOR === 'string' && ACK_PULSE_COLOR.length > 0,
+      'ACK_PULSE_COLOR must be a non-empty string');
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 4. ZONE_LABEL_STYLE constants
+// ---------------------------------------------------------------------------
+
+describe('zone-label-renderer — visual style constants', () => {
+
+  it('ZONE_LABEL_STYLE has the required visual fields', () => {
+    const required = ['bgFill', 'bgStroke', 'textColor', 'font', 'cornerRadius', 'padX', 'padY', 'lineWidth'];
+    for (const key of required) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(ZONE_LABEL_STYLE, key),
+        `ZONE_LABEL_STYLE must have field "${key}"`
+      );
+    }
+  });
+
+  it('ZONE_LABEL_STYLE is frozen', () => {
+    assert.ok(Object.isFrozen(ZONE_LABEL_STYLE), 'ZONE_LABEL_STYLE must be frozen');
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 5. renderZoneLabels — runs on mock ctx without crashing
+// ---------------------------------------------------------------------------
+
+describe('renderZoneLabels — mock-canvas execution', () => {
+
+  it('does not throw on a valid component list', () => {
+    const components = runComponents(cloneGraph());
+    const ctx        = makeMockCtx();
+    assert.doesNotThrow(() => renderZoneLabels(ctx, components, false));
+  });
+
+  it('does not throw when hideWhenDebug is true (no-op)', () => {
+    const components = runComponents(cloneGraph());
+    const ctx        = makeMockCtx();
+    assert.doesNotThrow(() => renderZoneLabels(ctx, components, true));
+  });
+
+  it('does not throw on an empty component list', () => {
+    const ctx = makeMockCtx();
+    assert.doesNotThrow(() => renderZoneLabels(ctx, [], false));
+  });
+
+  it('does not throw when ctx is null', () => {
+    const components = runComponents(cloneGraph());
+    assert.doesNotThrow(() => renderZoneLabels(null, components, false));
+  });
+
+  it('makes no draw calls when hideWhenDebug is true', () => {
+    const components = runComponents(cloneGraph());
+    const log        = [];
+    const ctx        = new Proxy({}, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => log.push({ method: String(p), args });
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+    renderZoneLabels(ctx, components, true);
+    assert.equal(log.length, 0, 'hideWhenDebug=true must produce zero draw calls');
+  });
+
+  it('produces draw calls for each zone-background when hideWhenDebug is false', () => {
+    const components = runComponents(cloneGraph());
+    const zoneBgs    = components.filter((c) => c.componentType === 'zone-background');
+    const log        = [];
+    const ctx        = new Proxy({ canvas: { width: 1060, height: 520 } }, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => { log.push({ method: String(p), args }); return 0; };
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+    renderZoneLabels(ctx, components, false);
+    // Each zone that has a WORLD_ZONES entry should produce at least one draw call
+    const zonesWithLabels = zoneBgs.filter((c) => Object.prototype.hasOwnProperty.call(WORLD_ZONES, c.id));
+    assert.ok(log.length > 0 || zonesWithLabels.length === 0,
+      'zone labels must produce draw calls for each zone with a WORLD_ZONES entry');
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 6. renderAllTaskChips — runs on mock ctx without crashing
+// ---------------------------------------------------------------------------
+
+describe('renderAllTaskChips — mock-canvas execution', () => {
+
+  it('does not throw on a valid component list', () => {
+    const components    = runComponents(cloneGraph());
+    const entityPos     = buildEntityPositionMap(components);
+    const ctx           = makeMockCtx();
+    assert.doesNotThrow(() => renderAllTaskChips(ctx, components, entityPos));
+  });
+
+  it('does not throw on an empty component list', () => {
+    const ctx = makeMockCtx();
+    assert.doesNotThrow(() => renderAllTaskChips(ctx, [], new Map()));
+  });
+
+  it('does not throw when ctx is null', () => {
+    const components = runComponents(cloneGraph());
+    assert.doesNotThrow(() => renderAllTaskChips(null, components, new Map()));
+  });
+
+  it('does not throw with a null entity position map', () => {
+    const components = runComponents(cloneGraph());
+    const ctx        = makeMockCtx();
+    assert.doesNotThrow(() => renderAllTaskChips(ctx, components, null));
+  });
+
+  it('produces draw calls for task-chip components', () => {
+    const components = runComponents(cloneGraph());
+    const entityPos  = buildEntityPositionMap(components);
+    const log        = [];
+    const ctx        = new Proxy({ canvas: { width: 1060, height: 520 } }, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => { log.push({ method: String(p), args }); return 0; };
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+    renderAllTaskChips(ctx, components, entityPos);
+    const taskChips = components.filter((c) => c.componentType === 'task-chip');
+    assert.ok(taskChips.length > 0, 'fixture must have task-chip components');
+    assert.ok(log.length > 0, 'rendering task chips must produce canvas draw calls');
+  });
+
+  it('ack pulse is drawn for processing visualState chips only', () => {
+    // Build a minimal scene with one processing chip only
+    const processingGraph = {
+      nodes: [
+        { id: 't-proc', type: 'task', status: 'execute_finished',
+          metadata: { duration: 100, queueTime: 2, latency: null, incidents: [] } },
+      ],
+      edges: [],
+      metadata: {},
+    };
+    const components = runComponents(processingGraph);
+    const entityPos  = buildEntityPositionMap(components);
+
+    // Count ellipse calls (used by drawAckPulse)
+    let ellipseCalls = 0;
+    const ctx = new Proxy({ canvas: { width: 1060, height: 520 } }, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => {
+          if (String(p) === 'ellipse') ellipseCalls++;
+          return 0;
+        };
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+
+    renderAllTaskChips(ctx, components, entityPos);
+    assert.ok(ellipseCalls > 0, 'processing task chip must invoke ellipse (ack pulse ring)');
+  });
+
+  it('anomaly badge draw calls occur for chips with anomaly data', () => {
+    const components = runComponents(cloneGraph());
+    const entityPos  = buildEntityPositionMap(components);
+    const failedChip = components.find(
+      (c) => c.componentType === 'task-chip' && c.id === 't-failed'
+    );
+    assert.ok(failedChip && failedChip.anomaly, 'failed chip must have anomaly set');
+
+    // Count fillRect calls — anomaly badge draws two fillRect (exclamation + dot)
+    let fillRectCalls = 0;
+    const ctx = new Proxy({ canvas: { width: 1060, height: 520 } }, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => {
+          if (String(p) === 'fillRect') fillRectCalls++;
+          return 0;
+        };
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+
+    renderAllTaskChips(ctx, components, entityPos);
+    assert.ok(fillRectCalls > 0,
+      'chips with anomaly must trigger fillRect draw calls for the anomaly badge');
+  });
+
+  it('no raw event keys appear in render call arguments', () => {
+    const components = runComponents(cloneGraph());
+    const entityPos  = buildEntityPositionMap(components);
+    const log        = [];
+    const ctx        = new Proxy({ canvas: { width: 1060, height: 520 } }, {
+      get(t, p) {
+        if (p in t) return t[p];
+        return (...args) => { log.push({ method: String(p), args }); return 0; };
+      },
+      set(t, p, v) { t[p] = v; return true; },
+    });
+
+    renderAllTaskChips(ctx, components, entityPos);
+
+    const argsStr = JSON.stringify(log.map((e) => e.args));
+    const forbidden = ['eventsByTaskId', 'eventsByWorkerId', 'rawEvents', 'TASK_CREATED', 'TASK_ACKED'];
+    for (const key of forbidden) {
+      assert.ok(!argsStr.includes(key),
+        `render call arguments must not contain "${key}" — rendering must not access raw events`);
+    }
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// 7. Two-pass determinism — same input → same task-chip output
+// ---------------------------------------------------------------------------
+
+describe('task-chip projection — determinism', () => {
+
+  it('two runs with the same graph produce identical task-chip component lists', () => {
+    const a = runComponents(cloneGraph()).filter((c) => c.componentType === 'task-chip');
+    const b = runComponents(cloneGraph()).filter((c) => c.componentType === 'task-chip');
+    assert.equal(JSON.stringify(a), JSON.stringify(b),
+      'task-chip component lists must be identical across runs');
+  });
+
+  it('zone-background component list is stable across runs', () => {
+    const a = runComponents(cloneGraph()).filter((c) => c.componentType === 'zone-background');
+    const b = runComponents(cloneGraph()).filter((c) => c.componentType === 'zone-background');
+    assert.equal(JSON.stringify(a), JSON.stringify(b),
+      'zone-background component lists must be identical across runs');
+  });
+
+});

--- a/tests/themed-world-projection.test.mjs
+++ b/tests/themed-world-projection.test.mjs
@@ -3,9 +3,9 @@
  *
  * Contracts for the Themed World Projection pass:
  *
- *  1. WORLD_ZONES — structure and completeness
+ *  1. LIFECYCLE_ZONE_THEMES — structure and completeness
  *  2. task-chip components — fields, visualState, zoneId, anomaly derivation
- *  3. renderZoneLabels  — no raw event access; uses WORLD_ZONES only
+ *  3. renderZoneLabels  — no raw event access; uses LIFECYCLE_ZONE_THEMES only
  *  4. renderAllTaskChips — no raw event access; uses visualState + anomaly only
  *  5. Zone label / task chip renderers — safe on a mock canvas context
  */
@@ -16,7 +16,7 @@ import assert from 'node:assert/strict';
 import {
   LIFECYCLE_ZONES,
   VISUAL_STATE_MAP,
-  WORLD_ZONES,
+  LIFECYCLE_ZONE_THEMES,
   buildWorldScene,
 } from '../rendering/world-scene.js';
 import { toRenderableComponents } from '../rendering/world-scene-adapter.js';
@@ -26,7 +26,7 @@ import {
   renderAllTaskChips,
   CHIP_STYLES,
   ANOMALY_BADGE_COLORS,
-  ACK_PULSE_COLOR,
+  PROCESSING_PULSE_COLOR,
 } from '../rendering/task-chip-renderer.js';
 
 // ---------------------------------------------------------------------------
@@ -70,57 +70,57 @@ function makeMockCtx() {
 }
 
 // ---------------------------------------------------------------------------
-// 1. WORLD_ZONES structure
+// 1. LIFECYCLE_ZONE_THEMES structure
 // ---------------------------------------------------------------------------
 
-describe('WORLD_ZONES — structure and completeness', () => {
+describe('LIFECYCLE_ZONE_THEMES — structure and completeness', () => {
 
-  it('WORLD_ZONES exists and is frozen', () => {
-    assert.ok(WORLD_ZONES && typeof WORLD_ZONES === 'object', 'WORLD_ZONES must be an object');
-    assert.ok(Object.isFrozen(WORLD_ZONES), 'WORLD_ZONES must be frozen');
+  it('LIFECYCLE_ZONE_THEMES exists and is frozen', () => {
+    assert.ok(LIFECYCLE_ZONE_THEMES && typeof LIFECYCLE_ZONE_THEMES === 'object', 'LIFECYCLE_ZONE_THEMES must be an object');
+    assert.ok(Object.isFrozen(LIFECYCLE_ZONE_THEMES), 'LIFECYCLE_ZONE_THEMES must be frozen');
   });
 
-  it('WORLD_ZONES has an entry for every LIFECYCLE_ZONES id', () => {
+  it('LIFECYCLE_ZONE_THEMES has an entry for every LIFECYCLE_ZONES id', () => {
     for (const zone of LIFECYCLE_ZONES) {
       assert.ok(
-        Object.prototype.hasOwnProperty.call(WORLD_ZONES, zone.id),
-        `WORLD_ZONES must have an entry for lifecycle zone "${zone.id}"`
+        Object.prototype.hasOwnProperty.call(LIFECYCLE_ZONE_THEMES, zone.id),
+        `LIFECYCLE_ZONE_THEMES must have an entry for lifecycle zone "${zone.id}"`
       );
     }
   });
 
-  it('each WORLD_ZONES entry has a non-empty label string', () => {
-    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
+  it('each LIFECYCLE_ZONE_THEMES entry has a non-empty label string', () => {
+    for (const [id, entry] of Object.entries(LIFECYCLE_ZONE_THEMES)) {
       assert.ok(
         typeof entry.label === 'string' && entry.label.length > 0,
-        `WORLD_ZONES["${id}"].label must be a non-empty string`
+        `LIFECYCLE_ZONE_THEMES["${id}"].label must be a non-empty string`
       );
     }
   });
 
-  it('each WORLD_ZONES entry has a non-empty theme string', () => {
-    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
+  it('each LIFECYCLE_ZONE_THEMES entry has a non-empty theme string', () => {
+    for (const [id, entry] of Object.entries(LIFECYCLE_ZONE_THEMES)) {
       assert.ok(
         typeof entry.theme === 'string' && entry.theme.length > 0,
-        `WORLD_ZONES["${id}"].theme must be a non-empty string`
+        `LIFECYCLE_ZONE_THEMES["${id}"].theme must be a non-empty string`
       );
     }
   });
 
-  it('all WORLD_ZONES entries are frozen', () => {
-    for (const [id, entry] of Object.entries(WORLD_ZONES)) {
-      assert.ok(Object.isFrozen(entry), `WORLD_ZONES["${id}"] entry must be frozen`);
+  it('all LIFECYCLE_ZONE_THEMES entries are frozen', () => {
+    for (const [id, entry] of Object.entries(LIFECYCLE_ZONE_THEMES)) {
+      assert.ok(Object.isFrozen(entry), `LIFECYCLE_ZONE_THEMES["${id}"] entry must be frozen`);
     }
   });
 
-  it('WORLD_ZONES covers exactly the same zone ids as LIFECYCLE_ZONES', () => {
+  it('LIFECYCLE_ZONE_THEMES covers exactly the same zone ids as LIFECYCLE_ZONES', () => {
     const lifecycleIds = new Set(LIFECYCLE_ZONES.map((z) => z.id));
-    const worldIds     = new Set(Object.keys(WORLD_ZONES));
+    const worldIds     = new Set(Object.keys(LIFECYCLE_ZONE_THEMES));
     for (const id of lifecycleIds) {
-      assert.ok(worldIds.has(id), `WORLD_ZONES missing lifecycle zone id "${id}"`);
+      assert.ok(worldIds.has(id), `LIFECYCLE_ZONE_THEMES missing lifecycle zone id "${id}"`);
     }
     for (const id of worldIds) {
-      assert.ok(lifecycleIds.has(id), `WORLD_ZONES has unexpected zone id "${id}"`);
+      assert.ok(lifecycleIds.has(id), `LIFECYCLE_ZONE_THEMES has unexpected zone id "${id}"`);
     }
   });
 
@@ -241,9 +241,9 @@ describe('task-chip-renderer — visual style constants', () => {
     assert.ok(typeof ANOMALY_BADGE_COLORS.default === 'string', 'ANOMALY_BADGE_COLORS.default must be a string');
   });
 
-  it('ACK_PULSE_COLOR is a non-empty string', () => {
-    assert.ok(typeof ACK_PULSE_COLOR === 'string' && ACK_PULSE_COLOR.length > 0,
-      'ACK_PULSE_COLOR must be a non-empty string');
+  it('PROCESSING_PULSE_COLOR is a non-empty string', () => {
+    assert.ok(typeof PROCESSING_PULSE_COLOR === 'string' && PROCESSING_PULSE_COLOR.length > 0,
+      'PROCESSING_PULSE_COLOR must be a non-empty string');
   });
 
 });
@@ -324,10 +324,10 @@ describe('renderZoneLabels — mock-canvas execution', () => {
       set(t, p, v) { t[p] = v; return true; },
     });
     renderZoneLabels(ctx, components, false);
-    // Each zone that has a WORLD_ZONES entry should produce at least one draw call
-    const zonesWithLabels = zoneBgs.filter((c) => Object.prototype.hasOwnProperty.call(WORLD_ZONES, c.id));
+    // Each zone that has a LIFECYCLE_ZONE_THEMES entry should produce at least one draw call
+    const zonesWithLabels = zoneBgs.filter((c) => Object.prototype.hasOwnProperty.call(LIFECYCLE_ZONE_THEMES, c.id));
     assert.ok(log.length > 0 || zonesWithLabels.length === 0,
-      'zone labels must produce draw calls for each zone with a WORLD_ZONES entry');
+      'zone labels must produce draw calls for each zone with a LIFECYCLE_ZONE_THEMES entry');
   });
 
 });
@@ -378,7 +378,7 @@ describe('renderAllTaskChips — mock-canvas execution', () => {
     assert.ok(log.length > 0, 'rendering task chips must produce canvas draw calls');
   });
 
-  it('ack pulse is drawn for processing visualState chips only', () => {
+  it('processing pulse is drawn for processing visualState chips only', () => {
     // Build a minimal scene with one processing chip only
     const processingGraph = {
       nodes: [
@@ -391,7 +391,7 @@ describe('renderAllTaskChips — mock-canvas execution', () => {
     const components = runComponents(processingGraph);
     const entityPos  = buildEntityPositionMap(components);
 
-    // Count ellipse calls (used by drawAckPulse)
+    // Count ellipse calls (used by drawProcessingPulse)
     let ellipseCalls = 0;
     const ctx = new Proxy({ canvas: { width: 1060, height: 520 } }, {
       get(t, p) {
@@ -405,7 +405,7 @@ describe('renderAllTaskChips — mock-canvas execution', () => {
     });
 
     renderAllTaskChips(ctx, components, entityPos);
-    assert.ok(ellipseCalls > 0, 'processing task chip must invoke ellipse (ack pulse ring)');
+    assert.ok(ellipseCalls > 0, 'processing task chip must invoke ellipse (processing pulse ring)');
   });
 
   it('anomaly badge draw calls occur for chips with anomaly data', () => {


### PR DESCRIPTION
…maly badges

Adds a visual/projection-only theming layer over the existing rendering pipeline. No TaskEngine, worker, provider, or lifecycle behaviour is changed.

Changes:
- rendering/world-scene.js: export WORLD_ZONES — maps LIFECYCLE_ZONES ids to themed display names (Intake Nook, Task Engine, Workshop, Delivery Bay, Archive Vault) consumed by zone-label-renderer.js
- rendering/zone-label-renderer.js (new): draws themed plaque badges at the top of each lifecycle zone; suppressed in debug mode which already shows raw IDs
- rendering/task-chip-renderer.js (new): renders task-chip components as warm parchment work-cards with a left state-colour bar; ack-pulse amber ring for 'processing' (awaiting-ack) entities; anomaly warning-triangle badge when component.anomaly is set — all derived from visualState/anomaly fields only
- rendering/world-scene-layer-renderer.js: adds layer 3.5 (zone labels) after zone sprites and layer 5.5 (task chips) after agent entities
- rendering/agent-entity-renderer.js: replaces plain monospace nameplate with a rounded dark badge; amber-brown border, warm cream text, anomaly tint
- style.css: adds .world-zone-label, .anomaly-badge, @keyframes ackPulse, and state-bar ::before accent strips on .ocp-item — mirrors canvas card style in the HTML sidebar
- tests/themed-world-projection.test.mjs (new): 35 tests across 7 suites covering WORLD_ZONES structure, task-chip contracts, renderer mock-canvas execution, anomaly badge/ack-pulse derivation, and two-pass determinism