### PR TITLE
feat(ui): add runtime prop asset layer

### DIFF
--- a/rendering/assets.js
+++ b/rendering/assets.js
@@ -96,9 +96,11 @@ export const assetPaths = [
   // ── Flow / stream ──────────────────────────────────────────────────────────
   'assets/slothworldassets/flow_stream_01.png',
   'assets/slothworldassets/flow_stream_cascade_01.png',
+  'assets/slothworldassets/flow_stream_small_01.png',
 
   // ── UI overlays ────────────────────────────────────────────────────────────
   'assets/slothworldassets/ui_floating_display_01.png',
+  'assets/slothworldassets/ui_floating_display_02.png',
   'assets/slothworldassets/ui_panel_small_01.png',
   'assets/slothworldassets/createtask.png',
   'assets/slothworldassets/createtaskselected.png',

--- a/rendering/diegetic-indicator-renderer.js
+++ b/rendering/diegetic-indicator-renderer.js
@@ -33,6 +33,7 @@ import {
   ENGINE_CRYSTAL_ANCHOR,
   ANOMALY_ANCHOR,
 } from './scene-anchors.js';
+import { drawRuntimePropAsset } from './prop-asset-renderer.js';
 
 // ---------------------------------------------------------------------------
 // Visual constants
@@ -435,26 +436,46 @@ export function renderDiegeticIndicators(ctx, components, now) {
 
     switch (zoneId) {
       case 'CREATED':
-        drawAtAnchor(anchor, (x, y) => drawPaperStack(ctx, x, y, count));
+        if (!drawRuntimePropAsset(ctx, 'intakePaperStack', { anchor, alpha: count > 0 ? 0.72 : 0.18 })) {
+          drawAtAnchor(anchor, (x, y) => drawPaperStack(ctx, x, y, count));
+        }
         break;
       case 'ENQUEUED':
-        drawAtAnchor(anchor, (x, y) => drawRuneGlow(ctx, x, y, count, safeNow));
+        if (!drawRuntimePropAsset(ctx, 'queueRuneStone', { anchor, alpha: count > 0 ? 0.36 : 0.12 })) {
+          drawAtAnchor(anchor, (x, y) => drawRuneGlow(ctx, x, y, count, safeNow));
+        }
         break;
       case 'CLAIMED':
-        drawAtAnchor(anchor, (x, y) => drawMonitorGlow(ctx, x, y, workingByZone[zoneId] ?? 0, safeNow));
+        if (!drawRuntimePropAsset(ctx, 'monitorGlow', { anchor, alpha: (workingByZone[zoneId] ?? 0) > 0 ? 0.30 : 0.10 })) {
+          drawAtAnchor(anchor, (x, y) => drawMonitorGlow(ctx, x, y, workingByZone[zoneId] ?? 0, safeNow));
+        }
         break;
       case 'EXECUTE_FINISHED':
-        drawAtAnchor(anchor, (x, y) => drawApprovalMarker(ctx, x, y, processingByZone[zoneId] ?? 0, safeNow));
+        if (!drawRuntimePropAsset(ctx, 'approvalMarker', { anchor, alpha: (processingByZone[zoneId] ?? 0) > 0 ? 0.46 : 0.12 })) {
+          drawAtAnchor(anchor, (x, y) => drawApprovalMarker(ctx, x, y, processingByZone[zoneId] ?? 0, safeNow));
+        }
         break;
       case 'ACKED':
-        drawAtAnchor(anchor, (x, y) => drawArchiveGlow(ctx, x, y, completedByZone[zoneId] ?? 0, safeNow));
+        if (!drawRuntimePropAsset(ctx, 'archiveGlow', { anchor, alpha: (completedByZone[zoneId] ?? 0) > 0 ? 0.28 : 0.08 })) {
+          drawAtAnchor(anchor, (x, y) => drawArchiveGlow(ctx, x, y, completedByZone[zoneId] ?? 0, safeNow));
+        }
         break;
     }
   }
 
   // Engine crystal - always drawn
-  drawAtAnchor(ENGINE_CRYSTAL_ANCHOR, (x, y) => drawEngineCrystalPulse(ctx, x, y, totalActive, safeNow));
+  if (!drawRuntimePropAsset(ctx, 'engineCrystalGlow', {
+    anchor: ENGINE_CRYSTAL_ANCHOR,
+    alpha: totalActive > 0 ? 0.42 : 0.18,
+  })) {
+    drawAtAnchor(ENGINE_CRYSTAL_ANCHOR, (x, y) => drawEngineCrystalPulse(ctx, x, y, totalActive, safeNow));
+  }
 
   // Anomaly glint - only when an anomaly is present
-  drawAtAnchor(ANOMALY_ANCHOR, (x, y) => drawAnomalyGlint(ctx, x, y, hasAnomaly, hasHighSeverity, safeNow));
+  if (!hasAnomaly || !drawRuntimePropAsset(ctx, 'anomalyShelfLight', {
+    anchor: ANOMALY_ANCHOR,
+    alpha: hasHighSeverity ? 0.38 : 0.24,
+  })) {
+    drawAtAnchor(ANOMALY_ANCHOR, (x, y) => drawAnomalyGlint(ctx, x, y, hasAnomaly, hasHighSeverity, safeNow));
+  }
 }

--- a/rendering/prop-asset-manifest.js
+++ b/rendering/prop-asset-manifest.js
@@ -1,0 +1,137 @@
+/**
+ * prop-asset-manifest.js
+ *
+ * Rendering-only manifest for transparent PNG runtime props. Entries are
+ * filename/path data plus draw defaults; state remains owned by callers.
+ */
+
+const ASSET_ROOT = 'assets/slothworldassets/';
+
+function entry(filename, config = {}) {
+  return Object.freeze({
+    filename,
+    path: `${ASSET_ROOT}${filename}`,
+    anchor: config.anchor ? Object.freeze({ ...config.anchor }) : null,
+    width: config.width,
+    height: config.height,
+    alpha: config.alpha ?? 1,
+    blend: config.blend ?? 'source-over',
+  });
+}
+
+export const PROP_ASSET_MANIFEST = Object.freeze({
+  engineCrystalGlow: entry('light_tree_glow_01.png', {
+    anchor: { group: 'crystal', key: 'engineCrystal' },
+    width: 76,
+    height: 76,
+    alpha: 0.46,
+    blend: 'screen',
+  }),
+  intakePaperStack: entry('task_stack_01.png', {
+    anchor: { group: 'shelves', key: 'intakeShelf' },
+    width: 34,
+    height: 28,
+    alpha: 0.84,
+  }),
+  queueRuneStone: entry('light_glow_orb_02.png', {
+    anchor: { group: 'shelves', key: 'queueRunes' },
+    width: 34,
+    height: 34,
+    alpha: 0.42,
+    blend: 'screen',
+  }),
+  monitorGlow: entry('ui_floating_display_01.png', {
+    anchor: { group: 'indicators', key: 'claimedMonitor' },
+    width: 36,
+    height: 22,
+    alpha: 0.30,
+    blend: 'screen',
+  }),
+  approvalMarker: entry('createtaskselected.png', {
+    anchor: { group: 'approvalDesk', key: 'deliveryDesk' },
+    width: 30,
+    height: 30,
+    alpha: 0.52,
+    blend: 'screen',
+  }),
+  archiveGlow: entry('light_glow_orb_03.png', {
+    anchor: { group: 'shelves', key: 'archiveShelf' },
+    width: 38,
+    height: 38,
+    alpha: 0.32,
+    blend: 'screen',
+  }),
+  anomalyShelfLight: entry('light_glow_orb_03.png', {
+    anchor: { group: 'warningShelf', key: 'anomalyShelf' },
+    width: 32,
+    height: 32,
+    alpha: 0.38,
+    blend: 'screen',
+  }),
+  dataStreamSoft: entry('flow_stream_small_01.png', {
+    width: 18,
+    height: 9,
+    alpha: 0.12,
+    blend: 'screen',
+  }),
+  dataStreamMain: entry('flow_stream_01.png', {
+    width: 22,
+    height: 11,
+    alpha: 0.18,
+    blend: 'screen',
+  }),
+  deskTerminal: entry('desk_terminal_organic_01.png', {
+    anchor: { group: 'decor', key: 'deskTerminal' },
+    width: 42,
+    height: 30,
+    alpha: 0.74,
+  }),
+  archiveShelf: entry('env_bookshelf_tall_01.png', {
+    anchor: { group: 'decor', key: 'archiveShelf' },
+    width: 96,
+    height: 160,
+    alpha: 0.58,
+  }),
+  mossShelf: entry('storage_shelf_moss_01.png', {
+    anchor: { group: 'decor', key: 'mossShelf' },
+    width: 80,
+    height: 64,
+    alpha: 0.62,
+  }),
+  foregroundVine: entry('decor_vine_01.png', {
+    anchor: { group: 'decor', key: 'foregroundVine' },
+    width: 76,
+    height: 252,
+    alpha: 0.64,
+  }),
+  smallPlants: Object.freeze([
+    entry('decor_plant_small_01.png', {
+      anchor: { group: 'decor', key: 'smallPlants' },
+      width: 28,
+      height: 32,
+      alpha: 0.78,
+    }),
+    entry('decor_plant_small_02.png', {
+      anchor: { group: 'decor', key: 'smallPlants' },
+      width: 26,
+      height: 30,
+      alpha: 0.78,
+    }),
+    entry('decor_plant_small_03.png', {
+      anchor: { group: 'decor', key: 'smallPlants' },
+      width: 24,
+      height: 28,
+      alpha: 0.78,
+    }),
+  ]),
+  booksStack: entry('decor_books_stack_01.png', {
+    anchor: { group: 'decor', key: 'booksStack' },
+    width: 44,
+    height: 42,
+    alpha: 0.72,
+  }),
+});
+
+export function listPropAssetEntries(manifest = PROP_ASSET_MANIFEST) {
+  return Object.values(manifest).flatMap((value) => Array.isArray(value) ? value : [value]);
+}

--- a/rendering/prop-asset-renderer.js
+++ b/rendering/prop-asset-renderer.js
@@ -1,0 +1,59 @@
+/**
+ * prop-asset-renderer.js
+ *
+ * Thin PNG runtime prop renderer. Returns false when an asset is missing so
+ * callers can keep their procedural canvas fallback.
+ */
+
+import { loadedAssets } from './assets.js';
+import { SCENE_ANCHORS } from './scene-anchors.js';
+import { PROP_ASSET_MANIFEST } from './prop-asset-manifest.js';
+
+function finite(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export function resolvePropAnchor(anchorRef, anchors = SCENE_ANCHORS) {
+  if (!anchorRef || !anchorRef.group || !anchorRef.key) return null;
+  return anchors[anchorRef.group]?.[anchorRef.key] ?? null;
+}
+
+export function getPropAssetEntry(assetKey, variantIndex = 0, manifest = PROP_ASSET_MANIFEST) {
+  const entry = manifest[assetKey];
+  if (Array.isArray(entry)) {
+    if (entry.length === 0) return null;
+    const idx = Math.abs(Math.trunc(finite(variantIndex, 0))) % entry.length;
+    return entry[idx];
+  }
+  return entry ?? null;
+}
+
+export function drawRuntimePropAsset(ctx, assetKey, options = {}) {
+  if (!ctx) return false;
+
+  const entry = getPropAssetEntry(assetKey, options.variantIndex);
+  if (!entry) return false;
+
+  const image = loadedAssets[entry.filename];
+  if (!image) return false;
+
+  const anchor = options.anchor || resolvePropAnchor(entry.anchor);
+  const scale = finite(options.scale, finite(anchor?.scale, 1));
+  const x = finite(options.x, finite(anchor?.x, 0));
+  const y = finite(options.y, finite(anchor?.y, 0));
+  const width = finite(options.width, entry.width) * scale;
+  const height = finite(options.height, entry.height) * scale;
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return false;
+  }
+
+  ctx.save();
+  ctx.globalAlpha = finite(options.alpha, entry.alpha);
+  ctx.globalCompositeOperation = options.blend || entry.blend || 'source-over';
+  ctx.drawImage(image, x - width / 2, y - height / 2, width, height);
+  ctx.restore();
+
+  return true;
+}
+

--- a/rendering/scene-anchors.js
+++ b/rendering/scene-anchors.js
@@ -61,12 +61,23 @@ export const SCENE_ANCHORS = Object.freeze({
   approvalDesk: Object.freeze({
     deliveryDesk: anchor({ x: 646, y: 248, scale: 0.76, depthY: 266, bounds: { x: 625, y: 227, width: 42, height: 42 } }),
   }),
+  indicators: Object.freeze({
+    claimedMonitor: anchor({ x: 286, y: 246, scale: 0.78, depthY: 262, bounds: { x: 265, y: 225, width: 42, height: 42 } }),
+  }),
+  decor: Object.freeze({
+    foregroundVine: anchor({ x: 1008, y: 276, scale: 0.74, depthY: 512, bounds: { x: 968, y: 150, width: 76, height: 252 } }),
+    smallPlants: anchor({ x: 708, y: 420, scale: 0.56, depthY: 432, bounds: { x: 684, y: 392, width: 48, height: 56 } }),
+    booksStack: anchor({ x: 904, y: 118, scale: 0.48, depthY: 138, bounds: { x: 882, y: 96, width: 44, height: 42 } }),
+    deskTerminal: anchor({ x: 288, y: 232, scale: 0.42, depthY: 238, bounds: { x: 270, y: 214, width: 36, height: 28 } }),
+    archiveShelf: anchor({ x: 925, y: 170, scale: 0.58, depthY: 218, bounds: { x: 878, y: 74, width: 96, height: 160 } }),
+    mossShelf: anchor({ x: 818, y: 338, scale: 0.50, depthY: 368, bounds: { x: 780, y: 306, width: 76, height: 60 } }),
+  }),
 });
 
 export const ZONE_INDICATOR_ANCHORS = Object.freeze({
   CREATED: Object.freeze(SCENE_ANCHORS.shelves.intakeShelf),
   ENQUEUED: Object.freeze(SCENE_ANCHORS.shelves.queueRunes),
-  CLAIMED: Object.freeze({ x: 286, y: 246, scale: 0.78, depthY: 262, bounds: Object.freeze({ x: 265, y: 225, width: 42, height: 42 }) }),
+  CLAIMED: Object.freeze(SCENE_ANCHORS.indicators.claimedMonitor),
   EXECUTE_FINISHED: Object.freeze(SCENE_ANCHORS.approvalDesk.deliveryDesk),
   ACKED: Object.freeze(SCENE_ANCHORS.shelves.archiveShelf),
 });

--- a/rendering/world-scene-asset-renderer.js
+++ b/rendering/world-scene-asset-renderer.js
@@ -28,6 +28,7 @@ import { CENTRAL_STRUCTURE, DECORATIONS } from './world-scene.js';
 import { renderTreehouseBackdrop } from './world-background-composition.js';
 import { spriteConfigs } from '../core/constants.js';
 import { compareByDepthY } from './scene-anchors.js';
+import { drawRuntimePropAsset } from './prop-asset-renderer.js';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -734,7 +735,17 @@ export function renderConnectionLayer(ctx, components, entityPositions, isDebugM
       const mx = (fromPos.x + toPos.x) / 2;
       const my = (fromPos.y + toPos.y) / 2;
       const filename = flowAssets[idx % flowAssets.length];
-      drawIfLoaded(ctx, filename, mx - FLOW_SIZE.w / 2, my - FLOW_SIZE.h / 2, FLOW_SIZE.w, FLOW_SIZE.h);
+      const assetKey = isDebugMode ? 'dataStreamMain' : 'dataStreamSoft';
+      const drawn = drawRuntimePropAsset(ctx, assetKey, {
+        x: mx,
+        y: my,
+        width: isDebugMode ? 22 : 18,
+        height: isDebugMode ? 11 : 9,
+        alpha: isDebugMode ? 0.18 : 0.10,
+      });
+      if (!drawn) {
+        drawIfLoaded(ctx, filename, mx - FLOW_SIZE.w / 2, my - FLOW_SIZE.h / 2, FLOW_SIZE.w, FLOW_SIZE.h);
+      }
     }
     idx++;
   }

--- a/tests/prop-asset-runtime.test.mjs
+++ b/tests/prop-asset-runtime.test.mjs
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assetPaths, loadedAssets } from '../rendering/assets.js';
+import { PROP_ASSET_MANIFEST, listPropAssetEntries } from '../rendering/prop-asset-manifest.js';
+import { SCENE_ANCHORS } from '../rendering/scene-anchors.js';
+import {
+  drawRuntimePropAsset,
+  getPropAssetEntry,
+  resolvePropAnchor,
+} from '../rendering/prop-asset-renderer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+function makeMockCtx() {
+  const calls = [];
+  return {
+    calls,
+    save: () => calls.push(['save']),
+    restore: () => calls.push(['restore']),
+    drawImage: (...args) => calls.push(['drawImage', ...args]),
+    set globalAlpha(value) { calls.push(['setGlobalAlpha', value]); },
+    set globalCompositeOperation(value) { calls.push(['setGlobalCompositeOperation', value]); },
+  };
+}
+
+test('runtime prop assets: manifest is frozen and deterministic', () => {
+  assert.ok(Object.isFrozen(PROP_ASSET_MANIFEST));
+  assert.ok(Object.isFrozen(PROP_ASSET_MANIFEST.smallPlants));
+
+  const first = JSON.stringify(PROP_ASSET_MANIFEST);
+  const second = JSON.stringify(PROP_ASSET_MANIFEST);
+  assert.equal(first, second);
+});
+
+test('runtime prop assets: every manifest entry has a valid preload path', () => {
+  const preloadPaths = new Set(assetPaths);
+
+  for (const entry of listPropAssetEntries()) {
+    assert.ok(entry.filename.endsWith('.png'), `${entry.filename} must be a PNG prop`);
+    assert.ok(entry.path.startsWith('assets/slothworldassets/'), `${entry.filename} asset root`);
+    assert.ok(preloadPaths.has(entry.path), `${entry.path} must be preloaded`);
+    assert.ok(Number.isFinite(entry.width) && entry.width > 0, `${entry.filename}.width`);
+    assert.ok(Number.isFinite(entry.height) && entry.height > 0, `${entry.filename}.height`);
+    assert.ok(Number.isFinite(entry.alpha) && entry.alpha >= 0 && entry.alpha <= 1, `${entry.filename}.alpha`);
+  }
+});
+
+test('runtime prop assets: anchored manifest entries resolve to scene anchors', () => {
+  for (const entry of listPropAssetEntries()) {
+    if (!entry.anchor) continue;
+    const anchor = resolvePropAnchor(entry.anchor);
+    assert.equal(anchor, SCENE_ANCHORS[entry.anchor.group][entry.anchor.key]);
+    assert.ok(Number.isFinite(anchor.x), `${entry.filename}.anchor.x`);
+    assert.ok(Number.isFinite(anchor.y), `${entry.filename}.anchor.y`);
+  }
+});
+
+test('runtime prop assets: missing image assets return false and do not throw', () => {
+  const ctx = makeMockCtx();
+  const previous = loadedAssets['task_stack_01.png'];
+  delete loadedAssets['task_stack_01.png'];
+
+  assert.doesNotThrow(() => {
+    assert.equal(drawRuntimePropAsset(ctx, 'intakePaperStack'), false);
+  });
+  assert.ok(!ctx.calls.some((call) => call[0] === 'drawImage'));
+
+  if (previous) loadedAssets['task_stack_01.png'] = previous;
+});
+
+test('runtime prop assets: loaded images draw through manifest geometry', () => {
+  const ctx = makeMockCtx();
+  const previous = loadedAssets['task_stack_01.png'];
+  const image = { width: 32, height: 32 };
+  loadedAssets['task_stack_01.png'] = image;
+
+  assert.equal(drawRuntimePropAsset(ctx, 'intakePaperStack'), true);
+  assert.ok(ctx.calls.some((call) => call[0] === 'drawImage' && call[1] === image));
+
+  if (previous) {
+    loadedAssets['task_stack_01.png'] = previous;
+  } else {
+    delete loadedAssets['task_stack_01.png'];
+  }
+});
+
+test('runtime prop assets: array variants are selected deterministically', () => {
+  assert.equal(getPropAssetEntry('smallPlants', 0).filename, 'decor_plant_small_01.png');
+  assert.equal(getPropAssetEntry('smallPlants', 1).filename, 'decor_plant_small_02.png');
+  assert.equal(getPropAssetEntry('smallPlants', 4).filename, 'decor_plant_small_02.png');
+});
+
+test('runtime prop assets: renderer modules do not read raw event or payload sources', () => {
+  const files = [
+    'rendering/prop-asset-manifest.js',
+    'rendering/prop-asset-renderer.js',
+    'rendering/diegetic-indicator-renderer.js',
+    'rendering/world-scene-asset-renderer.js',
+  ];
+  const forbidden = [
+    /\beventsByTaskId\b/,
+    /\beventsByWorkerId\b/,
+    /\bgetRawEvents\b/,
+    /\bpayload\s*\./,
+    /\bevent\s*\.\s*(?:type|payload|taskId|workerId|timestamp)\b/,
+    /\bindexedWorldSnapshot\b/,
+    /\bworldIndex\b/,
+    /\buiendgoal\b/,
+  ];
+
+  for (const file of files) {
+    const source = readFileSync(resolve(ROOT, file), 'utf8')
+      .split('\n')
+      .filter((line) => !/^\s*(?:\/\*|\*|\/\/)/.test(line))
+      .join('\n');
+    for (const re of forbidden) {
+      assert.ok(!re.test(source), `${file} must not match ${re}`);
+    }
+  }
+});
+


### PR DESCRIPTION
Adds a runtime prop asset layer for Slothworld UI props/effects using existing assets in assets/slothworldassets.

Changes:
- Adds frozen prop asset manifest.
- Adds prop asset renderer that draws loaded PNGs through the existing loadedAssets path.
- Falls back to procedural canvas indicators when assets are missing/not loaded.
- Integrates prop assets with diegetic indicators:
  - engine crystal glow
  - intake paper stack
  - queue rune/glow
  - monitor glow
  - approval marker
  - archive glow
  - anomaly shelf light
- Integrates subtle data stream assets in world-scene-asset-renderer.
- Adds preload paths for required prop/effect assets.
- Adds decor/indicator anchors in scene-anchors.

Architecture:
- UI/rendering only.
- No TaskEngine, worker, provider, selector, lifecycle event, or event taxonomy changes.
- No raw event/payload/world-index access.
- docs/ui-references/uiendgoal.png is not loaded at runtime.
- Missing images do not throw; procedural fallback remains.

Verified:
node --test tests/prop-asset-runtime.test.mjs tests/scene-anchors.test.mjs tests/canvas-inspection.test.mjs tests/diegetic-display-mode.test.mjs tests/world-scene-determinism.test.mjs tests/renderer-boundary.test.mjs tests/renderer-purity.test.mjs