### PR TITLE
feat(ui): add baked-mode workstation hotspot feedback

### DIFF
--- a/rendering/workstation-hotspots.js
+++ b/rendering/workstation-hotspots.js
@@ -14,6 +14,8 @@ function hotspot(config) {
     worldZoneIds: Object.freeze(config.worldZoneIds || []),
     zoneIds: Object.freeze(config.zoneIds || []),
     bounds: Object.freeze({ ...config.bounds }),
+    feedbackAnchor: Object.freeze(config.feedbackAnchor || config.bounds),
+    feedbackKind: config.feedbackKind || 'monitor',
   });
 }
 
@@ -34,6 +36,8 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['engineCrystal'],
     zoneIds: ['ENQUEUED'],
     bounds: { x: 454, y: 118, width: 78, height: 292 },
+    feedbackAnchor: SCENE_ANCHORS.crystal.engineCrystal,
+    feedbackKind: 'crystal',
   }),
   hotspot({
     id: 'intakeDeskHotspot',
@@ -41,6 +45,8 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['intakeDesk'],
     zoneIds: ['CREATED'],
     bounds: { x: 44, y: 116, width: 172, height: 126 },
+    feedbackAnchor: SCENE_ANCHORS.shelves.intakeShelf,
+    feedbackKind: 'shelf',
   }),
   hotspot({
     id: 'researchMonitorHotspot',
@@ -48,6 +54,7 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['researchDesk'],
     zoneIds: ['CLAIMED'],
     bounds: boundsFrom(SCENE_ANCHORS.desks['desk-0'], -24),
+    feedbackAnchor: SCENE_ANCHORS.desks['desk-0'],
   }),
   hotspot({
     id: 'shopifyMonitorHotspot',
@@ -55,6 +62,7 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['shopifyDesk'],
     zoneIds: ['CLAIMED'],
     bounds: boundsFrom(SCENE_ANCHORS.desks['desk-1'], -34),
+    feedbackAnchor: SCENE_ANCHORS.desks['desk-1'],
   }),
   hotspot({
     id: 'renderMonitorHotspot',
@@ -62,6 +70,7 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['renderDesk'],
     zoneIds: ['EXECUTE_FINISHED'],
     bounds: boundsFrom(SCENE_ANCHORS.desks['desk-4'], -46),
+    feedbackAnchor: SCENE_ANCHORS.desks['desk-4'],
   }),
   hotspot({
     id: 'supportMonitorHotspot',
@@ -69,6 +78,7 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['supportDesk'],
     zoneIds: ['CLAIMED'],
     bounds: boundsFrom(SCENE_ANCHORS.desks['desk-5'], -42),
+    feedbackAnchor: SCENE_ANCHORS.desks['desk-5'],
   }),
   hotspot({
     id: 'approvalDeskHotspot',
@@ -76,6 +86,8 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['approvalDesk'],
     zoneIds: ['EXECUTE_FINISHED'],
     bounds: boundsFrom(SCENE_ANCHORS.approvalDesk.deliveryDesk, 6),
+    feedbackAnchor: SCENE_ANCHORS.approvalDesk.deliveryDesk,
+    feedbackKind: 'shelf',
   }),
   hotspot({
     id: 'archiveShelfHotspot',
@@ -83,6 +95,8 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['archiveLibrary'],
     zoneIds: ['ACKED'],
     bounds: { x: 850, y: 42, width: 160, height: 250 },
+    feedbackAnchor: SCENE_ANCHORS.decor.archiveShelf,
+    feedbackKind: 'shelf',
   }),
   hotspot({
     id: 'anomalyShelfHotspot',
@@ -90,6 +104,8 @@ export const WORKSTATION_HOTSPOTS = Object.freeze([
     worldZoneIds: ['anomalyShelf'],
     zoneIds: ['ACKED'],
     bounds: boundsFrom(SCENE_ANCHORS.warningShelf.anomalyShelf, 8),
+    feedbackAnchor: SCENE_ANCHORS.warningShelf.anomalyShelf,
+    feedbackKind: 'warning',
   }),
 ]);
 
@@ -164,6 +180,121 @@ export function renderWorkstationHotspotDebug(ctx) {
     ctx.fillStyle = '#d9fff0';
     ctx.fillText(hotspot.id, b.x + 4, b.y + 2);
     ctx.fillStyle = 'rgba(18, 35, 28, 0.72)';
+  }
+  ctx.restore();
+}
+
+function anchorCenter(hotspot) {
+  const anchor = hotspot.feedbackAnchor || hotspot.bounds;
+  const bounds = anchor.bounds || null;
+  if (bounds) {
+    return {
+      x: bounds.x + bounds.width / 2,
+      y: bounds.y + bounds.height / 2,
+      radius: Math.max(10, Math.min(24, Math.max(bounds.width, bounds.height) * 0.42)),
+    };
+  }
+  return {
+    x: anchor.x ?? hotspot.bounds.x + hotspot.bounds.width / 2,
+    y: anchor.y ?? hotspot.bounds.y + hotspot.bounds.height / 2,
+    radius: Math.max(10, Math.min(24, (anchor.scale ?? 1) * 18)),
+  };
+}
+
+function isHotspotHovered(hotspot, inspectionState) {
+  return inspectionState?.hoveredComponentType === 'workstation-hotspot'
+    && inspectionState?.hoveredEntityId === hotspot.id;
+}
+
+function drawSoftGlow(ctx, point, color, alpha, radiusScale = 1) {
+  const radius = point.radius * radiusScale;
+  const glow = ctx.createRadialGradient(point.x, point.y, 0, point.x, point.y, radius);
+  glow.addColorStop(0, color.inner);
+  glow.addColorStop(0.46, color.mid);
+  glow.addColorStop(1, color.outer);
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawHoverShimmer(ctx, point, kind) {
+  ctx.globalAlpha = kind === 'warning' ? 0.28 : 0.20;
+  ctx.strokeStyle = kind === 'warning' ? 'rgba(255, 202, 110, 0.82)' : 'rgba(197, 245, 232, 0.72)';
+  ctx.lineWidth = 1.1;
+  ctx.beginPath();
+  ctx.ellipse(point.x, point.y, point.radius * 0.92, point.radius * 0.42, -0.12, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+function drawLiveBadge(ctx, point, color, anomaly) {
+  const badgeRadius = anomaly ? 3.8 : 3;
+  ctx.globalAlpha = anomaly ? 0.82 : 0.58;
+  ctx.fillStyle = anomaly ? 'rgba(255, 188, 83, 0.92)' : color.dot;
+  ctx.beginPath();
+  ctx.arc(point.x + point.radius * 0.42, point.y - point.radius * 0.34, badgeRadius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function paletteForHotspot(hotspot, summary) {
+  if (summary.anomaly || summary.failedTasks > 0 || hotspot.feedbackKind === 'warning') {
+    return {
+      inner: 'rgba(255, 222, 138, 0.58)',
+      mid: 'rgba(255, 173, 82, 0.22)',
+      outer: 'rgba(255, 173, 82, 0)',
+      dot: 'rgba(255, 202, 110, 0.88)',
+    };
+  }
+  if (hotspot.feedbackKind === 'crystal') {
+    return {
+      inner: 'rgba(187, 246, 255, 0.46)',
+      mid: 'rgba(121, 220, 235, 0.18)',
+      outer: 'rgba(121, 220, 235, 0)',
+      dot: 'rgba(185, 248, 255, 0.72)',
+    };
+  }
+  return {
+    inner: 'rgba(193, 248, 228, 0.42)',
+    mid: 'rgba(122, 224, 196, 0.16)',
+    outer: 'rgba(122, 224, 196, 0)',
+    dot: 'rgba(185, 248, 218, 0.68)',
+  };
+}
+
+/**
+ * Draws quiet normal-mode affordances over the baked room plate.
+ * Inactive hotspots intentionally produce no visible draw calls.
+ */
+export function renderWorkstationHotspotFeedback(ctx, components, inspectionState, options = {}) {
+  if (!ctx || options.debug === true || options.bakedBackground !== true) return;
+
+  ctx.save();
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const summary = summarizeHotspotFromComponents(hotspot, components);
+    const hovered = isHotspotHovered(hotspot, inspectionState);
+    const active = summary.activeTasks > 0
+      || summary.failedTasks > 0
+      || summary.activeAgents > 0
+      || summary.assignedAgents > 0
+      || summary.anomaly;
+
+    if (!hovered && !active) continue;
+
+    const point = anchorCenter(hotspot);
+    const palette = paletteForHotspot(hotspot, summary);
+    const anomaly = summary.anomaly || summary.failedTasks > 0 || hotspot.feedbackKind === 'warning';
+
+    if (hovered) {
+      drawSoftGlow(ctx, point, palette, anomaly ? 0.24 : 0.16, anomaly ? 1.25 : 1.08);
+      drawHoverShimmer(ctx, point, hotspot.feedbackKind);
+    }
+    if (active) {
+      drawSoftGlow(ctx, point, palette, anomaly ? 0.20 : 0.10, anomaly ? 1.08 : 0.82);
+      drawLiveBadge(ctx, point, palette, anomaly);
+    }
   }
   ctx.restore();
 }

--- a/rendering/world-scene-layer-renderer.js
+++ b/rendering/world-scene-layer-renderer.js
@@ -35,7 +35,8 @@ import { renderDiegeticIndicators } from './diegetic-indicator-renderer.js';
 import { renderWorldCompositionLayer } from './world-background-composition.js';
 import { loadedAssets } from './assets.js';
 import { isBakedBackgroundActive, selectLoadedBackground } from './background-config.js';
-import { renderWorkstationHotspotDebug } from './workstation-hotspots.js';
+import { canvasInspectionState } from './canvas-inspection-state.js';
+import { renderWorkstationHotspotDebug, renderWorkstationHotspotFeedback } from './workstation-hotspots.js';
 import {
   renderBackgroundLayer,
   renderCoreLayer,
@@ -97,6 +98,11 @@ export function renderAllLayers(ctx, components, frame) {
   renderZoneLabels(ctx, components, isRenderDebug);
   if (isRenderDebug) {
     renderWorkstationHotspotDebug(ctx);
+  } else {
+    renderWorkstationHotspotFeedback(ctx, components, canvasInspectionState, {
+      debug: false,
+      bakedBackground: bakedBackgroundActive,
+    });
   }
 
   // ── Layer 3.6: diegetic indicators (normal mode only) ──────────────────

--- a/tests/canvas-inspection.test.mjs
+++ b/tests/canvas-inspection.test.mjs
@@ -26,6 +26,10 @@ import {
 } from '../rendering/connection-renderer.js';
 import { renderWorldCompositionLayer } from '../rendering/world-background-composition.js';
 import { renderUIOverlayLayer } from '../rendering/world-scene-asset-renderer.js';
+import {
+  renderWorkstationHotspotDebug,
+  renderWorkstationHotspotFeedback,
+} from '../rendering/workstation-hotspots.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -443,6 +447,71 @@ test('canvas inspection: baked normal mode routes active agent hits to workstati
 
   assert.equal(hit.componentType, 'workstation-hotspot');
   assert.equal(hit.entityId, 'researchMonitorHotspot');
+});
+
+test('canvas inspection: baked normal inactive workstation hotspots do not draw rectangles', () => {
+  const ctx = createMockContext();
+  const inspectionState = createCanvasInspectionState();
+
+  renderWorkstationHotspotFeedback(ctx, [], inspectionState, { bakedBackground: true, debug: false });
+
+  assert.equal(ctx.calls.length, 2);
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+});
+
+test('canvas inspection: baked normal hovered workstation draws subtle feedback without labels', () => {
+  const ctx = createMockContext();
+  const inspectionState = createCanvasInspectionState();
+  inspectionState.hoveredEntityId = 'researchMonitorHotspot';
+  inspectionState.hoveredComponentType = 'workstation-hotspot';
+
+  renderWorkstationHotspotFeedback(ctx, [], inspectionState, { bakedBackground: true, debug: false });
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'ellipse'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'stroke'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'arc'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+});
+
+test('canvas inspection: baked normal active and anomaly hotspots draw state feedback', () => {
+  const activeCtx = createMockContext();
+  const activeComponents = [
+    { componentType: 'agent-sprite', id: 'agent-active', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', currentTaskId: 'task-active' },
+  ];
+
+  renderWorkstationHotspotFeedback(activeCtx, activeComponents, createCanvasInspectionState(), {
+    bakedBackground: true,
+    debug: false,
+  });
+
+  assert.ok(activeCtx.calls.some((call) => call[0] === 'arc'));
+  assert.ok(!activeCtx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+
+  const anomalyCtx = createMockContext();
+  const anomalyComponents = [
+    { componentType: 'task-chip', id: 'task-anomaly', visualState: 'error', worldZoneId: 'anomalyShelf', zoneId: 'ACKED', anomaly: { severity: 'high', type: 'stalled_tasks' } },
+  ];
+
+  renderWorkstationHotspotFeedback(anomalyCtx, anomalyComponents, createCanvasInspectionState(), {
+    bakedBackground: true,
+    debug: false,
+  });
+
+  assert.ok(anomalyCtx.calls.some((call) => call[0] === 'arc'));
+  assert.ok(anomalyCtx.calls.some((call) => call[0] === 'createRadialGradient'));
+  assert.ok(!anomalyCtx.calls.some((call) => call[0] === 'fillText'));
+});
+
+test('canvas inspection: debug mode still renders workstation hotspot bounds and IDs', () => {
+  const ctx = createMockContext();
+
+  renderWorkstationHotspotDebug(ctx);
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'strokeRect'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillRect'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'researchMonitorHotspot'));
 });
 
 test('canvas inspection: fallback normal mode still renders dynamic agents', async () => {


### PR DESCRIPTION
Adds subtle visual feedback for workstation hotspots in baked-background normal mode.

Changes:
- Adds anchor-based hotspot feedback metadata.
- Adds subtle hover shimmer and tiny active/anomaly glows.
- Keeps inactive hotspots invisible in normal mode.
- Preserves debug hotspot bounds/IDs.
- Keeps interaction attached to workstation hotspots, not decorative sloths.

Architecture:
- UI/rendering only.
- No TaskEngine, worker, provider, selector, lifecycle, or event taxonomy changes.
- No raw event/payload/world-index access.

Verified:
node --test tests/canvas-inspection.test.mjs tests/diegetic-display-mode.test.mjs tests/world-scene-determinism.test.mjs tests/renderer-boundary.test.mjs tests/renderer-purity.test.mjs