### PR TITLE
feat(ui): add diegetic canvas inspection

### DIFF
--- a/rendering/agent-entity-renderer.js
+++ b/rendering/agent-entity-renderer.js
@@ -340,6 +340,7 @@ export function renderAgentEntity(ctx, component, frameNow) {
   // Visual convention (Themed World Projection): rounded badge with amber border
   // and warm cream text, replacing the plain debug-style dark rectangle.
   if (component.id) {
+    const isDebugMode = isRenderDebugEnabled();
     const tagOffsetDx = offsets.dx;
     const tagOffsetDy = offsets.dy;
     const tagH  = sizes ? sizes.h : (spriteConfigs?.agent?.height ?? 54);
@@ -351,11 +352,12 @@ export function renderAgentEntity(ctx, component, frameNow) {
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'bottom';
 
-    const textW = ctx.measureText(component.id).width;
+    const labelText = isDebugMode ? component.id : '';
+    const textW = isDebugMode ? ctx.measureText(labelText).width : 12;
     const padX  = 4;
     const padY  = 2;
     const bw    = textW + padX * 2;
-    const bh    = 11 + padY * 2;
+    const bh    = isDebugMode ? 11 + padY * 2 : 5;
     const bx    = tagX - bw / 2;
     const by    = tagY - bh;
     const cr    = 3;
@@ -372,7 +374,7 @@ export function renderAgentEntity(ctx, component, frameNow) {
     ctx.lineTo(bx, by + cr);
     ctx.quadraticCurveTo(bx, by, bx + cr, by);
     ctx.closePath();
-    ctx.fillStyle = 'rgba(26, 14, 4, 0.82)';
+    ctx.fillStyle = isDebugMode ? 'rgba(26, 14, 4, 0.82)' : 'rgba(26, 14, 4, 0.32)';
     ctx.fill();
 
     // Badge border — amber-brown accent
@@ -387,13 +389,17 @@ export function renderAgentEntity(ctx, component, frameNow) {
     ctx.lineTo(bx, by + cr);
     ctx.quadraticCurveTo(bx, by, bx + cr, by);
     ctx.closePath();
-    ctx.strokeStyle = component.anomaly ? '#d07030' : '#8a6030';
-    ctx.lineWidth   = 0.8;
+    ctx.strokeStyle = component.anomaly
+      ? (isDebugMode ? '#d07030' : 'rgba(208, 112, 48, 0.38)')
+      : (isDebugMode ? '#8a6030' : 'rgba(138, 96, 48, 0.28)');
+    ctx.lineWidth   = isDebugMode ? 0.8 : 0.5;
     ctx.stroke();
 
     // Agent ID text — warm cream
-    ctx.fillStyle = '#e8d8b0';
-    ctx.fillText(component.id, tagX, tagY);
+    if (isDebugMode) {
+      ctx.fillStyle = '#e8d8b0';
+      ctx.fillText(labelText, tagX, tagY);
+    }
 
     ctx.restore();
   }

--- a/rendering/canvas-hit-test.js
+++ b/rendering/canvas-hit-test.js
@@ -5,7 +5,10 @@
  * descriptors and computed entity positions supplied by the canvas pipeline.
  */
 
+import { ZONE_INDICATOR_ANCHORS } from './diegetic-indicator-renderer.js';
+
 const TASK_CHIP_BOUNDS = Object.freeze({ width: 36, height: 16 });
+const ZONE_INDICATOR_BOUNDS = Object.freeze({ width: 48, height: 48 });
 
 const AGENT_DESK_BOUNDS = Object.freeze({
   'desk-0': Object.freeze({ width: 180, height: 170, dx: 0,  dy: 0 }),
@@ -87,6 +90,20 @@ export function getComponentHitBounds(component, entityPositions) {
   return null;
 }
 
+function getZoneIndicatorHitBounds(component) {
+  const anchor = component && component.id ? ZONE_INDICATOR_ANCHORS[component.id] : null;
+  if (!anchor) {
+    return null;
+  }
+
+  return {
+    x: anchor.x - ZONE_INDICATOR_BOUNDS.width / 2,
+    y: anchor.y - ZONE_INDICATOR_BOUNDS.height / 2,
+    width: ZONE_INDICATOR_BOUNDS.width,
+    height: ZONE_INDICATOR_BOUNDS.height,
+  };
+}
+
 function resultForComponent(component, componentType, bounds) {
   return {
     entityId: component.id ?? null,
@@ -96,10 +113,12 @@ function resultForComponent(component, componentType, bounds) {
   };
 }
 
-export function hitTestRenderableComponents(components, point, entityPositions) {
+export function hitTestRenderableComponents(components, point, entityPositions, options = {}) {
   if (!Array.isArray(components) || !point || !isFiniteNumber(point.x) || !isFiniteNumber(point.y)) {
     return null;
   }
+
+  const debug = options && options.debug === true;
 
   for (let i = components.length - 1; i >= 0; i--) {
     const component = components[i];
@@ -122,9 +141,20 @@ export function hitTestRenderableComponents(components, point, entityPositions) 
   for (let i = components.length - 1; i >= 0; i--) {
     const component = components[i];
     if (!component || component.componentType !== 'zone-background') continue;
-    const bounds = getComponentHitBounds(component, entityPositions);
+    const bounds = getZoneIndicatorHitBounds(component);
     if (bounds && rectContains(bounds, point)) {
       return resultForComponent(component, 'world-zone-indicator', bounds);
+    }
+  }
+
+  if (debug) {
+    for (let i = components.length - 1; i >= 0; i--) {
+      const component = components[i];
+      if (!component || component.componentType !== 'zone-background') continue;
+      const bounds = getComponentHitBounds(component, entityPositions);
+      if (bounds && rectContains(bounds, point)) {
+        return resultForComponent(component, 'world-zone-indicator', bounds);
+      }
     }
   }
 

--- a/rendering/canvas-hit-test.js
+++ b/rendering/canvas-hit-test.js
@@ -1,0 +1,136 @@
+/**
+ * canvas-hit-test.js
+ *
+ * Pure hit testing for projected render components. It only reads component
+ * descriptors and computed entity positions supplied by the canvas pipeline.
+ */
+
+const TASK_CHIP_BOUNDS = Object.freeze({ width: 36, height: 16 });
+
+const AGENT_DESK_BOUNDS = Object.freeze({
+  'desk-0': Object.freeze({ width: 180, height: 170, dx: 0,  dy: 0 }),
+  'desk-1': Object.freeze({ width: 300, height: 150, dx: 0,  dy: 0 }),
+  'desk-2': Object.freeze({ width: 300, height: 150, dx: 0,  dy: 0 }),
+  'desk-3': Object.freeze({ width: 200, height: 175, dx: 0,  dy: 0 }),
+  'desk-4': Object.freeze({ width: 300, height: 150, dx: 14, dy: 0 }),
+  'desk-5': Object.freeze({ width: 300, height: 150, dx: 14, dy: 0 }),
+});
+
+const AGENT_FALLBACK_BOUNDS = Object.freeze({ width: 64, height: 54, dx: 0, dy: 0 });
+
+const HOVERABLE_TYPES = Object.freeze([
+  'world-zone-indicator',
+  'agent-sprite',
+  'task-chip',
+]);
+
+function isFiniteNumber(value) {
+  return Number.isFinite(value);
+}
+
+function posOf(component, entityPositions) {
+  const fromMap = entityPositions && component && component.id
+    ? entityPositions.get(component.id)
+    : null;
+  if (fromMap && isFiniteNumber(fromMap.x) && isFiniteNumber(fromMap.y)) {
+    return fromMap;
+  }
+
+  return {
+    x: isFiniteNumber(component?.x) ? component.x : 0,
+    y: isFiniteNumber(component?.y) ? component.y : 0,
+  };
+}
+
+function rectContains(rect, point) {
+  return point.x >= rect.x
+    && point.x <= rect.x + rect.width
+    && point.y >= rect.y
+    && point.y <= rect.y + rect.height;
+}
+
+export function getComponentHitBounds(component, entityPositions) {
+  if (!component || typeof component !== 'object') {
+    return null;
+  }
+
+  if (component.componentType === 'task-chip') {
+    const p = posOf(component, entityPositions);
+    return {
+      x: p.x - TASK_CHIP_BOUNDS.width / 2,
+      y: p.y - TASK_CHIP_BOUNDS.height / 2,
+      width: TASK_CHIP_BOUNDS.width,
+      height: TASK_CHIP_BOUNDS.height,
+    };
+  }
+
+  if (component.componentType === 'agent-sprite') {
+    const p = posOf(component, entityPositions);
+    const bounds = AGENT_DESK_BOUNDS[component.deskId] ?? AGENT_FALLBACK_BOUNDS;
+    return {
+      x: p.x - bounds.width / 2 + bounds.dx,
+      y: p.y - bounds.height / 2 + bounds.dy,
+      width: bounds.width,
+      height: bounds.height,
+    };
+  }
+
+  if (component.componentType === 'zone-background') {
+    return {
+      x: isFiniteNumber(component.x) ? component.x : 0,
+      y: isFiniteNumber(component.y) ? component.y : 0,
+      width: Math.max(0, isFiniteNumber(component.width) ? component.width : 0),
+      height: Math.max(0, isFiniteNumber(component.height) ? component.height : 0),
+    };
+  }
+
+  return null;
+}
+
+function resultForComponent(component, componentType, bounds) {
+  return {
+    entityId: component.id ?? null,
+    componentType,
+    component,
+    bounds,
+  };
+}
+
+export function hitTestRenderableComponents(components, point, entityPositions) {
+  if (!Array.isArray(components) || !point || !isFiniteNumber(point.x) || !isFiniteNumber(point.y)) {
+    return null;
+  }
+
+  for (let i = components.length - 1; i >= 0; i--) {
+    const component = components[i];
+    if (!component || component.componentType !== 'task-chip') continue;
+    const bounds = getComponentHitBounds(component, entityPositions);
+    if (bounds && rectContains(bounds, point)) {
+      return resultForComponent(component, 'task-chip', bounds);
+    }
+  }
+
+  for (let i = components.length - 1; i >= 0; i--) {
+    const component = components[i];
+    if (!component || component.componentType !== 'agent-sprite') continue;
+    const bounds = getComponentHitBounds(component, entityPositions);
+    if (bounds && rectContains(bounds, point)) {
+      return resultForComponent(component, 'agent-sprite', bounds);
+    }
+  }
+
+  for (let i = components.length - 1; i >= 0; i--) {
+    const component = components[i];
+    if (!component || component.componentType !== 'zone-background') continue;
+    const bounds = getComponentHitBounds(component, entityPositions);
+    if (bounds && rectContains(bounds, point)) {
+      return resultForComponent(component, 'world-zone-indicator', bounds);
+    }
+  }
+
+  return null;
+}
+
+export function isHoverableComponentType(componentType) {
+  return HOVERABLE_TYPES.includes(componentType);
+}

--- a/rendering/canvas-inspection-state.js
+++ b/rendering/canvas-inspection-state.js
@@ -1,0 +1,108 @@
+/**
+ * canvas-inspection-state.js
+ *
+ * Small deterministic state holder for hover and click inspection.
+ */
+
+import { hitTestRenderableComponents } from './canvas-hit-test.js';
+
+export function createCanvasInspectionState() {
+  return {
+    hoveredEntityId: null,
+    hoveredComponentType: null,
+    selectedEntityId: null,
+    selectedComponentType: null,
+    pointer: { x: null, y: null, inside: false },
+    hoveredHit: null,
+    selectedHit: null,
+  };
+}
+
+export const canvasInspectionState = createCanvasInspectionState();
+
+function clearHover(state) {
+  state.hoveredEntityId = null;
+  state.hoveredComponentType = null;
+  state.hoveredHit = null;
+}
+
+function assignHover(state, hit) {
+  state.hoveredEntityId = hit ? hit.entityId : null;
+  state.hoveredComponentType = hit ? hit.componentType : null;
+  state.hoveredHit = hit;
+}
+
+export function updateInspectionHover(state, components, point, entityPositions) {
+  if (!state) return null;
+
+  if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+    state.pointer = { x: null, y: null, inside: false };
+    clearHover(state);
+    return null;
+  }
+
+  state.pointer = { x: point.x, y: point.y, inside: true };
+  const hit = hitTestRenderableComponents(components, point, entityPositions);
+  assignHover(state, hit);
+  return hit;
+}
+
+export function updateInspectionSelection(state, components, point, entityPositions) {
+  if (!state) return null;
+
+  const hit = hitTestRenderableComponents(components, point, entityPositions);
+  state.selectedEntityId = hit ? hit.entityId : null;
+  state.selectedComponentType = hit ? hit.componentType : null;
+  state.selectedHit = hit;
+  return hit;
+}
+
+export function clearInspectionSelection(state) {
+  if (!state) return;
+  state.selectedEntityId = null;
+  state.selectedComponentType = null;
+  state.selectedHit = null;
+}
+
+export function refreshInspectionSelection(state, components, entityPositions) {
+  if (!state || !state.selectedEntityId || !state.selectedComponentType || !Array.isArray(components)) {
+    return null;
+  }
+
+  const selected = components.find((component) => {
+    if (!component || component.id !== state.selectedEntityId) return false;
+    if (state.selectedComponentType === 'world-zone-indicator') {
+      return component.componentType === 'zone-background';
+    }
+    return component.componentType === state.selectedComponentType;
+  });
+
+  if (!selected) {
+    clearInspectionSelection(state);
+    return null;
+  }
+
+  const hit = hitTestRenderableComponents(
+    [selected],
+    {
+      x: selected.x ?? 0,
+      y: selected.y ?? 0,
+    },
+    entityPositions
+  );
+
+  state.selectedHit = hit
+    ? { ...hit, component: selected }
+    : {
+        entityId: selected.id ?? null,
+        componentType: state.selectedComponentType,
+        component: selected,
+        bounds: null,
+      };
+  return state.selectedHit;
+}
+
+export function resolveInspectionTarget(state) {
+  if (!state) return null;
+  return state.selectedHit || state.hoveredHit || null;
+}

--- a/rendering/canvas-inspection-state.js
+++ b/rendering/canvas-inspection-state.js
@@ -32,7 +32,7 @@ function assignHover(state, hit) {
   state.hoveredHit = hit;
 }
 
-export function updateInspectionHover(state, components, point, entityPositions) {
+export function updateInspectionHover(state, components, point, entityPositions, options = {}) {
   if (!state) return null;
 
   if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
@@ -42,15 +42,15 @@ export function updateInspectionHover(state, components, point, entityPositions)
   }
 
   state.pointer = { x: point.x, y: point.y, inside: true };
-  const hit = hitTestRenderableComponents(components, point, entityPositions);
+  const hit = hitTestRenderableComponents(components, point, entityPositions, options);
   assignHover(state, hit);
   return hit;
 }
 
-export function updateInspectionSelection(state, components, point, entityPositions) {
+export function updateInspectionSelection(state, components, point, entityPositions, options = {}) {
   if (!state) return null;
 
-  const hit = hitTestRenderableComponents(components, point, entityPositions);
+  const hit = hitTestRenderableComponents(components, point, entityPositions, options);
   state.selectedEntityId = hit ? hit.entityId : null;
   state.selectedComponentType = hit ? hit.componentType : null;
   state.selectedHit = hit;
@@ -64,7 +64,7 @@ export function clearInspectionSelection(state) {
   state.selectedHit = null;
 }
 
-export function refreshInspectionSelection(state, components, entityPositions) {
+export function refreshInspectionSelection(state, components, entityPositions, options = {}) {
   if (!state || !state.selectedEntityId || !state.selectedComponentType || !Array.isArray(components)) {
     return null;
   }
@@ -88,7 +88,8 @@ export function refreshInspectionSelection(state, components, entityPositions) {
       x: selected.x ?? 0,
       y: selected.y ?? 0,
     },
-    entityPositions
+    entityPositions,
+    options
   );
 
   state.selectedHit = hit

--- a/rendering/connection-renderer.js
+++ b/rendering/connection-renderer.js
@@ -36,6 +36,11 @@ export const FLOW_LINE_STYLE = Object.freeze({
   speed:   0.6,        // px of offset advancement per frame
 });
 
+export const NORMAL_FLOW_LINE_STYLE = Object.freeze({
+  stroke: 'rgba(96, 220, 200, 0.20)',
+  width:  1.1,
+});
+
 // ---------------------------------------------------------------------------
 // Renderer
 // ---------------------------------------------------------------------------
@@ -52,7 +57,7 @@ export const FLOW_LINE_STYLE = Object.freeze({
  * @param {{ x: number, y: number }} toPos     Resolved position of the "to" endpoint
  * @param {number}                   frame     Current render frame counter (read-only)
  */
-export function renderConnection(ctx, fromPos, toPos, frame) {
+export function renderConnection(ctx, fromPos, toPos, frame, isDebugMode = false) {
   if (!ctx || !fromPos || !toPos) return;
 
   const f = typeof frame === 'number' ? frame : 0;
@@ -76,8 +81,8 @@ export function renderConnection(ctx, fromPos, toPos, frame) {
   ctx.quadraticCurveTo(cx, cy, toPos.x, toPos.y);
   ctx.setLineDash([FLOW_LINE_STYLE.dashLen, FLOW_LINE_STYLE.gapLen]);
   ctx.lineDashOffset = dashOffset;
-  ctx.strokeStyle    = FLOW_LINE_STYLE.stroke;
-  ctx.lineWidth      = FLOW_LINE_STYLE.width;
+  ctx.strokeStyle    = isDebugMode ? FLOW_LINE_STYLE.stroke : NORMAL_FLOW_LINE_STYLE.stroke;
+  ctx.lineWidth      = isDebugMode ? FLOW_LINE_STYLE.width : NORMAL_FLOW_LINE_STYLE.width;
   ctx.stroke();
   ctx.restore();
 }
@@ -93,7 +98,7 @@ export function renderConnection(ctx, fromPos, toPos, frame) {
  * @param {Map<string, { x: number, y: number }>} entityPositions  id → position lookup
  * @param {number}                         frame           Current render frame counter
  */
-export function renderAllConnections(ctx, components, entityPositions, frame) {
+export function renderAllConnections(ctx, components, entityPositions, frame, isDebugMode = false) {
   if (!ctx || !Array.isArray(components) || !(entityPositions instanceof Map)) return;
 
   for (const c of components) {
@@ -103,7 +108,7 @@ export function renderAllConnections(ctx, components, entityPositions, frame) {
     const toPos   = entityPositions.get(c.to);
 
     if (fromPos && toPos) {
-      renderConnection(ctx, fromPos, toPos, frame);
+      renderConnection(ctx, fromPos, toPos, frame, isDebugMode);
     }
   }
 }

--- a/rendering/diegetic-indicator-renderer.js
+++ b/rendering/diegetic-indicator-renderer.js
@@ -260,28 +260,28 @@ function drawArchiveGlow(ctx, ax, ay, completedCount, now) {
 
   const phase  = (now % 3000) / 3000;
   const breathe = 0.5 + 0.5 * Math.sin(phase * Math.PI * 2);
-  const baseR  = 10 + Math.min(completedCount * 2.5, 18);
-  const radius = baseR + 3 * breathe;
+  const baseR  = 6 + Math.min(completedCount * 1.2, 8);
+  const radius = baseR + 1.6 * breathe;
   const alpha  = completedCount > 0
-    ? Math.min(0.72, 0.25 + completedCount * 0.06 + 0.2 * breathe)
-    : 0.10 + 0.06 * breathe;
+    ? Math.min(0.42, 0.14 + completedCount * 0.025 + 0.10 * breathe)
+    : 0.05 + 0.03 * breathe;
 
   // Outer aura
-  ctx.globalAlpha = alpha * 0.5;
+  ctx.globalAlpha = alpha * 0.36;
   ctx.fillStyle   = ARCHIVE_GLOW;
   ctx.beginPath();
-  ctx.arc(ax, ay, radius * 1.6, 0, Math.PI * 2);
+  ctx.arc(ax, ay, radius * 1.35, 0, Math.PI * 2);
   ctx.fill();
 
   // Core glow
   ctx.globalAlpha = alpha;
-  ctx.fillStyle   = 'rgba(100, 200, 230, 0.70)';
+  ctx.fillStyle   = 'rgba(100, 200, 230, 0.46)';
   ctx.beginPath();
   ctx.arc(ax, ay, radius, 0, Math.PI * 2);
   ctx.fill();
 
   // Crystal facet lines (static — purely decorative)
-  ctx.globalAlpha = alpha * 0.55;
+  ctx.globalAlpha = alpha * 0.38;
   ctx.strokeStyle = '#c8f0ff';
   ctx.lineWidth   = 0.7;
   ctx.beginPath();
@@ -356,33 +356,32 @@ function drawAnomalyGlint(ctx, ax, ay, hasAnomaly, hasHighSeverity, now) {
 
   ctx.save();
 
-  const phase = (now % 800) / 800;
+  const cycleMs = hasHighSeverity ? 900 : 1500;
+  const phase = (now % cycleMs) / cycleMs;
   const pulse = 0.5 + 0.5 * Math.sin(phase * Math.PI * 2);
-  const alpha = 0.55 + 0.40 * pulse;
-  const ts    = 7 + 1.5 * pulse;   // triangle half-span
+  const alpha = hasHighSeverity ? 0.40 + 0.30 * pulse : 0.18 + 0.16 * pulse;
+  const radius = hasHighSeverity ? 3.5 + pulse : 2.5 + pulse * 0.6;
 
-  // Glow halo
-  ctx.globalAlpha = alpha * 0.35;
+  // Tiny shelf-light halo
+  ctx.globalAlpha = alpha * 0.28;
   ctx.fillStyle   = ANOMALY_GLOW;
   ctx.beginPath();
-  ctx.arc(ax, ay, ts * 1.6, 0, Math.PI * 2);
+  ctx.arc(ax, ay, radius * 3, 0, Math.PI * 2);
   ctx.fill();
 
-  // Triangle
+  // Warning gem
   ctx.globalAlpha = alpha;
   ctx.fillStyle   = hasHighSeverity ? ANOMALY_RED : '#f57c00';
   ctx.beginPath();
-  ctx.moveTo(ax,          ay - ts);
-  ctx.lineTo(ax + ts,     ay + ts);
-  ctx.lineTo(ax - ts,     ay + ts);
-  ctx.closePath();
+  ctx.arc(ax, ay, radius, 0, Math.PI * 2);
   ctx.fill();
 
-  // Exclamation
-  ctx.globalAlpha = 0.95;
-  ctx.fillStyle   = '#ffffff';
-  ctx.fillRect(ax - 0.8, ay - 1.5, 1.6, 4.5);
-  ctx.fillRect(ax - 0.8, ay + 3.5, 1.6, 1.6);
+  ctx.globalAlpha = alpha * 0.8;
+  ctx.strokeStyle = 'rgba(255, 232, 190, 0.78)';
+  ctx.lineWidth = 0.7;
+  ctx.beginPath();
+  ctx.arc(ax, ay, radius + 1.5, 0, Math.PI * 2);
+  ctx.stroke();
 
   ctx.restore();
 }

--- a/rendering/inspection-popover-renderer.js
+++ b/rendering/inspection-popover-renderer.js
@@ -1,0 +1,193 @@
+/**
+ * inspection-popover-renderer.js
+ *
+ * Canvas popover for diegetic inspection. Content is sourced only from
+ * render component descriptors.
+ */
+
+const NORMAL_CARD_W = 150;
+const DEBUG_CARD_W = 218;
+const PAD = 8;
+const LINE_H = 12;
+
+const ZONE_TITLES = Object.freeze({
+  CREATED: 'Intake Nook',
+  ENQUEUED: 'Task Engine',
+  CLAIMED: 'Workshop',
+  EXECUTE_FINISHED: 'Delivery Bay',
+  ACKED: 'Archive Vault',
+  intakeDesk: 'Intake Desk',
+  researchDesk: 'Research Desk',
+  shopifyDesk: 'Shopify Desk',
+  renderDesk: 'Render Desk',
+  supportDesk: 'Support Desk',
+  engineCrystal: 'Engine Crystal',
+  approvalDesk: 'Approval Desk',
+  anomalyShelf: 'Anomaly Shelf',
+  archiveLibrary: 'Archive Library',
+});
+
+function finite(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function cleanText(value) {
+  if (value === null || value === undefined || value === '') return null;
+  return String(value);
+}
+
+function titleFor(component, componentType) {
+  if (componentType === 'task-chip') return 'Task Scroll';
+  if (componentType === 'agent-sprite') return 'Agent Desk';
+  const zoneId = cleanText(component.worldZoneId) || cleanText(component.zoneId) || cleanText(component.id);
+  return ZONE_TITLES[zoneId] || 'World Zone';
+}
+
+function typeLabel(componentType) {
+  if (componentType === 'task-chip') return 'task';
+  if (componentType === 'agent-sprite') return 'agent';
+  return 'world-zone';
+}
+
+function metricRows(metrics) {
+  if (!metrics || typeof metrics !== 'object') return [];
+  const rows = [];
+  for (const key of ['duration', 'queueTime', 'latency']) {
+    const value = metrics[key];
+    if (value !== null && value !== undefined) {
+      rows.push(`${key}: ${value}`);
+    }
+  }
+  return rows;
+}
+
+export function buildInspectionPopoverRows(hit, options = {}) {
+  if (!hit || !hit.component) return null;
+
+  const component = hit.component;
+  const isDebug = Boolean(options.debug);
+  const rows = [
+    `type: ${typeLabel(hit.componentType)}`,
+  ];
+
+  const visualState = cleanText(component.visualState);
+  if (visualState && (isDebug || visualState !== 'unknown')) rows.push(`status: ${visualState}`);
+
+  const zone = cleanText(component.worldZoneId) || cleanText(component.zoneId);
+  if (zone) rows.push(`zone: ${zone}`);
+
+  if (isDebug && hit.componentType === 'agent-sprite') {
+    const currentTaskId = cleanText(component.currentTaskId);
+    if (currentTaskId) rows.push(`current task: ${currentTaskId}`);
+  }
+
+  if (isDebug) rows.push(...metricRows(component.metrics));
+
+  if (isDebug && component.anomaly) {
+    const severity = cleanText(component.anomaly.severity) || 'unknown';
+    const detail = cleanText(component.anomaly.type) || 'anomaly';
+    rows.push(`anomaly: ${severity} ${detail}`);
+  }
+
+  if (isDebug) {
+    const id = cleanText(component.id);
+    if (id) rows.push(`id: ${id}`);
+    if (hit.bounds) {
+      rows.push(`bounds: ${Math.round(hit.bounds.x)},${Math.round(hit.bounds.y)} ${Math.round(hit.bounds.width)}x${Math.round(hit.bounds.height)}`);
+    }
+    const zoneId = cleanText(component.zoneId);
+    const worldZoneId = cleanText(component.worldZoneId);
+    if (zoneId && worldZoneId && zoneId !== worldZoneId) {
+      rows.push(`lifecycle zone: ${zoneId}`);
+    }
+  }
+
+  return {
+    title: titleFor(component, hit.componentType),
+    rows,
+    hasAnomaly: Boolean(component.anomaly),
+    debug: isDebug,
+  };
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  const cr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + cr, y);
+  ctx.lineTo(x + w - cr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + cr);
+  ctx.lineTo(x + w, y + h - cr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - cr, y + h);
+  ctx.lineTo(x + cr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - cr);
+  ctx.lineTo(x, y + cr);
+  ctx.quadraticCurveTo(x, y, x + cr, y);
+  ctx.closePath();
+}
+
+function anchorFor(ctx, hit, width, height) {
+  const canvasW = finite(ctx?.canvas?.width, 1060);
+  const canvasH = finite(ctx?.canvas?.height, 520);
+  const bounds = hit.bounds || { x: 0, y: 0, width: 0, height: 0 };
+  let x = bounds.x + bounds.width + 8;
+  let y = bounds.y - 6;
+
+  if (x + width > canvasW - 8) {
+    x = bounds.x - width - 8;
+  }
+  if (x < 8) x = 8;
+  if (y + height > canvasH - 8) y = canvasH - height - 8;
+  if (y < 8) y = 8;
+
+  return { x, y };
+}
+
+export function renderInspectionPopover(ctx, hit, options = {}) {
+  if (!ctx || !hit) return;
+
+  const model = buildInspectionPopoverRows(hit, options);
+  if (!model) return;
+
+  const cardW = model.debug ? DEBUG_CARD_W : NORMAL_CARD_W;
+  const cardH = PAD * 2 + 15 + model.rows.length * LINE_H;
+  const { x, y } = anchorFor(ctx, hit, cardW, cardH);
+
+  ctx.save();
+
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.32)';
+  ctx.shadowBlur = 8;
+  ctx.shadowOffsetY = 2;
+  roundRect(ctx, x, y, cardW, cardH, 6);
+  ctx.fillStyle = model.debug ? 'rgba(32, 20, 8, 0.86)' : 'rgba(32, 22, 12, 0.68)';
+  ctx.fill();
+
+  ctx.shadowColor = 'transparent';
+  ctx.strokeStyle = model.hasAnomaly ? 'rgba(207, 105, 54, 0.70)' : 'rgba(215, 174, 104, 0.46)';
+  ctx.lineWidth = 0.8;
+  roundRect(ctx, x, y, cardW, cardH, 6);
+  ctx.stroke();
+
+  ctx.fillStyle = '#f0d9a8';
+  ctx.font = 'bold 10px monospace';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText(model.title, x + PAD, y + PAD);
+
+  if (model.hasAnomaly) {
+    ctx.fillStyle = 'rgba(230, 91, 59, 0.82)';
+    ctx.beginPath();
+    ctx.arc(x + cardW - PAD - 4, y + PAD + 5, 3, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  ctx.font = '9px monospace';
+  ctx.fillStyle = 'rgba(252, 239, 204, 0.84)';
+  let rowY = y + PAD + 16;
+  for (const row of model.rows) {
+    ctx.fillText(row, x + PAD, rowY);
+    rowY += LINE_H;
+  }
+
+  ctx.restore();
+}

--- a/rendering/renderer-loop.js
+++ b/rendering/renderer-loop.js
@@ -38,17 +38,25 @@ export function initRenderer() {
 
   canvas.addEventListener('mousemove', (event) => {
     const point = eventToCanvasPoint(event);
+    const hitTestOptions = { debug: isRenderDebugEnabled() };
     const hit = updateInspectionHover(
       canvasInspectionState,
       _latestComponents,
       point,
-      _latestEntityPositions
+      _latestEntityPositions,
+      hitTestOptions
     );
     canvas.style.cursor = hit ? 'pointer' : 'default';
   });
 
   canvas.addEventListener('mouseleave', () => {
-    updateInspectionHover(canvasInspectionState, _latestComponents, null, _latestEntityPositions);
+    updateInspectionHover(
+      canvasInspectionState,
+      _latestComponents,
+      null,
+      _latestEntityPositions,
+      { debug: isRenderDebugEnabled() }
+    );
     canvas.style.cursor = 'default';
   });
 
@@ -58,7 +66,8 @@ export function initRenderer() {
       canvasInspectionState,
       _latestComponents,
       point,
-      _latestEntityPositions
+      _latestEntityPositions,
+      { debug: isRenderDebugEnabled() }
     );
   });
 
@@ -80,14 +89,16 @@ export function renderFrame(renderView) {
   const entityPositions = buildEntityPositionMap(components);
   _latestComponents = components;
   _latestEntityPositions = entityPositions;
-  refreshInspectionSelection(canvasInspectionState, components, entityPositions);
+  const hitTestOptions = { debug: isRenderDebugEnabled() };
+  refreshInspectionSelection(canvasInspectionState, components, entityPositions, hitTestOptions);
 
   if (canvasInspectionState.pointer.inside) {
     updateInspectionHover(
       canvasInspectionState,
       components,
       canvasInspectionState.pointer,
-      entityPositions
+      entityPositions,
+      hitTestOptions
     );
   }
 

--- a/rendering/renderer-loop.js
+++ b/rendering/renderer-loop.js
@@ -3,11 +3,66 @@ import { buildWorldScene } from './world-scene.js';
 import { toRenderableComponents } from './world-scene-adapter.js';
 import { renderAllLayers } from './world-scene-layer-renderer.js';
 import { assertGraphShape, assertEventDriven } from './render-guards.js';
+import { buildEntityPositionMap } from './zone-renderer.js';
+import {
+  canvasInspectionState,
+  updateInspectionHover,
+  updateInspectionSelection,
+  refreshInspectionSelection,
+  resolveInspectionTarget,
+} from './canvas-inspection-state.js';
+import { renderInspectionPopover } from './inspection-popover-renderer.js';
+import { isRenderDebugEnabled } from './debug.js';
 
 let _frame = 0;
+let _inspectionBindingsAttached = false;
+let _latestComponents = [];
+let _latestEntityPositions = new Map();
+
+function eventToCanvasPoint(event) {
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width || !rect.height) {
+    return null;
+  }
+
+  return {
+    x: (event.clientX - rect.left) * (canvas.width / rect.width),
+    y: (event.clientY - rect.top) * (canvas.height / rect.height),
+  };
+}
 
 export function initRenderer() {
-  // Reserved for future renderer bootstrapping.
+  if (_inspectionBindingsAttached || !canvas) {
+    return;
+  }
+
+  canvas.addEventListener('mousemove', (event) => {
+    const point = eventToCanvasPoint(event);
+    const hit = updateInspectionHover(
+      canvasInspectionState,
+      _latestComponents,
+      point,
+      _latestEntityPositions
+    );
+    canvas.style.cursor = hit ? 'pointer' : 'default';
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    updateInspectionHover(canvasInspectionState, _latestComponents, null, _latestEntityPositions);
+    canvas.style.cursor = 'default';
+  });
+
+  canvas.addEventListener('click', (event) => {
+    const point = eventToCanvasPoint(event);
+    updateInspectionSelection(
+      canvasInspectionState,
+      _latestComponents,
+      point,
+      _latestEntityPositions
+    );
+  });
+
+  _inspectionBindingsAttached = true;
 }
 
 export function renderErrorState() {
@@ -22,6 +77,19 @@ export function renderFrame(renderView) {
   const scene      = buildWorldScene(renderView);
   assertEventDriven(scene);
   const components = toRenderableComponents(scene);
+  const entityPositions = buildEntityPositionMap(components);
+  _latestComponents = components;
+  _latestEntityPositions = entityPositions;
+  refreshInspectionSelection(canvasInspectionState, components, entityPositions);
+
+  if (canvasInspectionState.pointer.inside) {
+    updateInspectionHover(
+      canvasInspectionState,
+      components,
+      canvasInspectionState.pointer,
+      entityPositions
+    );
+  }
 
   // Targeted debug — logs once per second (~60 frames) when DEV_MODE is on
   if (window.DEV_MODE && _frame % 60 === 0) {
@@ -36,5 +104,8 @@ export function renderFrame(renderView) {
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   renderAllLayers(ctx, components, _frame);
+  renderInspectionPopover(ctx, resolveInspectionTarget(canvasInspectionState), {
+    debug: isRenderDebugEnabled(),
+  });
   _frame += 1;
 }

--- a/rendering/world-background-composition.js
+++ b/rendering/world-background-composition.js
@@ -28,7 +28,6 @@ export const WORLD_COMPOSITION_ZONES = Object.freeze(
 
 const LABEL_STYLE = Object.freeze({
   font: 'bold 9px monospace',
-  subtleFill: 'rgba(234, 217, 178, 0.64)',
   debugFill: '#fff2bd',
 });
 
@@ -211,20 +210,6 @@ function drawZoneProp(ctx, zone, frame) {
   drawDesk(ctx, zone, 'rgba(73, 58, 35, 0.78)');
 }
 
-function drawSubtleLabel(ctx, zone) {
-  const p = scalePoint(ctx, zone.position.x, zone.position.y);
-  const text = zone.label;
-  ctx.save();
-  ctx.font = LABEL_STYLE.font;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  const width = Math.max(40, (ctx.measureText(text)?.width || text.length * 5) + 12);
-  fillPill(ctx, p.x - width / 2, p.y - zone.size.height * 0.18, width, 16, 'rgba(23, 13, 5, 0.46)');
-  ctx.fillStyle = LABEL_STYLE.subtleFill;
-  ctx.fillText(text, p.x, p.y - zone.size.height * 0.18 + 8);
-  ctx.restore();
-}
-
 function drawDebugZone(ctx, zone) {
   const r = scaleRect(ctx, zone);
   ctx.save();
@@ -294,7 +279,7 @@ export function renderTreehouseBackdrop(ctx, frame = 0) {
 }
 
 /**
- * Draw semantic-zone props and labels. Debug mode overlays bounds and raw zone ids.
+ * Draw semantic-zone props. Debug mode overlays bounds and raw zone ids.
  *
  * @param {CanvasRenderingContext2D} ctx
  * @param {{ debug?: boolean, frame?: number }} options
@@ -308,8 +293,10 @@ export function renderWorldCompositionLayer(ctx, options = {}) {
   for (const zone of WORLD_COMPOSITION_ZONES) {
     drawZoneProp(ctx, zone, frame);
   }
-  for (const zone of WORLD_COMPOSITION_ZONES) {
-    debug ? drawDebugZone(ctx, zone) : drawSubtleLabel(ctx, zone);
+  if (debug) {
+    for (const zone of WORLD_COMPOSITION_ZONES) {
+      drawDebugZone(ctx, zone);
+    }
   }
   ctx.restore();
 }

--- a/rendering/world-scene-adapter.js
+++ b/rendering/world-scene-adapter.js
@@ -51,6 +51,7 @@ function entityToAgentSpriteComponent(entity) {
     y:             entity.position ? entity.position.y : 0,
     visualState:   entity.visualState   ?? 'unknown',
     zoneId:        entity.zoneId        ?? null,
+    worldZoneId:   entity.worldZoneId   ?? null,
     deskId:        entity.deskId        ?? null,
     // Forwarded from agentSelectors output via buildWorldScene — null when agent is idle.
     currentTaskId: entity.currentTaskId ?? null,
@@ -77,6 +78,7 @@ function entityToTaskChipComponent(entity) {
     y:             entity.position ? entity.position.y : 0,
     visualState:   entity.visualState ?? 'unknown',
     zoneId:        entity.zoneId      ?? null,
+    worldZoneId:   entity.worldZoneId ?? null,
     metrics:       entity.metrics     ?? { duration: null, queueTime: null, latency: null },
     anomaly:       entity.anomaly     ?? null,
   };

--- a/rendering/world-scene-asset-renderer.js
+++ b/rendering/world-scene-asset-renderer.js
@@ -717,9 +717,13 @@ export function renderZoneLayer(ctx, components) {
  * @param {Array<object>} components
  * @param {Map<string, {x:number, y:number}>} entityPositions
  */
-export function renderConnectionLayer(ctx, components, entityPositions) {
+export function renderConnectionLayer(ctx, components, entityPositions, isDebugMode = false) {
   const flowAssets = ASSET_MAPPING.effects.flow;
   let idx = 0;
+  ctx.save();
+  if (!isDebugMode) {
+    ctx.globalAlpha = 0.28;
+  }
   for (const c of components) {
     if (c.componentType !== 'flow-line') continue;
     const fromPos = entityPositions.get(c.from);
@@ -732,6 +736,7 @@ export function renderConnectionLayer(ctx, components, entityPositions) {
     }
     idx++;
   }
+  ctx.restore();
 }
 
 // ---------------------------------------------------------------------------

--- a/rendering/world-scene-layer-renderer.js
+++ b/rendering/world-scene-layer-renderer.js
@@ -32,6 +32,7 @@ import { buildEntityPositionMap }   from './zone-renderer.js';
 import { renderZoneLabels }         from './zone-label-renderer.js';
 import { renderAllTaskChips }       from './task-chip-renderer.js';
 import { renderDiegeticIndicators } from './diegetic-indicator-renderer.js';
+import { renderWorldCompositionLayer } from './world-background-composition.js';
 import {
   renderBackgroundLayer,
   renderCoreLayer,
@@ -98,8 +99,8 @@ export function renderAllLayers(ctx, components, frame) {
   }
 
   // ── Layer 4: connection ─────────────────────────────────────────────────
-  renderAllConnections(ctx, components, entityPositions, frame);
-  renderConnectionLayer(ctx, components, entityPositions);
+  renderAllConnections(ctx, components, entityPositions, frame, isRenderDebug);
+  renderConnectionLayer(ctx, components, entityPositions, isRenderDebug);
 
   // ── Layers 5–8: agents, props, effects, UI overlay ─────────────────────
   // Layer 5 agent rendering always runs and resolves positions through

--- a/tests/canvas-inspection.test.mjs
+++ b/tests/canvas-inspection.test.mjs
@@ -95,14 +95,32 @@ test('canvas inspection: hit-test returns stable result for known component posi
   assert.deepStrictEqual(hit.bounds, taskBounds);
 });
 
-test('canvas inspection: agent and zone hit regions are deterministic', () => {
+test('canvas inspection: normal mode still hits task-chip and agent-sprite', () => {
+  const taskHit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null, { debug: false });
+  assert.equal(taskHit.entityId, 'task-1');
+  assert.equal(taskHit.componentType, 'task-chip');
+
   const agentHit = hitTestRenderableComponents(COMPONENTS, { x: 230, y: 225 }, null);
   assert.equal(agentHit.entityId, 'agent-1');
   assert.equal(agentHit.componentType, 'agent-sprite');
+});
 
-  const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null);
+test('canvas inspection: normal mode does not hit broad zone-background rectangles', () => {
+  const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null, { debug: false });
+  assert.equal(zoneHit, null);
+});
+
+test('canvas inspection: debug mode can hit broad zone-background rectangles', () => {
+  const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null, { debug: true });
   assert.equal(zoneHit.entityId, 'CREATED');
   assert.equal(zoneHit.componentType, 'world-zone-indicator');
+});
+
+test('canvas inspection: normal mode hits small diegetic indicator anchors', () => {
+  const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 107, y: 165 }, null, { debug: false });
+  assert.equal(zoneHit.entityId, 'CREATED');
+  assert.equal(zoneHit.componentType, 'world-zone-indicator');
+  assert.deepStrictEqual(zoneHit.bounds, { x: 83, y: 141, width: 48, height: 48 });
 });
 
 test('canvas inspection: hover and click state update deterministically', () => {
@@ -125,7 +143,7 @@ test('canvas inspection: background click clears selection', () => {
   updateInspectionSelection(state, COMPONENTS, { x: 300, y: 260 }, null);
   assert.equal(state.selectedEntityId, 'task-1');
 
-  const selection = updateInspectionSelection(state, COMPONENTS, { x: 1040, y: 500 }, null);
+  const selection = updateInspectionSelection(state, COMPONENTS, { x: 60, y: 80 }, null, { debug: false });
   assert.equal(selection, null);
   assert.equal(state.selectedEntityId, null);
   assert.equal(state.selectedComponentType, null);
@@ -172,7 +190,7 @@ test('canvas inspection: popover normal mode hides unknown status', () => {
 });
 
 test('canvas inspection: zone popover uses friendly zone title without unknown status', () => {
-  const hit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null);
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 107, y: 165 }, null, { debug: false });
   const model = buildInspectionPopoverRows(hit, { debug: false });
 
   assert.equal(model.title, 'Intake Nook');
@@ -249,6 +267,8 @@ test('canvas inspection: inspection modules do not access raw event sources', ()
     /\bgetRawEvents\b/,
     /\bpayload\s*\./,
     /\bindexedWorldSnapshot\b/,
+    /\bworldIndex\b/,
+    /\bworld-index\b/,
   ];
 
   for (const file of files) {

--- a/tests/canvas-inspection.test.mjs
+++ b/tests/canvas-inspection.test.mjs
@@ -1,0 +1,260 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getComponentHitBounds,
+  hitTestRenderableComponents,
+} from '../rendering/canvas-hit-test.js';
+import {
+  createCanvasInspectionState,
+  updateInspectionHover,
+  updateInspectionSelection,
+  refreshInspectionSelection,
+  resolveInspectionTarget,
+} from '../rendering/canvas-inspection-state.js';
+import {
+  buildInspectionPopoverRows,
+  renderInspectionPopover,
+} from '../rendering/inspection-popover-renderer.js';
+import {
+  FLOW_LINE_STYLE,
+  NORMAL_FLOW_LINE_STYLE,
+  renderConnection,
+} from '../rendering/connection-renderer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const COMPONENTS = Object.freeze([
+  Object.freeze({
+    componentType: 'zone-background',
+    id: 'CREATED',
+    x: 25,
+    y: 55,
+    width: 165,
+    height: 155,
+  }),
+  Object.freeze({
+    componentType: 'agent-sprite',
+    id: 'agent-1',
+    x: 300,
+    y: 260,
+    visualState: 'working',
+    zoneId: 'CLAIMED',
+    worldZoneId: 'workshop-desk',
+    deskId: 'desk-0',
+    currentTaskId: 'task-1',
+  }),
+  Object.freeze({
+    componentType: 'task-chip',
+    id: 'task-1',
+    x: 300,
+    y: 260,
+    visualState: 'processing',
+    zoneId: 'EXECUTE_FINISHED',
+    worldZoneId: 'delivery-bay',
+    metrics: { duration: 1200, queueTime: 200, latency: null },
+    anomaly: { severity: 'high', type: 'stalled_tasks' },
+  }),
+]);
+
+function createMockContext() {
+  const calls = [];
+  const ctx = {
+    canvas: { width: 1060, height: 520 },
+    calls,
+    save: () => calls.push(['save']),
+    restore: () => calls.push(['restore']),
+    beginPath: () => calls.push(['beginPath']),
+    moveTo: (...args) => calls.push(['moveTo', ...args]),
+    lineTo: (...args) => calls.push(['lineTo', ...args]),
+    quadraticCurveTo: (...args) => calls.push(['quadraticCurveTo', ...args]),
+    closePath: () => calls.push(['closePath']),
+    fill: () => calls.push(['fill']),
+    stroke: () => calls.push(['stroke']),
+    fillText: (...args) => calls.push(['fillText', ...args]),
+    fillRect: (...args) => calls.push(['fillRect', ...args]),
+    arc: (...args) => calls.push(['arc', ...args]),
+    setLineDash: (...args) => calls.push(['setLineDash', ...args]),
+    measureText: (text) => ({ width: String(text).length * 6 }),
+  };
+
+  return ctx;
+}
+
+test('canvas inspection: hit-test returns stable result for known component positions', () => {
+  const taskBounds = getComponentHitBounds(COMPONENTS[2], null);
+  assert.deepStrictEqual(taskBounds, { x: 282, y: 252, width: 36, height: 16 });
+
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null);
+  assert.equal(hit.entityId, 'task-1');
+  assert.equal(hit.componentType, 'task-chip');
+  assert.deepStrictEqual(hit.bounds, taskBounds);
+});
+
+test('canvas inspection: agent and zone hit regions are deterministic', () => {
+  const agentHit = hitTestRenderableComponents(COMPONENTS, { x: 230, y: 225 }, null);
+  assert.equal(agentHit.entityId, 'agent-1');
+  assert.equal(agentHit.componentType, 'agent-sprite');
+
+  const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null);
+  assert.equal(zoneHit.entityId, 'CREATED');
+  assert.equal(zoneHit.componentType, 'world-zone-indicator');
+});
+
+test('canvas inspection: hover and click state update deterministically', () => {
+  const state = createCanvasInspectionState();
+
+  const hover = updateInspectionHover(state, COMPONENTS, { x: 300, y: 260 }, null);
+  assert.equal(hover.entityId, 'task-1');
+  assert.equal(state.hoveredEntityId, 'task-1');
+  assert.equal(state.hoveredComponentType, 'task-chip');
+
+  const selection = updateInspectionSelection(state, COMPONENTS, { x: 230, y: 225 }, null);
+  assert.equal(selection.entityId, 'agent-1');
+  assert.equal(state.selectedEntityId, 'agent-1');
+  assert.equal(resolveInspectionTarget(state).entityId, 'agent-1');
+});
+
+test('canvas inspection: background click clears selection', () => {
+  const state = createCanvasInspectionState();
+
+  updateInspectionSelection(state, COMPONENTS, { x: 300, y: 260 }, null);
+  assert.equal(state.selectedEntityId, 'task-1');
+
+  const selection = updateInspectionSelection(state, COMPONENTS, { x: 1040, y: 500 }, null);
+  assert.equal(selection, null);
+  assert.equal(state.selectedEntityId, null);
+  assert.equal(state.selectedComponentType, null);
+});
+
+test('canvas inspection: selected component refreshes from latest descriptors', () => {
+  const state = createCanvasInspectionState();
+  updateInspectionSelection(state, COMPONENTS, { x: 230, y: 225 }, null);
+
+  const updated = COMPONENTS.map((component) => component.id === 'agent-1'
+    ? { ...component, visualState: 'idle', currentTaskId: null }
+    : component);
+
+  refreshInspectionSelection(state, updated, null);
+  assert.equal(state.selectedHit.component.visualState, 'idle');
+  assert.equal(state.selectedHit.component.currentTaskId, null);
+});
+
+test('canvas inspection: popover normal mode is compact and hides diagnostics', () => {
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null);
+  const model = buildInspectionPopoverRows(hit, { debug: false });
+
+  assert.equal(model.title, 'Task Scroll');
+  assert.equal(model.rows.length, 3);
+  assert.ok(model.rows.includes('type: task'));
+  assert.ok(model.rows.includes('status: processing'));
+  assert.ok(model.rows.includes('zone: delivery-bay'));
+  assert.ok(!model.rows.some((row) => row.startsWith('duration:')));
+  assert.ok(!model.rows.some((row) => row.startsWith('anomaly:')));
+  assert.ok(!model.rows.some((row) => row.startsWith('id:')));
+  assert.ok(!model.rows.some((row) => row.startsWith('bounds:')));
+});
+
+test('canvas inspection: popover normal mode hides unknown status', () => {
+  const hit = {
+    entityId: 'mystery',
+    componentType: 'task-chip',
+    component: { componentType: 'task-chip', id: 'mystery', visualState: 'unknown', worldZoneId: 'nook' },
+    bounds: { x: 10, y: 10, width: 36, height: 16 },
+  };
+  const model = buildInspectionPopoverRows(hit, { debug: false });
+
+  assert.deepStrictEqual(model.rows, ['type: task', 'zone: nook']);
+});
+
+test('canvas inspection: zone popover uses friendly zone title without unknown status', () => {
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 60, y: 80 }, null);
+  const model = buildInspectionPopoverRows(hit, { debug: false });
+
+  assert.equal(model.title, 'Intake Nook');
+  assert.ok(model.rows.includes('type: world-zone'));
+  assert.ok(!model.rows.includes('status: unknown'));
+});
+
+test('canvas inspection: popover debug mode shows full diagnostics', () => {
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null);
+  const model = buildInspectionPopoverRows(hit, { debug: true });
+
+  assert.ok(model.rows.includes('duration: 1200'));
+  assert.ok(model.rows.includes('anomaly: high stalled_tasks'));
+  assert.ok(model.rows.includes('id: task-1'));
+  assert.ok(model.rows.some((row) => row.startsWith('bounds: ')));
+});
+
+test('canvas inspection: popover renderer runs on a mock canvas context', () => {
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 230, y: 225 }, null);
+  const ctx = createMockContext();
+
+  assert.doesNotThrow(() => renderInspectionPopover(ctx, hit, { debug: false }));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'Agent Desk'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'current task: task-1'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
+});
+
+test('canvas inspection: connection stream is softer in normal mode and full in debug mode', () => {
+  const normalCtx = createMockContext();
+  renderConnection(normalCtx, { x: 10, y: 10 }, { x: 90, y: 30 }, 12, false);
+  assert.equal(normalCtx.strokeStyle, NORMAL_FLOW_LINE_STYLE.stroke);
+  assert.equal(normalCtx.lineWidth, NORMAL_FLOW_LINE_STYLE.width);
+
+  const debugCtx = createMockContext();
+  renderConnection(debugCtx, { x: 10, y: 10 }, { x: 90, y: 30 }, 12, true);
+  assert.equal(debugCtx.strokeStyle, FLOW_LINE_STYLE.stroke);
+  assert.equal(debugCtx.lineWidth, FLOW_LINE_STYLE.width);
+});
+
+test('canvas inspection: agent raw IDs are hidden in normal mode and visible in debug mode', async () => {
+  const canvas = {
+    width: 1060,
+    height: 520,
+    getContext: () => createMockContext(),
+    addEventListener: () => {},
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 1060, height: 520 }),
+  };
+  globalThis.document = { getElementById: () => canvas };
+  globalThis.window = { __SLOTHWORLD_RENDER_DEBUG__: false, location: { search: '' } };
+
+  const moduleUrl = `../rendering/agent-entity-renderer.js?inspection-test=${Date.now()}`;
+  const { renderAgentEntity } = await import(moduleUrl);
+  const component = { componentType: 'agent-sprite', id: 'agent-raw-123', x: 100, y: 120, visualState: 'idle' };
+
+  const normalCtx = createMockContext();
+  renderAgentEntity(normalCtx, component, 0);
+  assert.ok(!normalCtx.calls.some((call) => call[0] === 'fillText' && call[1] === 'agent-raw-123'));
+
+  globalThis.window.__SLOTHWORLD_RENDER_DEBUG__ = true;
+  const debugCtx = createMockContext();
+  renderAgentEntity(debugCtx, component, 0);
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'fillText' && call[1] === 'agent-raw-123'));
+});
+
+test('canvas inspection: inspection modules do not access raw event sources', () => {
+  const files = [
+    'rendering/canvas-hit-test.js',
+    'rendering/canvas-inspection-state.js',
+    'rendering/inspection-popover-renderer.js',
+  ];
+  const forbidden = [
+    /\beventsByTaskId\b/,
+    /\beventsByWorkerId\b/,
+    /\bgetRawEvents\b/,
+    /\bpayload\s*\./,
+    /\bindexedWorldSnapshot\b/,
+  ];
+
+  for (const file of files) {
+    const source = readFileSync(resolve(ROOT, file), 'utf8');
+    for (const re of forbidden) {
+      assert.ok(!re.test(source), `${file} must not match ${re}`);
+    }
+  }
+});

--- a/tests/world-background-composition.test.mjs
+++ b/tests/world-background-composition.test.mjs
@@ -109,7 +109,7 @@ test('world background renderer runs against a mock canvas context', () => {
   assert.doesNotThrow(() => renderTreehouseBackdrop(ctx, 12));
   assert.doesNotThrow(() => renderWorldCompositionLayer(ctx, { debug: false, frame: 12 }));
   assert.ok(log.some((entry) => entry.method === 'fillRect'), 'expected fillRect calls');
-  assert.ok(log.some((entry) => entry.method === 'fillText'), 'expected labels to render');
+  assert.ok(!log.some((entry) => entry.method === 'fillText'), 'normal mode must not render semantic labels');
 });
 
 test('world background composition is deterministic for identical inputs', () => {
@@ -162,4 +162,18 @@ test('debug overlay draws zone bounds and semantic ids', () => {
     assert.ok(labels.includes(zone.id), `missing debug label ${zone.id}`);
   }
   assert.ok(log.some((entry) => entry.method === 'strokeRect'), 'expected debug bounds');
+});
+
+test('normal world composition suppresses semantic zone labels', () => {
+  const { ctx, log } = makeMockCtx();
+  renderWorldCompositionLayer(ctx, { debug: false, frame: 0 });
+
+  const labels = log
+    .filter((entry) => entry.method === 'fillText')
+    .map((entry) => entry.args[0]);
+
+  for (const zone of WORLD_COMPOSITION_ZONES) {
+    assert.ok(!labels.includes(zone.label), `normal mode must hide semantic label ${zone.label}`);
+    assert.ok(!labels.includes(zone.id), `normal mode must hide semantic id ${zone.id}`);
+  }
 });

--- a/tests/world-scene-e2e.test.mjs
+++ b/tests/world-scene-e2e.test.mjs
@@ -294,7 +294,7 @@ describe('E2E — no semantic leakage', () => {
 
   it('agent-sprite components have only the expected structural keys', () => {
     const { components } = runFullPipeline(clone(GRAPH));
-    const expected = 'anomaly,componentType,currentTaskId,deskId,id,metrics,visualState,x,y,zoneId';
+    const expected = 'anomaly,componentType,currentTaskId,deskId,id,metrics,visualState,worldZoneId,x,y,zoneId';
     for (const c of components.filter(c => c.componentType === 'agent-sprite')) {
       const keys = Object.keys(c).sort().join(',');
       assert.equal(keys, expected, `unexpected keys on agent-sprite "${c.id}": ${keys}`);
@@ -303,7 +303,7 @@ describe('E2E — no semantic leakage', () => {
 
   it('task-chip components have only the expected structural keys', () => {
     const { components } = runFullPipeline(clone(GRAPH));
-    const expected = 'anomaly,componentType,id,metrics,visualState,x,y,zoneId';
+    const expected = 'anomaly,componentType,id,metrics,visualState,worldZoneId,x,y,zoneId';
     for (const c of components.filter(c => c.componentType === 'task-chip')) {
       const keys = Object.keys(c).sort().join(',');
       assert.equal(keys, expected, `unexpected keys on task-chip "${c.id}": ${keys}`);


### PR DESCRIPTION
Adds diegetic canvas inspection:
- canvas hit-testing for task chips, agents, and diegetic indicator areas
- hover/click selection state
- themed inspection popover
- quieter normal mode labels/streams/agent plaques
- debug mode keeps raw IDs, bounds, and full zone hit-testing

No TaskEngine, worker, provider, selector, lifecycle event, or event taxonomy changes.