### PR TITLE
feat(ui): add scene anchors and depth polish

### DIFF
--- a/rendering/agent-entity-renderer.js
+++ b/rendering/agent-entity-renderer.js
@@ -24,6 +24,7 @@ import {
 } from '../core/constants.js';
 import { hashString } from '../core/utils.js';
 import { isRenderDebugEnabled, debugPointer } from './debug.js';
+import { compareByDepthY } from './scene-anchors.js';
 
 // ---------------------------------------------------------------------------
 // Static visual style table — one entry per supported visualState
@@ -268,17 +269,22 @@ export function renderAgentEntity(ctx, component, frameNow) {
   const offsets = (component.deskId && DESK_SPRITE_OFFSETS[component.deskId])
     ? DESK_SPRITE_OFFSETS[component.deskId]
     : { dx: 0, dy: 0 };
+  const anchorScale = Number.isFinite(component.scale) && component.scale > 0 ? component.scale : 1;
 
   if (spriteImage) {
     if (sizes) {
       // Desk sprite — fixed dimensions, no frame animation.
+      const drawW = sizes.w * anchorScale;
+      const drawH = sizes.h * anchorScale;
+      const drawDx = offsets.dx * anchorScale;
+      const drawDy = offsets.dy * anchorScale;
       ctx.drawImage(spriteImage,
-        x - sizes.w / 2 + offsets.dx,
-        y - sizes.h / 2 + offsets.dy,
-        sizes.w, sizes.h);
+        x - drawW / 2 + drawDx,
+        y - drawH / 2 + drawDy,
+        drawW, drawH);
 
       if (isRenderDebugEnabled()) {
-        const label = spriteFilename.replace('.png', '');
+        const label = `${spriteFilename.replace('.png', '')} @${anchorScale.toFixed(2)}`;
         ctx.font      = '8px monospace';
         ctx.fillStyle = style.stroke;
         ctx.textAlign = 'center';
@@ -292,7 +298,12 @@ export function renderAgentEntity(ctx, component, frameNow) {
       // are propagated through the component descriptor.
       const now   = typeof frameNow === 'number' ? frameNow : Date.now();
       const frame = resolveSpriteFrame(null, spriteImage, now, component.id);
-      const drawSize = resolveSpriteDrawSize(frame);
+      const baseDrawSize = resolveSpriteDrawSize(frame);
+      const drawSize = {
+        width: baseDrawSize.width * anchorScale,
+        height: baseDrawSize.height * anchorScale,
+        scale: baseDrawSize.scale * anchorScale,
+      };
 
       const isHovered = debugPointer.inside
         && Number.isFinite(debugPointer.x)
@@ -319,7 +330,7 @@ export function renderAgentEntity(ctx, component, frameNow) {
   } else {
     // Keep geometry fallback while images are still loading.
     ctx.beginPath();
-    ctx.arc(x, y, style.radius, 0, Math.PI * 2);
+    ctx.arc(x, y, style.radius * anchorScale, 0, Math.PI * 2);
     ctx.fillStyle   = style.fill;
     ctx.strokeStyle = style.stroke;
     ctx.lineWidth   = 2;
@@ -330,7 +341,7 @@ export function renderAgentEntity(ctx, component, frameNow) {
   // Anomaly ring — drawn over the body when anomaly is present
   if (component.anomaly) {
     ctx.beginPath();
-    ctx.arc(x, y, style.radius + 4, 0, Math.PI * 2);
+    ctx.arc(x, y, style.radius * anchorScale + 4, 0, Math.PI * 2);
     ctx.strokeStyle = component.anomaly.severity === 'high' ? '#d32f2f' : '#f57c00';
     ctx.lineWidth   = 2;
     ctx.stroke();
@@ -341,9 +352,9 @@ export function renderAgentEntity(ctx, component, frameNow) {
   // and warm cream text, replacing the plain debug-style dark rectangle.
   if (component.id) {
     const isDebugMode = isRenderDebugEnabled();
-    const tagOffsetDx = offsets.dx;
-    const tagOffsetDy = offsets.dy;
-    const tagH  = sizes ? sizes.h : (spriteConfigs?.agent?.height ?? 54);
+    const tagOffsetDx = offsets.dx * anchorScale;
+    const tagOffsetDy = offsets.dy * anchorScale;
+    const tagH  = (sizes ? sizes.h : (spriteConfigs?.agent?.height ?? 54)) * anchorScale;
     const tagX  = x + tagOffsetDx;
     const tagY  = y - tagH / 2 + tagOffsetDy - 6;
 
@@ -414,10 +425,15 @@ export function renderAgentEntity(ctx, component, frameNow) {
  */
 export function renderAllAgentEntities(ctx, components, entityPositions, frameNow) {
   if (!ctx || !Array.isArray(components)) return;
-  for (const c of components) {
-    if (c && c.componentType === 'agent-sprite') {
+  const agents = components
+    .filter((c) => c && c.componentType === 'agent-sprite')
+    .map((c) => {
       const p = entityPositions && entityPositions.get(c.id);
-      renderAgentEntity(ctx, p ? { ...c, x: p.x, y: p.y } : c, frameNow);
-    }
+      return p ? { ...c, ...p } : c;
+    })
+    .sort(compareByDepthY);
+
+  for (const c of agents) {
+    renderAgentEntity(ctx, c, frameNow);
   }
 }

--- a/rendering/canvas-hit-test.js
+++ b/rendering/canvas-hit-test.js
@@ -5,7 +5,7 @@
  * descriptors and computed entity positions supplied by the canvas pipeline.
  */
 
-import { ZONE_INDICATOR_ANCHORS } from './diegetic-indicator-renderer.js';
+import { ZONE_INDICATOR_ANCHORS } from './scene-anchors.js';
 
 const TASK_CHIP_BOUNDS = Object.freeze({ width: 36, height: 16 });
 const ZONE_INDICATOR_BOUNDS = Object.freeze({ width: 48, height: 48 });
@@ -94,6 +94,15 @@ function getZoneIndicatorHitBounds(component) {
   const anchor = component && component.id ? ZONE_INDICATOR_ANCHORS[component.id] : null;
   if (!anchor) {
     return null;
+  }
+
+  if (anchor.bounds) {
+    return {
+      x: anchor.bounds.x,
+      y: anchor.bounds.y,
+      width: anchor.bounds.width,
+      height: anchor.bounds.height,
+    };
   }
 
   return {

--- a/rendering/connection-renderer.js
+++ b/rendering/connection-renderer.js
@@ -37,8 +37,8 @@ export const FLOW_LINE_STYLE = Object.freeze({
 });
 
 export const NORMAL_FLOW_LINE_STYLE = Object.freeze({
-  stroke: 'rgba(96, 220, 200, 0.20)',
-  width:  1.1,
+  stroke: 'rgba(96, 220, 200, 0.14)',
+  width:  0.85,
 });
 
 // ---------------------------------------------------------------------------
@@ -76,6 +76,8 @@ export function renderConnection(ctx, fromPos, toPos, frame, isDebugMode = false
   const cy = Math.abs(dy) > Math.abs(dx) ? my        : my - bow;
 
   ctx.save();
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
   ctx.beginPath();
   ctx.moveTo(fromPos.x, fromPos.y);
   ctx.quadraticCurveTo(cx, cy, toPos.x, toPos.y);

--- a/rendering/diegetic-indicator-renderer.js
+++ b/rendering/diegetic-indicator-renderer.js
@@ -22,29 +22,17 @@
  *  - Positions are hardcoded to match the 1060×520 background layout
  */
 
-// ---------------------------------------------------------------------------
-// Indicator anchor positions — matched to the 1060×520 canvas background
-// ---------------------------------------------------------------------------
+export {
+  ZONE_INDICATOR_ANCHORS,
+  ENGINE_CRYSTAL_ANCHOR,
+  ANOMALY_ANCHOR,
+} from './scene-anchors.js';
 
-/**
- * Per-lifecycle-zone indicator anchor (canvas x/y).
- * Each entry sits near a visually meaningful area within the zone.
- *
- * @type {Readonly<Record<string, Readonly<{ x: number, y: number }>>>}
- */
-export const ZONE_INDICATOR_ANCHORS = Object.freeze({
-  CREATED:          Object.freeze({ x: 107, y: 165 }),  // intake nook desk surface
-  ENQUEUED:         Object.freeze({ x: 117, y: 358 }),  // rune-stone area
-  CLAIMED:          Object.freeze({ x: 297, y: 240 }),  // workshop floor centre
-  EXECUTE_FINISHED: Object.freeze({ x: 657, y: 240 }),  // delivery bay floor centre
-  ACKED:            Object.freeze({ x: 894, y: 182 }),  // archive shelving upper area
-});
-
-/** Engine-crystal pulse anchor — base of the central tree crystal. */
-export const ENGINE_CRYSTAL_ANCHOR = Object.freeze({ x: 480, y: 388 });
-
-/** Anomaly shelf anchor — lower-right quadrant of the ACKED zone. */
-export const ANOMALY_ANCHOR = Object.freeze({ x: 878, y: 415 });
+import {
+  ZONE_INDICATOR_ANCHORS,
+  ENGINE_CRYSTAL_ANCHOR,
+  ANOMALY_ANCHOR,
+} from './scene-anchors.js';
 
 // ---------------------------------------------------------------------------
 // Visual constants

--- a/rendering/scene-anchors.js
+++ b/rendering/scene-anchors.js
@@ -1,0 +1,90 @@
+/**
+ * scene-anchors.js
+ *
+ * Frozen anchor data for placing rendered assets into the illustrated
+ * Slothworld treehouse. These are rendering-only coordinates; they do not
+ * derive lifecycle state or inspect events.
+ */
+
+export const SCENE_CANVAS = Object.freeze({ width: 1060, height: 520 });
+
+function anchor(config) {
+  return Object.freeze({
+    x: config.x,
+    y: config.y,
+    scale: config.scale,
+    depthY: config.depthY,
+    ...(config.bounds
+      ? {
+          bounds: Object.freeze({
+            x: config.bounds.x,
+            y: config.bounds.y,
+            width: config.bounds.width,
+            height: config.bounds.height,
+          }),
+        }
+      : {}),
+  });
+}
+
+export const SCENE_ANCHORS = Object.freeze({
+  desks: Object.freeze({
+    'desk-0': anchor({ x: 370, y: 220, scale: 0.94, depthY: 246, bounds: { x: 280, y: 135, width: 180, height: 170 } }),
+    'desk-1': anchor({ x: 740, y: 230, scale: 0.82, depthY: 250, bounds: { x: 590, y: 155, width: 300, height: 150 } }),
+    'desk-2': anchor({ x: 840, y: 275, scale: 0.88, depthY: 296, bounds: { x: 690, y: 200, width: 300, height: 150 } }),
+    'desk-3': anchor({ x: 580, y: 420, scale: 1.06, depthY: 444, bounds: { x: 480, y: 332, width: 200, height: 175 } }),
+    'desk-4': anchor({ x: 750, y: 450, scale: 1.10, depthY: 472, bounds: { x: 600, y: 370, width: 300, height: 145 } }),
+    'desk-5': anchor({ x: 880, y: 380, scale: 1.00, depthY: 404, bounds: { x: 730, y: 305, width: 300, height: 150 } }),
+  }),
+  chairs: Object.freeze({
+    'chair-0': anchor({ x: 346, y: 236, scale: 0.92, depthY: 244 }),
+    'chair-1': anchor({ x: 710, y: 246, scale: 0.80, depthY: 252 }),
+    'chair-2': anchor({ x: 812, y: 292, scale: 0.86, depthY: 300 }),
+    'chair-3': anchor({ x: 552, y: 440, scale: 1.04, depthY: 448 }),
+    'chair-4': anchor({ x: 722, y: 466, scale: 1.08, depthY: 474 }),
+    'chair-5': anchor({ x: 852, y: 396, scale: 0.98, depthY: 406 }),
+  }),
+  shelves: Object.freeze({
+    intakeShelf: anchor({ x: 107, y: 165, scale: 0.82, depthY: 182, bounds: { x: 83, y: 141, width: 48, height: 48 } }),
+    queueRunes: anchor({ x: 117, y: 358, scale: 0.95, depthY: 368, bounds: { x: 93, y: 334, width: 48, height: 48 } }),
+    archiveShelf: anchor({ x: 894, y: 182, scale: 0.88, depthY: 206, bounds: { x: 870, y: 158, width: 48, height: 48 } }),
+  }),
+  crystal: Object.freeze({
+    engineCrystal: anchor({ x: 480, y: 388, scale: 1.00, depthY: 392, bounds: { x: 456, y: 364, width: 48, height: 48 } }),
+  }),
+  river: Object.freeze({
+    lowerStream: anchor({ x: 518, y: 456, scale: 1.00, depthY: 456, bounds: { x: 210, y: 406, width: 616, height: 84 } }),
+  }),
+  warningShelf: Object.freeze({
+    anomalyShelf: anchor({ x: 878, y: 415, scale: 1.00, depthY: 426, bounds: { x: 854, y: 391, width: 48, height: 48 } }),
+  }),
+  approvalDesk: Object.freeze({
+    deliveryDesk: anchor({ x: 657, y: 240, scale: 0.90, depthY: 262, bounds: { x: 633, y: 216, width: 48, height: 48 } }),
+  }),
+});
+
+export const ZONE_INDICATOR_ANCHORS = Object.freeze({
+  CREATED: Object.freeze(SCENE_ANCHORS.shelves.intakeShelf),
+  ENQUEUED: Object.freeze(SCENE_ANCHORS.shelves.queueRunes),
+  CLAIMED: Object.freeze({ x: 297, y: 240, scale: 0.92, depthY: 260, bounds: Object.freeze({ x: 273, y: 216, width: 48, height: 48 }) }),
+  EXECUTE_FINISHED: Object.freeze(SCENE_ANCHORS.approvalDesk.deliveryDesk),
+  ACKED: Object.freeze(SCENE_ANCHORS.shelves.archiveShelf),
+});
+
+export const ENGINE_CRYSTAL_ANCHOR = SCENE_ANCHORS.crystal.engineCrystal;
+export const ANOMALY_ANCHOR = SCENE_ANCHORS.warningShelf.anomalyShelf;
+
+export function getDeskAnchor(deskId) {
+  return deskId && SCENE_ANCHORS.desks[deskId] ? SCENE_ANCHORS.desks[deskId] : null;
+}
+
+export function getZoneIndicatorAnchor(zoneId) {
+  return zoneId && ZONE_INDICATOR_ANCHORS[zoneId] ? ZONE_INDICATOR_ANCHORS[zoneId] : null;
+}
+
+export function compareByDepthY(a, b) {
+  const da = Number.isFinite(a?.depthY) ? a.depthY : (Number.isFinite(a?.y) ? a.y : 0);
+  const db = Number.isFinite(b?.depthY) ? b.depthY : (Number.isFinite(b?.y) ? b.y : 0);
+  if (da !== db) return da - db;
+  return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+}

--- a/rendering/task-chip-renderer.js
+++ b/rendering/task-chip-renderer.js
@@ -22,6 +22,8 @@
  *  - No DOM or asset dependencies — safe to import in headless test environments
  */
 
+import { compareByDepthY } from './scene-anchors.js';
+
 // ---------------------------------------------------------------------------
 // Card geometry constants
 // ---------------------------------------------------------------------------
@@ -282,12 +284,17 @@ function drawAnomalyBadge(ctx, x, y, anomaly) {
 export function renderAllTaskChips(ctx, components, entityPositions, isDebugMode) {
   if (!ctx || !Array.isArray(components)) return;
 
-  for (const c of components) {
-    if (!c || c.componentType !== 'task-chip') continue;
+  const chips = components
+    .filter((c) => c && c.componentType === 'task-chip')
+    .map((c) => {
+      const p = entityPositions && entityPositions.get(c.id);
+      return p ? { ...c, ...p } : c;
+    })
+    .sort(compareByDepthY);
 
-    const p = entityPositions && entityPositions.get(c.id);
-    const x = p ? p.x : (typeof c.x === 'number' ? c.x : 0);
-    const y = p ? p.y : (typeof c.y === 'number' ? c.y : 0);
+  for (const c of chips) {
+    const x = typeof c.x === 'number' ? c.x : 0;
+    const y = typeof c.y === 'number' ? c.y : 0;
 
     let chipAlpha = 1;
     if (!isDebugMode) {

--- a/rendering/world-scene-asset-renderer.js
+++ b/rendering/world-scene-asset-renderer.js
@@ -27,6 +27,7 @@ import { ASSET_MAPPING, loadedAssets } from './assets.js';
 import { CENTRAL_STRUCTURE, DECORATIONS } from './world-scene.js';
 import { renderTreehouseBackdrop } from './world-background-composition.js';
 import { spriteConfigs } from '../core/constants.js';
+import { compareByDepthY } from './scene-anchors.js';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -722,7 +723,8 @@ export function renderConnectionLayer(ctx, components, entityPositions, isDebugM
   let idx = 0;
   ctx.save();
   if (!isDebugMode) {
-    ctx.globalAlpha = 0.28;
+    ctx.globalAlpha = 0.18;
+    ctx.globalCompositeOperation = 'screen';
   }
   for (const c of components) {
     if (c.componentType !== 'flow-line') continue;
@@ -770,9 +772,14 @@ export function renderPropLayer(ctx, components, entityPositions) {
   const taskAssets  = ASSET_MAPPING.props.task;
   const booksAssets = ASSET_MAPPING.props.books;
   let   debugLogged = false;
-  for (const c of components) {
-    if (c.componentType !== 'agent-sprite') continue;
-    const { x, y }  = posOf(c, entityPositions);
+  const agents = components
+    .filter((c) => c && c.componentType === 'agent-sprite')
+    .map((c) => ({ ...c, ...posOf(c, entityPositions) }))
+    .sort(compareByDepthY);
+
+  for (const c of agents) {
+    const { x, y, scale = 1 }  = c;
+    const propSize = PROP_SIZE * (Number.isFinite(scale) ? scale : 1);
     // Props offset relative to agent anchor; larger PROP_SIZE to stay visible
     // next to the now-bigger sloth sprites.
     const taskFile  = taskAssets[deterministicIndex(c.id, taskAssets.length)];
@@ -782,8 +789,8 @@ export function renderPropLayer(ctx, components, entityPositions) {
         '| books prop:', booksFile, '| loaded:', !!loadedAssets[booksFile]);
       debugLogged = true;
     }
-    drawIfLoaded(ctx, taskFile,  x + 22, y - 6, PROP_SIZE, PROP_SIZE);
-    drawIfLoaded(ctx, booksFile, x - 22, y - 6, PROP_SIZE, PROP_SIZE);
+    drawIfLoaded(ctx, taskFile,  x + 22, y - 6, propSize, propSize);
+    drawIfLoaded(ctx, booksFile, x - 22, y - 6, propSize, propSize);
   }
 }
 

--- a/rendering/zone-renderer.js
+++ b/rendering/zone-renderer.js
@@ -17,6 +17,8 @@
  *  - No event access, no selector access, no lifecycle inference
  */
 
+import { SCENE_ANCHORS, getDeskAnchor } from './scene-anchors.js';
+
 // ---------------------------------------------------------------------------
 // Static visual style for zones
 // ---------------------------------------------------------------------------
@@ -52,14 +54,7 @@ export const ZONE_STYLE = Object.freeze({
 // Background image is 1376×768; canvas is 1060×520 (scale ≈ 0.770x, 0.677y).
 // Anchor = desk surface centre. left_back dx offset is handled in
 // agent-entity-renderer.js (DESK_SPRITE_OFFSETS), not here.
-export const DESK_POSITIONS = Object.freeze({
-  'desk-0': Object.freeze({ x: 370, y: 220 }),  // left mushroom platform (right_front)
-  'desk-1': Object.freeze({ x: 740, y: 230 }),  // upper-right first desk  (left_front)
-  'desk-2': Object.freeze({ x: 840, y: 275 }),  // upper-right second desk (left_front)
-  'desk-3': Object.freeze({ x: 580, y: 420 }),  // lower-centre desk       (right_back)
-  'desk-4': Object.freeze({ x: 750, y: 450 }),  // lower-right first desk  (left_back) +14dx in renderer
-  'desk-5': Object.freeze({ x: 880, y: 380 }),  // far lower-right desk    (left_back) +14dx in renderer
-});
+export const DESK_POSITIONS = SCENE_ANCHORS.desks;
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -180,8 +175,15 @@ export function buildEntityPositionMap(components) {
 
     // Prefer desk-specific position when deskId is known — gives accurate
     // per-desk placement without any layout computation.
-    if (c.deskId && DESK_POSITIONS[c.deskId]) {
-      positions.set(c.id, { ...DESK_POSITIONS[c.deskId] });
+    const deskAnchor = getDeskAnchor(c.deskId);
+    if (deskAnchor) {
+      positions.set(c.id, {
+        x: deskAnchor.x,
+        y: deskAnchor.y,
+        scale: deskAnchor.scale,
+        depthY: deskAnchor.depthY,
+        anchorId: c.deskId,
+      });
       continue;
     }
 
@@ -189,7 +191,9 @@ export function buildEntityPositionMap(components) {
 
     if (!zone) {
       // No zone assigned — use the component's own x/y directly
-      positions.set(c.id, { x: c.x ?? 0, y: c.y ?? 0 });
+      const x = c.x ?? 0;
+      const y = c.y ?? 0;
+      positions.set(c.id, { x, y, scale: 1, depthY: y });
       continue;
     }
 
@@ -201,7 +205,7 @@ export function buildEntityPositionMap(components) {
     const px = zone.x + ZONE_STYLE.padding + slotWidth / 2 + slotIndex * slotWidth;
     const py = zone.y + (zone.height ?? 0) / 2;
 
-    positions.set(c.id, { x: px, y: py });
+    positions.set(c.id, { x: px, y: py, scale: 1, depthY: py });
   }
 
   return positions;

--- a/tests/scene-anchors.test.mjs
+++ b/tests/scene-anchors.test.mjs
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SCENE_ANCHORS,
+  SCENE_CANVAS,
+  ZONE_INDICATOR_ANCHORS,
+  compareByDepthY,
+  getDeskAnchor,
+} from '../rendering/scene-anchors.js';
+import { buildEntityPositionMap } from '../rendering/zone-renderer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+function flattenAnchors(grouped) {
+  const anchors = [];
+  for (const [groupName, group] of Object.entries(grouped)) {
+    for (const [anchorName, anchor] of Object.entries(group)) {
+      anchors.push({ groupName, anchorName, anchor });
+    }
+  }
+  return anchors;
+}
+
+test('scene anchors: all anchors are finite and within canvas', () => {
+  for (const { groupName, anchorName, anchor } of flattenAnchors(SCENE_ANCHORS)) {
+    const label = `${groupName}.${anchorName}`;
+    assert.ok(Number.isFinite(anchor.x), `${label}.x`);
+    assert.ok(Number.isFinite(anchor.y), `${label}.y`);
+    assert.ok(Number.isFinite(anchor.scale), `${label}.scale`);
+    assert.ok(Number.isFinite(anchor.depthY), `${label}.depthY`);
+    assert.ok(anchor.x >= 0 && anchor.x <= SCENE_CANVAS.width, `${label}.x canvas bounds`);
+    assert.ok(anchor.y >= 0 && anchor.y <= SCENE_CANVAS.height, `${label}.y canvas bounds`);
+    assert.ok(anchor.depthY >= 0 && anchor.depthY <= SCENE_CANVAS.height, `${label}.depthY canvas bounds`);
+    assert.ok(anchor.scale > 0 && anchor.scale <= 1.5, `${label}.scale usable range`);
+
+    if (anchor.bounds) {
+      assert.ok(anchor.bounds.x >= 0, `${label}.bounds.x`);
+      assert.ok(anchor.bounds.y >= 0, `${label}.bounds.y`);
+      assert.ok(anchor.bounds.width > 0, `${label}.bounds.width`);
+      assert.ok(anchor.bounds.height > 0, `${label}.bounds.height`);
+      assert.ok(anchor.bounds.x + anchor.bounds.width <= SCENE_CANVAS.width, `${label}.bounds right`);
+      assert.ok(anchor.bounds.y + anchor.bounds.height <= SCENE_CANVAS.height, `${label}.bounds bottom`);
+    }
+  }
+});
+
+test('scene anchors: required diegetic indicator anchors remain available', () => {
+  assert.deepStrictEqual(
+    Object.keys(ZONE_INDICATOR_ANCHORS).sort(),
+    ['ACKED', 'CLAIMED', 'CREATED', 'ENQUEUED', 'EXECUTE_FINISHED'].sort(),
+  );
+});
+
+test('scene anchors: desk positions preserve assignment-derived placement metadata', () => {
+  const components = [
+    { componentType: 'agent-sprite', id: 'sloth-1', deskId: 'desk-0', x: 0, y: 0 },
+    { componentType: 'agent-sprite', id: 'sloth-2', deskId: 'desk-4', x: 0, y: 0 },
+  ];
+  const positions = buildEntityPositionMap(components);
+
+  for (const component of components) {
+    const anchor = getDeskAnchor(component.deskId);
+    const pos = positions.get(component.id);
+    assert.deepStrictEqual(pos, {
+      x: anchor.x,
+      y: anchor.y,
+      scale: anchor.scale,
+      depthY: anchor.depthY,
+      anchorId: component.deskId,
+    });
+  }
+});
+
+test('scene anchors: depth sorting is deterministic with stable tie-breaks', () => {
+  const input = [
+    { id: 'b', y: 200, depthY: 300 },
+    { id: 'c', y: 400, depthY: 300 },
+    { id: 'a', y: 100, depthY: 120 },
+  ];
+
+  const first = [...input].sort(compareByDepthY).map((item) => item.id);
+  const second = [...input].sort(compareByDepthY).map((item) => item.id);
+
+  assert.deepStrictEqual(first, ['a', 'b', 'c']);
+  assert.deepStrictEqual(second, first);
+});
+
+test('scene anchors: renderer anchoring code does not read raw event or payload sources', () => {
+  const files = [
+    'rendering/scene-anchors.js',
+    'rendering/zone-renderer.js',
+    'rendering/agent-entity-renderer.js',
+    'rendering/task-chip-renderer.js',
+    'rendering/world-scene-layer-renderer.js',
+  ];
+  const forbidden = [
+    /\beventsByTaskId\b/,
+    /\beventsByWorkerId\b/,
+    /\bgetRawEvents\b/,
+    /\bpayload\s*\./,
+    /\bevent\s*\.\s*(?:type|payload|taskId|workerId|timestamp)\b/,
+    /\bindexedWorldSnapshot\b/,
+  ];
+
+  for (const file of files) {
+    const source = readFileSync(resolve(ROOT, file), 'utf8')
+      .split('\n')
+      .filter((line) => !/^\s*(?:\/\*|\*|\/\/)/.test(line))
+      .join('\n');
+    for (const re of forbidden) {
+      assert.ok(!re.test(source), `${file} must not match ${re}`);
+    }
+  }
+});
+
+test('scene anchors: debug mode flag remains renderer-only and available', () => {
+  const source = readFileSync(resolve(ROOT, 'rendering/world-scene-layer-renderer.js'), 'utf8');
+  assert.match(source, /__SLOTHWORLD_RENDER_DEBUG__/);
+  assert.match(source, /renderDebug/);
+  assert.match(source, /renderZoneLabels\(ctx, components, isRenderDebug\)/);
+});
+


### PR DESCRIPTION
Adds a render-only scene anchor/depth system to make agents, props, flows, and indicators feel physically embedded in the illustrated treehouse scene.

Changes:
- Adds frozen scene anchor config with x/y/scale/depthY/bounds.
- Routes desk agents through scene anchors while preserving assignment-derived deskId.
- Adds render-only scale/depthY/anchorId metadata.
- Sorts agent sprites and task chips deterministically by depth.
- Tunes normal-mode flow styling to be softer and less synthetic.
- Moves diegetic indicator anchors to shared scene-anchor config.
- Updates hit testing to use anchor bounds for normal-mode indicator hit areas.

Architecture:
- UI/rendering only.
- No TaskEngine, worker, provider, selector, lifecycle event, or event taxonomy changes.
- No raw event/payload/world-index access.
- Debug mode preserved.

Verified:
node --test tests/scene-anchors.test.mjs tests/canvas-inspection.test.mjs tests/diegetic-display-mode.test.mjs tests/world-scene-determinism.test.mjs tests/renderer-boundary.test.mjs tests/renderer-purity.test.mjs