### PR TITLE
ui overall change and refactor

### DIFF
--- a/docs/canvas-interaction-contract.md
+++ b/docs/canvas-interaction-contract.md
@@ -1,0 +1,125 @@
+# Canvas Interaction Contract
+
+This contract defines how the Slothworld canvas chooses interaction targets, renders popovers, and boots the baked background. It is intended to keep normal mode friendly and user-facing while preserving diagnostics in debug and calibration modes.
+
+## Mode Split
+
+Normal mode is the user-facing projection. It must only expose selector-safe, friendly view models and broad workstation affordances.
+
+Debug and calibration modes may expose diagnostics, raw ids, bounds, zones, priorities, and render-path traces so layout and hit testing can be inspected.
+
+## Interaction Priority
+
+Normal mode target priority:
+
+1. `taskResult`
+2. `taskMarker`
+3. `station`
+4. background
+
+Debug and calibration target priority:
+
+1. `taskResult`
+2. `taskMarker`
+3. `agent`
+4. `station`
+5. world/debug zones
+
+Task result targets must beat station hotspots. Task marker targets must beat station hotspots. Station hotspots are broad, forgiving fallback targets when no higher-priority task target is hit.
+
+## Target Types
+
+Allowed normal-mode target types:
+
+- `taskResult`
+- `taskMarker`
+- `station`
+- `agent`, only when the agent component is explicitly marked `normalInteractive: true` and carries a friendly `agentInspectionViewModel`
+
+Debug-only target types:
+
+- default `agent` targets
+- `world-zone-indicator`
+- raw zone/debug bounds
+
+World zones are never normal-mode popover targets.
+
+## Normal Popovers
+
+Allowed normal popover fields:
+
+- friendly title
+- short status label
+- friendly station summary lines
+- friendly task result lines
+- friendly task marker lines
+- friendly agent lines from `agentInspectionViewModel` only
+- anomaly indication as user-facing attention state
+
+Banned normal popover fields and text:
+
+- `type:`
+- `target:`
+- `priority:`
+- `zone:`
+- `bounds:`
+- `world-zone`
+- raw `sloth-` ids
+- `engineCrystal`
+- `TASK_`
+- `AGENT_`
+- raw event names
+- camelCase internals
+- raw target metadata
+- raw geometry or hit-test bounds
+
+Debug mode may show these diagnostics.
+
+## Station And Agent Responsibility
+
+Stations own normal-mode workstation interaction. Hotspots should be broad and forgiving so users can inspect desks, monitors, shelves, and work areas without needing pixel-perfect target geometry.
+
+Agents are debug-only in normal mode unless explicitly marked `normalInteractive: true` and supplied with a friendly `agentInspectionViewModel`. Default agent sprites must not steal station hover or click in normal mode.
+
+## Task Results
+
+Task result access is explicit and high priority. A task result target must win over overlapping station hotspots, and its normal popover must come from a friendly task result view model. Task marker targets follow the same rule and beat stations.
+
+## Baked Background Boot Policy
+
+The background boot policy has three states:
+
+- `baked-ready`: a baked background asset is loaded and should be drawn.
+- `baked-pending`: normal mode is waiting for the baked background; draw only the neutral boot background.
+- `fallback-allowed`: debug, calibration, or explicit opt-in mode may draw the legacy procedural fallback.
+
+During baked-pending normal boot:
+
+- do not call `renderTreehouseBackdrop()`
+- do not call semantic prop composition from `renderWorldCompositionLayer()`
+- do not draw task result/trend overlays over the blank boot background
+- do not flash the legacy procedural scene
+
+The procedural fallback remains available for debug and calibration.
+
+## Calibration And Export
+
+Calibration mode may expose diagnostic overlays, station bounds, handles, ids, and export tooling. Calibration data must remain projection data: it describes UI hit areas and anchors, not TaskEngine lifecycle state. Exported hotspot geometry should be treated as canvas interaction calibration, not engine data.
+
+## Flags
+
+Render boot tracing is gated and off by default:
+
+```js
+window.__SLOTHWORLD_TRACE_RENDER_BOOT__ = true
+localStorage.setItem('slothworld.traceRenderBoot', '1')
+```
+
+Procedural fallback rendering is gated during baked-pending normal boot. It may be explicitly enabled with:
+
+```js
+window.__SLOTHWORLD_ALLOW_PROCEDURAL_FALLBACK__ = true
+localStorage.setItem('slothworld.allowProceduralFallback', '1')
+```
+
+Debug mode may also enable procedural fallback and diagnostic interaction behavior.

--- a/rendering/background-config.js
+++ b/rendering/background-config.js
@@ -15,6 +15,12 @@ export const BACKGROUND_ASSET_PREFERENCE = Object.freeze([
   'scene_background_01.jpg',
 ]);
 
+export const BACKGROUND_BOOT_POLICY = Object.freeze({
+  BAKED_READY: 'baked-ready',
+  BAKED_PENDING: 'baked-pending',
+  FALLBACK_ALLOWED: 'fallback-allowed',
+});
+
 export function selectLoadedBackground(loadedAssets) {
   if (!loadedAssets || typeof loadedAssets !== 'object') return null;
   for (const filename of BACKGROUND_ASSET_PREFERENCE) {
@@ -32,4 +38,35 @@ export function isBakedBackgroundActive(backgroundOrAssets) {
     ? backgroundOrAssets
     : selectLoadedBackground(backgroundOrAssets);
   return selected ? selected.isPreferredBakedPlate === true : false;
+}
+
+export function isProceduralFallbackAllowed(options = {}) {
+  if (options && (options.debug === true || options.calibration === true || options.allowProceduralFallback === true)) {
+    return true;
+  }
+
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (window.__SLOTHWORLD_ALLOW_PROCEDURAL_FALLBACK__ === true) {
+    return true;
+  }
+
+  try {
+    return window.localStorage?.getItem('slothworld.allowProceduralFallback') === '1';
+  } catch (_error) {
+    return false;
+  }
+}
+
+export function getBackgroundBootPolicy(loadedAssets, options = {}) {
+  const selected = selectLoadedBackground(loadedAssets);
+  if (selected && selected.image) {
+    return BACKGROUND_BOOT_POLICY.BAKED_READY;
+  }
+  if (isProceduralFallbackAllowed(options)) {
+    return BACKGROUND_BOOT_POLICY.FALLBACK_ALLOWED;
+  }
+  return BACKGROUND_BOOT_POLICY.BAKED_PENDING;
 }

--- a/rendering/canvas-hit-test.js
+++ b/rendering/canvas-hit-test.js
@@ -6,7 +6,12 @@
  */
 
 import { ZONE_INDICATOR_ANCHORS } from './scene-anchors.js';
-import { WORKSTATION_HOTSPOTS, componentForHotspot } from './workstation-hotspots.js';
+import { WORKSTATION_HOTSPOTS, buildWorkstationHotspotComponents } from './workstation-hotspots.js';
+import { hitTestWorkstationHotspots, rectContainsPoint } from '../ui/hotspots/hitTestHotspots.js';
+import {
+  buildInteractionTargets,
+  getInteractionTargetAtPoint,
+} from '../ui/interactions/interactionTargets.js';
 
 const TASK_CHIP_BOUNDS = Object.freeze({ width: 36, height: 16 });
 const ZONE_INDICATOR_BOUNDS = Object.freeze({ width: 48, height: 48 });
@@ -47,13 +52,6 @@ function posOf(component, entityPositions) {
   };
 }
 
-function rectContains(rect, point) {
-  return point.x >= rect.x
-    && point.x <= rect.x + rect.width
-    && point.y >= rect.y
-    && point.y <= rect.y + rect.height;
-}
-
 export function getComponentHitBounds(component, entityPositions) {
   if (!component || typeof component !== 'object') {
     return null;
@@ -92,15 +90,6 @@ export function getComponentHitBounds(component, entityPositions) {
   return null;
 }
 
-function isNormalInteractiveAgent(component) {
-  return component
-    && (component.visualState === 'working'
-      || component.visualState === 'processing'
-      || component.visualState === 'error'
-      || Boolean(component.anomaly)
-      || Boolean(component.currentTaskId));
-}
-
 function getZoneIndicatorHitBounds(component) {
   const anchor = component && component.id ? ZONE_INDICATOR_ANCHORS[component.id] : null;
   if (!anchor) {
@@ -133,6 +122,58 @@ function resultForComponent(component, componentType, bounds) {
   };
 }
 
+function boundsFromRectShape(shape) {
+  if (!shape || shape.type !== 'rect') return null;
+  return { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+}
+
+function resultForInteractionTarget(target) {
+  if (!target) return null;
+  const source = target.source;
+  if (target.type === 'station') {
+    const component = source?.component || null;
+    return {
+      entityId: component?.id || source?.hotspot?.id || null,
+      componentType: 'workstation-hotspot',
+      component,
+      bounds: source?.hotspot?.bounds || boundsFromRectShape(target.hitArea),
+      interactionTarget: target,
+    };
+  }
+  if (target.type === 'taskResult') {
+    const component = {
+      componentType: 'task-result',
+      popoverViewModel: target.viewModel,
+    };
+    return {
+      entityId: target.id,
+      componentType: 'task-result',
+      component,
+      bounds: boundsFromRectShape(target.hitArea),
+      interactionTarget: target,
+    };
+  }
+  if (target.type === 'taskMarker') {
+    return {
+      entityId: source?.id ?? target.id,
+      componentType: 'task-chip',
+      component: source ? { ...source, popoverViewModel: target.viewModel } : { componentType: 'task-chip', popoverViewModel: target.viewModel },
+      bounds: boundsFromRectShape(target.hitArea),
+      interactionTarget: target,
+    };
+  }
+  if (target.type === 'agent') {
+    return {
+      entityId: source?.id ?? target.id,
+      componentType: 'agent-sprite',
+      component: source ? { ...source, agentInspectionViewModel: target.viewModel } : { componentType: 'agent-sprite', agentInspectionViewModel: target.viewModel },
+      bounds: boundsFromRectShape(target.hitArea),
+      interactionTarget: target,
+    };
+  }
+  return null;
+}
+
 export function hitTestRenderableComponents(components, point, entityPositions, options = {}) {
   if (!Array.isArray(components) || !point || !isFiniteNumber(point.x) || !isFiniteNumber(point.y)) {
     return null;
@@ -140,12 +181,26 @@ export function hitTestRenderableComponents(components, point, entityPositions, 
 
   const debug = options && options.debug === true;
   const bakedBackground = options && options.bakedBackground === true;
+  const hotspots = options.hotspots || WORKSTATION_HOTSPOTS;
+  const stationComponents = options.stationComponents || buildWorkstationHotspotComponents(hotspots, components);
+  const interactionTarget = getInteractionTargetAtPoint(
+    buildInteractionTargets(components, {
+      debug,
+      bakedBackground,
+      entityPositions,
+      hotspots,
+      stationComponents,
+      canvasSize: options.canvasSize,
+    }),
+    point
+  );
+  if (interactionTarget) return resultForInteractionTarget(interactionTarget);
 
   for (let i = components.length - 1; i >= 0; i--) {
     const component = components[i];
     if (!component || component.componentType !== 'task-chip') continue;
     const bounds = getComponentHitBounds(component, entityPositions);
-    if (bounds && rectContains(bounds, point)) {
+    if (bounds && rectContainsPoint(bounds, point)) {
       return resultForComponent(component, 'task-chip', bounds);
     }
   }
@@ -153,37 +208,34 @@ export function hitTestRenderableComponents(components, point, entityPositions, 
   for (let i = components.length - 1; i >= 0; i--) {
     const component = components[i];
     if (!component || component.componentType !== 'agent-sprite') continue;
-    if (!debug && bakedBackground) continue;
-    if (!debug && !isNormalInteractiveAgent(component)) continue;
+    if (!debug) continue;
     const bounds = getComponentHitBounds(component, entityPositions);
-    if (bounds && rectContains(bounds, point)) {
+    if (bounds && rectContainsPoint(bounds, point)) {
       return resultForComponent(component, 'agent-sprite', bounds);
     }
   }
 
-  for (let i = WORKSTATION_HOTSPOTS.length - 1; i >= 0; i--) {
-    const hotspot = WORKSTATION_HOTSPOTS[i];
-    if (hotspot.bounds && rectContains(hotspot.bounds, point)) {
-      const component = componentForHotspot(hotspot, components);
-      return resultForComponent(component, 'workstation-hotspot', hotspot.bounds);
-    }
-  }
-
-  for (let i = components.length - 1; i >= 0; i--) {
-    const component = components[i];
-    if (!component || component.componentType !== 'zone-background') continue;
-    const bounds = getZoneIndicatorHitBounds(component);
-    if (bounds && rectContains(bounds, point)) {
-      return resultForComponent(component, 'world-zone-indicator', bounds);
-    }
+  const hotspot = hitTestWorkstationHotspots(point, hotspots, { canvasSize: options.canvasSize });
+  if (hotspot) {
+    const component = stationComponents.find((candidate) => candidate.id === hotspot.id) || null;
+    return resultForComponent(component, 'workstation-hotspot', hotspot.bounds);
   }
 
   if (debug) {
     for (let i = components.length - 1; i >= 0; i--) {
       const component = components[i];
       if (!component || component.componentType !== 'zone-background') continue;
+      const bounds = getZoneIndicatorHitBounds(component);
+      if (bounds && rectContainsPoint(bounds, point)) {
+        return resultForComponent(component, 'world-zone-indicator', bounds);
+      }
+    }
+
+    for (let i = components.length - 1; i >= 0; i--) {
+      const component = components[i];
+      if (!component || component.componentType !== 'zone-background') continue;
       const bounds = getComponentHitBounds(component, entityPositions);
-      if (bounds && rectContains(bounds, point)) {
+      if (bounds && rectContainsPoint(bounds, point)) {
         return resultForComponent(component, 'world-zone-indicator', bounds);
       }
     }

--- a/rendering/canvas-hit-test.js
+++ b/rendering/canvas-hit-test.js
@@ -124,7 +124,12 @@ function resultForComponent(component, componentType, bounds) {
 
 function boundsFromRectShape(shape) {
   if (!shape || shape.type !== 'rect') return null;
-  return { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+  return {
+    x: shape.x,
+    y: shape.y,
+    width: Number.isFinite(shape.width) ? shape.width : shape.w,
+    height: Number.isFinite(shape.height) ? shape.height : shape.h,
+  };
 }
 
 function resultForInteractionTarget(target) {

--- a/rendering/canvas-inspection-state.js
+++ b/rendering/canvas-inspection-state.js
@@ -5,7 +5,12 @@
  */
 
 import { hitTestRenderableComponents } from './canvas-hit-test.js';
-import { buildWorkstationHotspotComponents, componentForHotspot, getWorkstationHotspotById } from './workstation-hotspots.js';
+import {
+  WORKSTATION_HOTSPOTS,
+  buildWorkstationHotspotComponents,
+  componentForHotspot,
+  getWorkstationHotspotById,
+} from './workstation-hotspots.js';
 import {
   buildInteractionTargets,
 } from '../ui/interactions/interactionTargets.js';
@@ -98,10 +103,11 @@ export function refreshInspectionSelection(state, components, entityPositions, o
   }
 
   if (state.selectedTargetId) {
-    const hotspots = options.hotspots || [];
+    const hotspots = options.hotspots || WORKSTATION_HOTSPOTS;
     const stationComponents = options.stationComponents || buildWorkstationHotspotComponents(hotspots, components);
     const targets = buildInteractionTargets(components, {
       ...options,
+      hotspots,
       entityPositions,
       stationComponents,
     });

--- a/rendering/canvas-inspection-state.js
+++ b/rendering/canvas-inspection-state.js
@@ -5,14 +5,25 @@
  */
 
 import { hitTestRenderableComponents } from './canvas-hit-test.js';
-import { componentForHotspot, getWorkstationHotspotById } from './workstation-hotspots.js';
+import { buildWorkstationHotspotComponents, componentForHotspot, getWorkstationHotspotById } from './workstation-hotspots.js';
+import {
+  buildInteractionTargets,
+} from '../ui/interactions/interactionTargets.js';
 
 export function createCanvasInspectionState() {
   return {
     hoveredEntityId: null,
     hoveredComponentType: null,
+    hoveredHotspotId: null,
+    hoveredTargetId: null,
+    hoveredTargetType: null,
+    hoveredInteractionTarget: null,
     selectedEntityId: null,
     selectedComponentType: null,
+    selectedHotspotId: null,
+    selectedTargetId: null,
+    selectedTargetType: null,
+    selectedInteractionTarget: null,
     pointer: { x: null, y: null, inside: false },
     hoveredHit: null,
     selectedHit: null,
@@ -24,12 +35,20 @@ export const canvasInspectionState = createCanvasInspectionState();
 function clearHover(state) {
   state.hoveredEntityId = null;
   state.hoveredComponentType = null;
+  state.hoveredHotspotId = null;
+  state.hoveredTargetId = null;
+  state.hoveredTargetType = null;
+  state.hoveredInteractionTarget = null;
   state.hoveredHit = null;
 }
 
 function assignHover(state, hit) {
   state.hoveredEntityId = hit ? hit.entityId : null;
   state.hoveredComponentType = hit ? hit.componentType : null;
+  state.hoveredHotspotId = hit?.componentType === 'workstation-hotspot' ? hit.entityId : null;
+  state.hoveredTargetId = hit?.interactionTarget?.id || null;
+  state.hoveredTargetType = hit?.interactionTarget?.type || null;
+  state.hoveredInteractionTarget = hit?.interactionTarget || null;
   state.hoveredHit = hit;
 }
 
@@ -54,6 +73,10 @@ export function updateInspectionSelection(state, components, point, entityPositi
   const hit = hitTestRenderableComponents(components, point, entityPositions, options);
   state.selectedEntityId = hit ? hit.entityId : null;
   state.selectedComponentType = hit ? hit.componentType : null;
+  state.selectedHotspotId = hit?.componentType === 'workstation-hotspot' ? hit.entityId : null;
+  state.selectedTargetId = hit?.interactionTarget?.id || null;
+  state.selectedTargetType = hit?.interactionTarget?.type || null;
+  state.selectedInteractionTarget = hit?.interactionTarget || null;
   state.selectedHit = hit;
   return hit;
 }
@@ -62,12 +85,54 @@ export function clearInspectionSelection(state) {
   if (!state) return;
   state.selectedEntityId = null;
   state.selectedComponentType = null;
+  state.selectedHotspotId = null;
+  state.selectedTargetId = null;
+  state.selectedTargetType = null;
+  state.selectedInteractionTarget = null;
   state.selectedHit = null;
 }
 
 export function refreshInspectionSelection(state, components, entityPositions, options = {}) {
   if (!state || !state.selectedEntityId || !state.selectedComponentType || !Array.isArray(components)) {
     return null;
+  }
+
+  if (state.selectedTargetId) {
+    const hotspots = options.hotspots || [];
+    const stationComponents = options.stationComponents || buildWorkstationHotspotComponents(hotspots, components);
+    const targets = buildInteractionTargets(components, {
+      ...options,
+      entityPositions,
+      stationComponents,
+    });
+    const target = targets.find((candidate) => candidate.id === state.selectedTargetId);
+    if (target) {
+      state.selectedInteractionTarget = target;
+      state.selectedTargetType = target.type;
+      if (target.type === 'station') {
+        const component = target.source?.component || stationComponents.find((candidate) => `station:${candidate.id}` === target.id) || null;
+        state.selectedHit = {
+          entityId: component?.id || target.source?.hotspot?.id || null,
+          componentType: 'workstation-hotspot',
+          component,
+          bounds: target.source?.hotspot?.bounds || null,
+          interactionTarget: target,
+        };
+        state.selectedHotspotId = state.selectedHit.entityId;
+        return state.selectedHit;
+      }
+      if (target.type === 'taskResult') {
+        state.selectedHit = {
+          entityId: target.id,
+          componentType: 'task-result',
+          component: { componentType: 'task-result', popoverViewModel: target.viewModel },
+          bounds: target.hitArea?.type === 'rect' ? target.hitArea : null,
+          interactionTarget: target,
+        };
+        state.selectedHotspotId = null;
+        return state.selectedHit;
+      }
+    }
   }
 
   if (state.selectedComponentType === 'workstation-hotspot') {
@@ -82,6 +147,7 @@ export function refreshInspectionSelection(state, components, entityPositions, o
       component: componentForHotspot(hotspot, components),
       bounds: hotspot.bounds,
     };
+    state.selectedHotspotId = hotspot.id;
     return state.selectedHit;
   }
 
@@ -116,6 +182,9 @@ export function refreshInspectionSelection(state, components, entityPositions, o
         component: selected,
         bounds: null,
       };
+  state.selectedHotspotId = state.selectedHit.componentType === 'workstation-hotspot'
+    ? state.selectedHit.entityId
+    : null;
   return state.selectedHit;
 }
 

--- a/rendering/debug.js
+++ b/rendering/debug.js
@@ -8,9 +8,14 @@
  *  - DOM access is guarded by typeof window checks for headless compatibility
  */
 
-import { canvas } from '../core/app-state.js';
-
 let debugBindingsAttached = false;
+
+function getCanvasElement() {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  return document.getElementById('game');
+}
 
 /**
  * Tracks pointer position inside the canvas for hover-based debug overlays.
@@ -47,12 +52,83 @@ export function isRenderDebugEnabled() {
 }
 
 /**
+ * Returns true when boot-time render tracing is explicitly enabled.
+ *
+ * Enable in DevTools before refresh with either:
+ *   window.__SLOTHWORLD_TRACE_RENDER_BOOT__ = true
+ *   localStorage.setItem('slothworld.traceRenderBoot', '1')
+ *
+ * @returns {boolean}
+ */
+export function isRenderBootTraceEnabled() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (window.__SLOTHWORLD_TRACE_RENDER_BOOT__ === true) {
+    return true;
+  }
+
+  try {
+    return window.localStorage?.getItem('slothworld.traceRenderBoot') === '1';
+  } catch (_error) {
+    return false;
+  }
+}
+
+function canvasSizeFrom(details) {
+  if (details && details.canvasSize) {
+    return details.canvasSize;
+  }
+  const canvasFromContext = details && details.ctx && details.ctx.canvas;
+  if (canvasFromContext) {
+    return {
+      width: canvasFromContext.width,
+      height: canvasFromContext.height,
+    };
+  }
+  const canvas = getCanvasElement();
+  if (canvas) {
+    return {
+      width: canvas.width,
+      height: canvas.height,
+    };
+  }
+  return null;
+}
+
+/**
+ * Gated boot render trace logger. Does nothing unless isRenderBootTraceEnabled().
+ *
+ * @param {string} pathName
+ * @param {object} [details]
+ */
+export function traceRenderBoot(pathName, details = {}) {
+  if (!isRenderBootTraceEnabled()) {
+    return;
+  }
+
+  const { ctx, ...rest } = details || {};
+  const payload = {
+    path: pathName,
+    timestamp: Date.now(),
+    performanceNow: typeof performance !== 'undefined' ? Number(performance.now().toFixed(2)) : null,
+    canvasSize: canvasSizeFrom(details),
+    ...rest,
+  };
+
+  console.log('[Slothworld render boot trace]', payload);
+  void ctx;
+}
+
+/**
  * Attaches mousemove / mouseenter / mouseleave listeners to the canvas so
  * that debugPointer tracks the scaled canvas-coordinate cursor position.
  *
  * Safe to call multiple times — listeners are attached at most once.
  */
 export function ensureDebugBindings() {
+  const canvas = getCanvasElement();
   if (debugBindingsAttached || typeof window === 'undefined' || !canvas) {
     return;
   }

--- a/rendering/hotspot-highlight-renderer.js
+++ b/rendering/hotspot-highlight-renderer.js
@@ -1,0 +1,345 @@
+/**
+ * Dedicated workstation hotspot highlight layer.
+ *
+ * Drawn after world assets and before inspection popovers. Normal mode uses
+ * quiet cyan hover/selection affordances; debug mode shows hitboxes and IDs.
+ */
+
+import { WORKSTATION_HOTSPOTS } from '../ui/hotspots/workstationHotspots.js';
+import {
+  HOTSPOT_CANONICAL_SIZE,
+  drawShapePath,
+  getShapeBounds,
+  scaleShape,
+} from '../ui/hotspots/hotspotGeometry.js';
+
+function targetSizeFor(ctx, options) {
+  return options.canvasSize || {
+    width: ctx?.canvas?.width || HOTSPOT_CANONICAL_SIZE.width,
+    height: ctx?.canvas?.height || HOTSPOT_CANONICAL_SIZE.height,
+  };
+}
+
+function scalePoint(point, targetSize) {
+  return {
+    x: (point?.x ?? 0) * targetSize.width / HOTSPOT_CANONICAL_SIZE.width,
+    y: (point?.y ?? 0) * targetSize.height / HOTSPOT_CANONICAL_SIZE.height,
+  };
+}
+
+function shapeFor(hotspot, targetSize, key) {
+  const base = hotspot[key] || hotspot.hitArea || { type: 'rect', ...hotspot.bounds };
+  return scaleShape(base, targetSize);
+}
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalVisualStyleFor(hotspot) {
+  const style = hotspot?.visualStyle || {};
+  return {
+    tint: typeof style.tint === 'string' ? style.tint : 'cyan',
+    intensity: clamp(style.intensity, 0.45, 1.25),
+    pulse: style.pulse !== false,
+    sparkle: style.sparkle === true,
+  };
+}
+
+function componentByHotspotId(components) {
+  const map = new Map();
+  if (!Array.isArray(components)) return map;
+  for (const component of components) {
+    if (component?.id) map.set(component.id, component);
+  }
+  return map;
+}
+
+function stationVisualModelFor(hotspot, componentsById) {
+  const model = componentsById.get(hotspot.id)?.visualStateViewModel;
+  if (!model || typeof model !== 'object') {
+    return {
+      hotspotId: hotspot.id,
+      visualState: 'idle',
+      tone: 'quiet',
+      intensity: 0,
+      effect: 'none',
+    };
+  }
+  return model;
+}
+
+function paletteForVisualState(visualState) {
+  if (visualState === 'queued') {
+    return { fill: 'rgba(244, 174, 82, 0.038)', stroke: 'rgba(250, 188, 96, 0.18)', glow: 'rgba(248, 186, 86, 0.26)' };
+  }
+  if (visualState === 'awaiting') {
+    return { fill: 'rgba(255, 220, 132, 0.046)', stroke: 'rgba(255, 219, 128, 0.24)', glow: 'rgba(255, 216, 120, 0.30)' };
+  }
+  if (visualState === 'completed') {
+    return { fill: 'rgba(210, 242, 255, 0.026)', stroke: 'rgba(196, 237, 255, 0.18)', glow: 'rgba(190, 236, 255, 0.24)' };
+  }
+  if (visualState === 'failed') {
+    return { fill: 'rgba(255, 116, 76, 0.054)', stroke: 'rgba(255, 141, 90, 0.32)', glow: 'rgba(255, 108, 72, 0.36)' };
+  }
+  return { fill: 'rgba(72, 220, 255, 0.032)', stroke: 'rgba(92, 226, 248, 0.20)', glow: 'rgba(92, 226, 248, 0.28)' };
+}
+
+function drawStationSparkle(ctx, bounds, alpha) {
+  const x = bounds.x + bounds.width * 0.78;
+  const y = bounds.y + bounds.height * 0.24;
+  ctx.strokeStyle = `rgba(229, 249, 255, ${alpha})`;
+  ctx.lineWidth = 0.7;
+  ctx.beginPath();
+  ctx.moveTo(x - 3, y);
+  ctx.lineTo(x + 3, y);
+  ctx.moveTo(x, y - 3);
+  ctx.lineTo(x, y + 3);
+  ctx.stroke();
+}
+
+function drawStationStateGlow(ctx, hotspot, model, frame, targetSize) {
+  if (!model || model.visualState === 'idle' || model.effect === 'none') return;
+
+  const shape = shapeFor(hotspot, targetSize, 'highlightShape');
+  const bounds = getShapeBounds(shape) || { x: 0, y: 0, width: 0, height: 0 };
+  const palette = paletteForVisualState(model.visualState);
+  const intensity = clamp(model.intensity, 0.18, 1);
+  const tick = Number.isFinite(frame) ? frame : 0;
+  const pulse = model.effect === 'pulse' ? 0.5 + 0.5 * Math.sin(tick / 24) : 0;
+  const shimmer = model.effect === 'shimmer' ? 0.5 + 0.5 * Math.sin(tick / 18) : 0;
+  const glint = model.effect === 'glint' ? 0.5 + 0.5 * Math.sin(tick / 12) : 0;
+  const motion = Math.max(pulse, shimmer * 0.7, glint);
+
+  ctx.save();
+  ctx.shadowColor = palette.glow;
+  ctx.shadowBlur = 6 + motion * 8;
+  ctx.fillStyle = palette.fill;
+  drawShapePath(ctx, shape);
+  ctx.fill();
+
+  ctx.shadowColor = 'transparent';
+  ctx.strokeStyle = palette.stroke;
+  ctx.lineWidth = model.visualState === 'failed' ? 0.9 : 0.6;
+  drawShapePath(ctx, shape);
+  ctx.stroke();
+
+  if (model.effect === 'sparkle') {
+    drawStationSparkle(ctx, bounds, 0.26 + 0.16 * Math.sin(tick / 20) * intensity);
+  }
+
+  if (model.effect === 'glint') {
+    ctx.strokeStyle = `rgba(255, 190, 106, ${0.30 + glint * 0.18})`;
+    ctx.lineWidth = 0.8;
+    ctx.beginPath();
+    ctx.moveTo(bounds.x + bounds.width * 0.22, bounds.y + bounds.height * 0.30);
+    ctx.lineTo(bounds.x + bounds.width * 0.72, bounds.y + bounds.height * 0.18);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function drawDiegeticHotspotHighlight(ctx, shape, selected, pulse, intensity) {
+  const fillAlpha = Math.min(
+    selected ? 0.056 : 0.026,
+    (selected ? 0.034 + pulse * 0.012 : 0.018) * intensity
+  );
+  const glowAlpha = Math.min(
+    selected ? 0.42 : 0.20,
+    (selected ? 0.28 + pulse * 0.09 : 0.14) * intensity
+  );
+  const outlineAlpha = Math.min(
+    selected ? 0.58 : 0.28,
+    (selected ? 0.42 + pulse * 0.10 : 0.20) * intensity
+  );
+
+  ctx.shadowColor = `rgba(72, 220, 255, ${glowAlpha})`;
+  ctx.shadowBlur = selected ? 17 + pulse * 5 : 9;
+  ctx.strokeStyle = `rgba(76, 213, 248, ${selected ? 0.22 : 0.12})`;
+  ctx.lineWidth = selected ? 3 : 2;
+  drawShapePath(ctx, shape);
+  ctx.stroke();
+
+  ctx.shadowColor = 'transparent';
+  ctx.fillStyle = `rgba(70, 205, 242, ${fillAlpha})`;
+  drawShapePath(ctx, shape);
+  ctx.fill();
+
+  ctx.strokeStyle = `rgba(138, 240, 255, ${outlineAlpha})`;
+  ctx.lineWidth = selected ? 0.9 : 0.5;
+  drawShapePath(ctx, shape);
+  ctx.stroke();
+}
+
+function drawNormalHighlight(ctx, hotspot, tone, frame, targetSize) {
+  const shape = shapeFor(hotspot, targetSize, 'highlightShape');
+  const selected = tone === 'selected';
+  const visualStyle = normalVisualStyleFor(hotspot);
+  const pulse = selected && visualStyle.pulse
+    ? 0.5 + 0.5 * Math.sin((Number.isFinite(frame) ? frame : 0) / 22)
+    : 0;
+
+  ctx.save();
+  drawDiegeticHotspotHighlight(ctx, shape, selected, pulse, visualStyle.intensity);
+  ctx.restore();
+}
+
+function drawDebugHotspot(ctx, hotspot, targetSize, visualModel) {
+  const hitArea = shapeFor(hotspot, targetSize, 'hitArea');
+  const highlightShape = shapeFor(hotspot, targetSize, 'highlightShape');
+  const anchor = scalePoint(hotspot.popoverAnchor, targetSize);
+  const b = getShapeBounds(hitArea) || { x: 0, y: 0, width: 0, height: 0 };
+  const selected = hotspot.id === (hotspot.__selectedHotspotId || null);
+
+  ctx.fillStyle = 'rgba(68, 171, 255, 0.16)';
+  drawShapePath(ctx, hitArea);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(68, 171, 255, 0.72)';
+  ctx.lineWidth = 1;
+  drawShapePath(ctx, hitArea);
+  ctx.stroke();
+
+  ctx.strokeStyle = selected ? 'rgba(255, 246, 176, 0.98)' : 'rgba(98, 240, 255, 0.92)';
+  ctx.lineWidth = selected ? 2 : 1.4;
+  drawShapePath(ctx, highlightShape);
+  ctx.stroke();
+
+  ctx.fillStyle = 'rgba(255, 246, 176, 0.95)';
+  ctx.beginPath();
+  ctx.arc(anchor.x, anchor.y, 3, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(18, 35, 28, 0.72)';
+  ctx.fillRect(b.x, b.y, Math.max(80, hotspot.id.length * 5 + 8), 12);
+  ctx.fillStyle = '#d9fff0';
+  ctx.fillText(hotspot.id, b.x + 4, b.y + 2);
+  if (visualModel?.visualState) {
+    ctx.fillText(`state: ${visualModel.visualState}`, b.x + 4, b.y + 14);
+  }
+}
+
+function drawHandle(ctx, x, y, selected = false) {
+  ctx.fillStyle = selected ? 'rgba(255, 255, 255, 0.96)' : 'rgba(184, 250, 255, 0.88)';
+  ctx.strokeStyle = selected ? 'rgba(255, 220, 104, 0.96)' : 'rgba(58, 211, 244, 0.92)';
+  ctx.lineWidth = selected ? 1.4 : 1;
+  ctx.beginPath();
+  ctx.arc(x, y, selected ? 4 : 3, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
+function drawShapeHandles(ctx, shape, selectedVertexIndex) {
+  if (!shape) return;
+  if (shape.type === 'polygon') {
+    shape.points.forEach((point, index) => drawHandle(ctx, point.x, point.y, index === selectedVertexIndex));
+    return;
+  }
+  if (shape.type === 'circle') {
+    drawHandle(ctx, shape.cx, shape.cy, selectedVertexIndex === 'center');
+    drawHandle(ctx, shape.cx + shape.radius, shape.cy, selectedVertexIndex === 'radius');
+    return;
+  }
+  if (shape.type === 'rect') {
+    drawHandle(ctx, shape.x, shape.y);
+    drawHandle(ctx, shape.x + shape.width, shape.y);
+    drawHandle(ctx, shape.x + shape.width, shape.y + shape.height);
+    drawHandle(ctx, shape.x, shape.y + shape.height);
+  }
+}
+
+function drawCalibrationEditor(ctx, hotspots, targetSize, calibration) {
+  if (!calibration?.editMode) return;
+  const selectedId = calibration.selectedHotspotId || hotspots[0]?.id || null;
+  const selected = hotspots.find((hotspot) => hotspot.id === selectedId);
+  if (!selected) return;
+
+  const hitArea = shapeFor(selected, targetSize, 'hitArea');
+  const highlightShape = shapeFor(selected, targetSize, 'highlightShape');
+  const anchor = scalePoint(selected.popoverAnchor, targetSize);
+
+  ctx.save();
+  ctx.strokeStyle = 'rgba(255, 246, 176, 0.98)';
+  ctx.lineWidth = 2.2;
+  drawShapePath(ctx, highlightShape);
+  ctx.stroke();
+
+  if (calibration.editLayer === 'hitArea' || calibration.editLayer === 'all') {
+    drawShapeHandles(ctx, hitArea, calibration.selectedVertexIndex);
+  }
+  if (calibration.editLayer === 'highlightShape' || calibration.editLayer === 'all') {
+    drawShapeHandles(ctx, highlightShape, calibration.selectedVertexIndex);
+  }
+  if (calibration.editLayer === 'popoverAnchor' || calibration.editLayer === 'all') {
+    drawHandle(ctx, anchor.x, anchor.y, calibration.editLayer === 'popoverAnchor');
+  }
+
+  ctx.fillStyle = 'rgba(18, 35, 28, 0.78)';
+  ctx.fillRect(10, 10, 292, 66);
+  ctx.fillStyle = '#d9fff0';
+  ctx.font = '9px monospace';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText(`edit: ${selected.id}`, 16, 16);
+  ctx.fillText(`layer: ${calibration.editLayer}`, 16, 28);
+  ctx.fillText('E toggle | 1 hit | 2 glow | 3 anchor | 4 all', 16, 40);
+  ctx.fillText('Ctrl+C selected | Shift+Ctrl+C all | S download', 16, 52);
+  ctx.fillText('Ctrl+S dev save when enabled', 16, 64);
+  ctx.restore();
+}
+
+export function renderHotspotHighlights(ctx, inspectionState, options = {}) {
+  if (!ctx) return;
+  const debug = options.debug === true;
+  const targetSize = targetSizeFor(ctx, options);
+  const hotspots = options.hotspots || WORKSTATION_HOTSPOTS;
+  const componentsById = componentByHotspotId(options.hotspotComponents);
+
+  ctx.save();
+  if (debug) {
+    ctx.font = '8px monospace';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    const selectedHotspotId = options.calibration?.selectedHotspotId || inspectionState?.selectedHotspotId || null;
+    for (const hotspot of hotspots) {
+      drawDebugHotspot(
+        ctx,
+        { ...hotspot, __selectedHotspotId: selectedHotspotId },
+        targetSize,
+        stationVisualModelFor(hotspot, componentsById)
+      );
+    }
+    drawCalibrationEditor(ctx, hotspots, targetSize, options.calibration);
+    ctx.restore();
+    return;
+  }
+
+  const hoveredId = inspectionState?.hoveredHotspotId || null;
+  const selectedId = inspectionState?.selectedHotspotId || null;
+  let drewAmbient = false;
+  for (const hotspot of hotspots) {
+    const visualModel = stationVisualModelFor(hotspot, componentsById);
+    if (visualModel.visualState !== 'idle') {
+      drawStationStateGlow(ctx, hotspot, visualModel, options.frame, targetSize);
+      drewAmbient = true;
+    }
+  }
+
+  if (!hoveredId && !selectedId && !drewAmbient) {
+    ctx.restore();
+    return;
+  }
+
+  for (const hotspot of hotspots) {
+    if (hotspot.id === selectedId) {
+      drawNormalHighlight(ctx, hotspot, 'selected', options.frame, targetSize);
+    } else if (hotspot.id === hoveredId) {
+      drawNormalHighlight(ctx, hotspot, 'hovered', options.frame, targetSize);
+    }
+  }
+  ctx.restore();
+}

--- a/rendering/inspection-popover-renderer.js
+++ b/rendering/inspection-popover-renderer.js
@@ -109,6 +109,8 @@ const NORMAL_POPOVER_FORBIDDEN_PATTERNS = Object.freeze([
   /\bzone\s*:/i,
   /\bpriority\s*:/i,
   /\bbounds\s*:/i,
+  /\bid\s*:/i,
+  /\bdebug\s*:/i,
   /\bworld-zone\b/i,
   /\bsloth-[\w-]*\b/i,
   /\bTASK_[A-Z0-9_]+\b/,

--- a/rendering/inspection-popover-renderer.js
+++ b/rendering/inspection-popover-renderer.js
@@ -51,6 +51,46 @@ function typeLabel(componentType) {
   return 'world-zone';
 }
 
+function workstationViewModel(component) {
+  const model = component?.popoverViewModel;
+  if (model && typeof model === 'object' && Array.isArray(model.lines)) return model;
+  const fallback = cleanText(component?.purpose) || 'Workstation is idle';
+  return {
+    title: cleanText(component?.title) || cleanText(component?.label) || 'Workstation',
+    lines: [fallback],
+    tone: 'quiet',
+    maxLines: 2,
+  };
+}
+
+function workstationInspectionModel(component) {
+  const model = component?.inspectionViewModel;
+  if (model && typeof model === 'object' && Array.isArray(model.lines) && Array.isArray(model.taskSummaries)) {
+    return model;
+  }
+  const fallback = cleanText(component?.purpose) || 'Ready for work';
+  return {
+    title: cleanText(component?.title) || cleanText(component?.label) || 'Workstation',
+    statusLabel: 'Idle',
+    lines: [fallback],
+    taskSummaries: [],
+    tone: 'quiet',
+  };
+}
+
+function agentInspectionModel(component) {
+  const model = component?.agentInspectionViewModel;
+  if (model && typeof model === 'object' && Array.isArray(model.lines)) return model;
+  return {
+    targetType: 'agent',
+    title: 'Sloth Worker',
+    statusLabel: 'Idle',
+    lines: ['Waiting for work'],
+    tone: 'agent',
+    maxLines: 2,
+  };
+}
+
 function metricRows(metrics) {
   if (!metrics || typeof metrics !== 'object') return [];
   const rows = [];
@@ -63,36 +103,170 @@ function metricRows(metrics) {
   return rows;
 }
 
+const NORMAL_POPOVER_FORBIDDEN_PATTERNS = Object.freeze([
+  /\btype\s*:/i,
+  /\btarget\s*:/i,
+  /\bzone\s*:/i,
+  /\bpriority\s*:/i,
+  /\bbounds\s*:/i,
+  /\bworld-zone\b/i,
+  /\bsloth-[\w-]*\b/i,
+  /\bTASK_[A-Z0-9_]+\b/,
+  /\bAGENT_[A-Z0-9_]+\b/,
+  /\bengineCrystal\b/,
+]);
+
+function normalTextIsSafe(model) {
+  const text = [
+    model?.title,
+    ...(Array.isArray(model?.rows) ? model.rows : []),
+  ].filter(Boolean).join('\n');
+  return !NORMAL_POPOVER_FORBIDDEN_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function hasLineViewModel(model) {
+  return Boolean(model
+    && typeof model === 'object'
+    && typeof model.title === 'string'
+    && Array.isArray(model.lines));
+}
+
+function hasStationInspectionViewModel(model) {
+  return Boolean(model
+    && typeof model === 'object'
+    && typeof model.title === 'string'
+    && typeof model.statusLabel === 'string'
+    && Array.isArray(model.lines)
+    && Array.isArray(model.taskSummaries));
+}
+
+function hasAgentInspectionViewModel(model) {
+  return Boolean(model
+    && typeof model === 'object'
+    && typeof model.title === 'string'
+    && typeof model.statusLabel === 'string'
+    && Array.isArray(model.lines));
+}
+
+export function canRenderNormalPopover(targetOrHit) {
+  const target = targetOrHit?.interactionTarget || targetOrHit;
+  const component = targetOrHit?.component || target?.source?.component || target?.source || null;
+  const type = target?.type || (
+    targetOrHit?.componentType === 'task-result' ? 'taskResult'
+      : targetOrHit?.componentType === 'task-chip' ? 'taskMarker'
+        : targetOrHit?.componentType === 'workstation-hotspot' ? 'station'
+          : targetOrHit?.componentType === 'agent-sprite' ? 'agent'
+            : null
+  );
+  const viewModel = target?.viewModel || component?.inspectionViewModel || component?.popoverViewModel || component?.agentInspectionViewModel || null;
+
+  if (type === 'taskResult' || type === 'taskMarker') return hasLineViewModel(viewModel);
+  if (type === 'station') return hasStationInspectionViewModel(viewModel) || hasLineViewModel(viewModel);
+  if (type === 'agent') return component?.normalInteractive === true && hasAgentInspectionViewModel(viewModel);
+  return false;
+}
+
+export function getFriendlyPopoverViewModelForTarget(hit, options = {}) {
+  if (!hit || !hit.component || options.debug === true) return null;
+  if (!canRenderNormalPopover(hit)) return null;
+  const component = hit.component;
+
+  if (hit.componentType === 'workstation-hotspot') {
+    const summary = component.summary && typeof component.summary === 'object' ? component.summary : {};
+    if (options.selected === true) {
+      const viewModel = workstationInspectionModel(component);
+      return {
+        title: viewModel.title,
+        rows: [
+          viewModel.statusLabel,
+          ...viewModel.lines.slice(0, 3),
+          ...viewModel.taskSummaries.slice(0, 3),
+        ],
+        hasAnomaly: Boolean(summary.failedTasks || summary.anomaly) || viewModel.tone === 'warning',
+        debug: false,
+      };
+    }
+    const viewModel = workstationViewModel(component);
+    return {
+      title: viewModel.title,
+      rows: viewModel.lines.slice(0, viewModel.maxLines || 2),
+      hasAnomaly: Boolean(summary.failedTasks || summary.anomaly) || viewModel.tone === 'warning',
+      debug: false,
+    };
+  }
+
+  if (hit.componentType === 'agent-sprite') {
+    const model = agentInspectionModel(component);
+    return {
+      title: cleanText(model.title) || 'Sloth Worker',
+      rows: [model.statusLabel, ...model.lines.slice(0, model.maxLines || 2)],
+      hasAnomaly: model.tone === 'warning',
+      debug: false,
+    };
+  }
+
+  if (component.popoverViewModel && typeof component.popoverViewModel === 'object') {
+    const model = component.popoverViewModel;
+    const rows = Array.isArray(model.lines) ? model.lines.slice(0, 4) : [];
+    return {
+      title: cleanText(model.title) || (hit.componentType === 'task-chip' ? 'Task' : 'Result'),
+      rows,
+      hasAnomaly: model.tone === 'warning',
+      debug: false,
+    };
+  }
+
+  return null;
+}
+
 export function buildInspectionPopoverRows(hit, options = {}) {
   if (!hit || !hit.component) return null;
 
   const component = hit.component;
   const isDebug = Boolean(options.debug);
+  if (!isDebug) {
+    const friendlyModel = getFriendlyPopoverViewModelForTarget(hit, options);
+    return friendlyModel && normalTextIsSafe(friendlyModel) ? friendlyModel : null;
+  }
   const rows = [];
-  if (isDebug || hit.componentType !== 'workstation-hotspot') {
-    rows.push(`type: ${typeLabel(hit.componentType)}`);
+  rows.push(`type: ${typeLabel(hit.componentType)}`);
+  if (hit.interactionTarget) {
+    rows.push(`target: ${hit.interactionTarget.type}`);
+    rows.push(`priority: ${hit.interactionTarget.priority}`);
   }
 
   if (hit.componentType === 'workstation-hotspot') {
     const summary = component.summary && typeof component.summary === 'object' ? component.summary : {};
     const activeTasks = summary.activeTasks ?? 0;
     const waitingTasks = summary.waitingTasks ?? 0;
-    if (isDebug || activeTasks > 0) rows.push(`active tasks: ${activeTasks}`);
-    if (isDebug || waitingTasks > 0) rows.push(`waiting tasks: ${waitingTasks}`);
-    if (summary.failedTasks || summary.anomaly) rows.push('attention: yes');
-    if (summary.assignedAgents) rows.push(`assigned agents: ${summary.assignedAgents}`);
-    if (isDebug) {
-      const id = cleanText(component.id);
-      if (id) rows.push(`id: ${id}`);
-      if (hit.bounds) {
-        rows.push(`bounds: ${Math.round(hit.bounds.x)},${Math.round(hit.bounds.y)} ${Math.round(hit.bounds.width)}x${Math.round(hit.bounds.height)}`);
-      }
+    rows.push(`active tasks: ${activeTasks}`);
+    rows.push(`waiting tasks: ${waitingTasks}`);
+    rows.push(`created tasks: ${summary.createdTasks ?? 0}`);
+    rows.push(`processing tasks: ${summary.processingTasks ?? 0}`);
+    rows.push(`completed tasks: ${summary.completedTasks ?? 0}`);
+    rows.push(`failed tasks: ${summary.failedTasks ?? 0}`);
+    rows.push(`semantic active: ${summary.semanticActiveTasks ?? 0}`);
+    rows.push(`station active: ${summary.focusedActiveTasks ?? 0}`);
+    rows.push(`station waiting: ${summary.focusedWaitingTasks ?? 0}`);
+    rows.push(`station processing: ${summary.focusedProcessingTasks ?? 0}`);
+    rows.push(`station completed: ${summary.focusedCompletedTasks ?? 0}`);
+    rows.push(`station failed: ${summary.focusedFailedTasks ?? 0}`);
+    if (summary.anomaly) rows.push('attention: yes');
+    rows.push(`assigned agents: ${summary.assignedAgents ?? 0}`);
+    const id = cleanText(component.id);
+    if (id) rows.push(`id: ${id}`);
+    const zoneId = cleanText(component.zoneId);
+    const worldZoneId = cleanText(component.worldZoneId);
+    if (worldZoneId) rows.push(`world zone: ${worldZoneId}`);
+    if (zoneId) rows.push(`lifecycle zone: ${zoneId}`);
+    if (hit.bounds) {
+      rows.push(`bounds: ${Math.round(hit.bounds.x)},${Math.round(hit.bounds.y)} ${Math.round(hit.bounds.width)}x${Math.round(hit.bounds.height)}`);
     }
     return {
       title: titleFor(component, hit.componentType),
       rows,
       hasAnomaly: Boolean(summary.failedTasks || summary.anomaly),
-      debug: isDebug,
+      debug: true,
     };
   }
 
@@ -102,30 +276,28 @@ export function buildInspectionPopoverRows(hit, options = {}) {
   const zone = cleanText(component.worldZoneId) || cleanText(component.zoneId);
   if (zone) rows.push(`zone: ${zone}`);
 
-  if (isDebug && hit.componentType === 'agent-sprite') {
+  if (hit.componentType === 'agent-sprite') {
     const currentTaskId = cleanText(component.currentTaskId);
     if (currentTaskId) rows.push(`current task: ${currentTaskId}`);
   }
 
-  if (isDebug) rows.push(...metricRows(component.metrics));
+  rows.push(...metricRows(component.metrics));
 
-  if (isDebug && component.anomaly) {
+  if (component.anomaly) {
     const severity = cleanText(component.anomaly.severity) || 'unknown';
     const detail = cleanText(component.anomaly.type) || 'anomaly';
     rows.push(`anomaly: ${severity} ${detail}`);
   }
 
-  if (isDebug) {
-    const id = cleanText(component.id);
-    if (id) rows.push(`id: ${id}`);
-    if (hit.bounds) {
-      rows.push(`bounds: ${Math.round(hit.bounds.x)},${Math.round(hit.bounds.y)} ${Math.round(hit.bounds.width)}x${Math.round(hit.bounds.height)}`);
-    }
-    const zoneId = cleanText(component.zoneId);
-    const worldZoneId = cleanText(component.worldZoneId);
-    if (zoneId && worldZoneId && zoneId !== worldZoneId) {
-      rows.push(`lifecycle zone: ${zoneId}`);
-    }
+  const id = cleanText(component.id);
+  if (id) rows.push(`id: ${id}`);
+  if (hit.bounds) {
+    rows.push(`bounds: ${Math.round(hit.bounds.x)},${Math.round(hit.bounds.y)} ${Math.round(hit.bounds.width)}x${Math.round(hit.bounds.height)}`);
+  }
+  const zoneId = cleanText(component.zoneId);
+  const worldZoneId = cleanText(component.worldZoneId);
+  if (zoneId && worldZoneId && zoneId !== worldZoneId) {
+    rows.push(`lifecycle zone: ${zoneId}`);
   }
 
   return {
@@ -154,6 +326,15 @@ function roundRect(ctx, x, y, w, h, r) {
 function anchorFor(ctx, hit, width, height) {
   const canvasW = finite(ctx?.canvas?.width, 1060);
   const canvasH = finite(ctx?.canvas?.height, 520);
+  if (hit.componentType === 'workstation-hotspot' && hit.component?.popoverAnchor) {
+    const anchor = hit.component.popoverAnchor;
+    const scaledX = finite(anchor.x, 0) * canvasW / 1060;
+    const scaledY = finite(anchor.y, 0) * canvasH / 520;
+    return {
+      x: Math.max(8, Math.min(canvasW - width - 8, scaledX + 8)),
+      y: Math.max(8, Math.min(canvasH - height - 8, scaledY - 6)),
+    };
+  }
   const bounds = hit.bounds || { x: 0, y: 0, width: 0, height: 0 };
   let x = bounds.x + bounds.width + 8;
   let y = bounds.y - 6;

--- a/rendering/renderer-loop.js
+++ b/rendering/renderer-loop.js
@@ -12,9 +12,22 @@ import {
   resolveInspectionTarget,
 } from './canvas-inspection-state.js';
 import { renderInspectionPopover } from './inspection-popover-renderer.js';
-import { isRenderDebugEnabled } from './debug.js';
+import { isRenderDebugEnabled, traceRenderBoot } from './debug.js';
 import { loadedAssets } from './assets.js';
-import { isBakedBackgroundActive } from './background-config.js';
+import { isBakedBackgroundActive, selectLoadedBackground } from './background-config.js';
+import { renderHotspotHighlights } from './hotspot-highlight-renderer.js';
+import {
+  getCalibratedHotspots,
+  handleHotspotCalibrationPointerDown,
+  handleHotspotCalibrationPointerMove,
+  handleHotspotCalibrationPointerUp,
+  handleHotspotCalibrationKeydown,
+  hotspotCalibrationState,
+  isHotspotCalibrationEditMode,
+  isHotspotCalibrationEnabled,
+  selectHotspotForCalibration,
+} from '../ui/hotspots/hotspotCalibration.js';
+import { buildWorkstationHotspotComponents } from './workstation-hotspots.js';
 
 let _frame = 0;
 let _inspectionBindingsAttached = false;
@@ -37,6 +50,8 @@ function currentHitTestOptions() {
   return {
     debug: isRenderDebugEnabled(),
     bakedBackground: isBakedBackgroundActive(loadedAssets),
+    canvasSize: canvas ? { width: canvas.width, height: canvas.height } : undefined,
+    hotspots: getCalibratedHotspots(),
   };
 }
 
@@ -47,6 +62,14 @@ export function initRenderer() {
 
   canvas.addEventListener('mousemove', (event) => {
     const point = eventToCanvasPoint(event);
+    if (isHotspotCalibrationEditMode() && handleHotspotCalibrationPointerMove(point, {
+      altKey: event.altKey,
+      hotspots: getCalibratedHotspots(),
+    })) {
+      canvas.style.cursor = 'grabbing';
+      event.preventDefault?.();
+      return;
+    }
     const hitTestOptions = currentHitTestOptions();
     const hit = updateInspectionHover(
       canvasInspectionState,
@@ -56,6 +79,24 @@ export function initRenderer() {
       hitTestOptions
     );
     canvas.style.cursor = hit ? 'pointer' : 'default';
+  });
+
+  canvas.addEventListener('mousedown', (event) => {
+    const point = eventToCanvasPoint(event);
+    if (handleHotspotCalibrationPointerDown(point, {
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      hotspots: getCalibratedHotspots(),
+    })) {
+      canvas.style.cursor = 'grabbing';
+      event.preventDefault?.();
+    }
+  });
+
+  canvas.addEventListener('mouseup', () => {
+    if (handleHotspotCalibrationPointerUp()) {
+      canvas.style.cursor = 'pointer';
+    }
   });
 
   canvas.addEventListener('mouseleave', () => {
@@ -71,14 +112,21 @@ export function initRenderer() {
 
   canvas.addEventListener('click', (event) => {
     const point = eventToCanvasPoint(event);
-    updateInspectionSelection(
+    const hit = updateInspectionSelection(
       canvasInspectionState,
       _latestComponents,
       point,
       _latestEntityPositions,
       currentHitTestOptions()
     );
+    if (hit?.componentType === 'workstation-hotspot') {
+      selectHotspotForCalibration(hit.entityId);
+    }
   });
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', handleHotspotCalibrationKeydown);
+  }
 
   _inspectionBindingsAttached = true;
 }
@@ -91,6 +139,15 @@ export function renderErrorState() {
 }
 
 export function renderFrame(renderView) {
+  const bootTraceBackground = selectLoadedBackground(loadedAssets);
+  traceRenderBoot('renderer-loop.renderFrame:start', {
+    ctx,
+    frame: _frame,
+    backgroundLoaded: Boolean(bootTraceBackground && bootTraceBackground.image),
+    backgroundSource: bootTraceBackground ? bootTraceBackground.filename : null,
+    bakedBackgroundActive: isBakedBackgroundActive(bootTraceBackground || loadedAssets),
+  });
+
   assertGraphShape(renderView);
   const scene      = buildWorldScene(renderView);
   assertEventDriven(scene);
@@ -99,6 +156,9 @@ export function renderFrame(renderView) {
   _latestComponents = components;
   _latestEntityPositions = entityPositions;
   const hitTestOptions = currentHitTestOptions();
+  const calibratedHotspots = getCalibratedHotspots();
+  const workstationHotspotComponents = buildWorkstationHotspotComponents(calibratedHotspots, components);
+  hitTestOptions.stationComponents = workstationHotspotComponents;
   refreshInspectionSelection(canvasInspectionState, components, entityPositions, hitTestOptions);
 
   if (canvasInspectionState.pointer.inside) {
@@ -123,9 +183,32 @@ export function renderFrame(renderView) {
   }
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  renderAllLayers(ctx, components, _frame);
-  renderInspectionPopover(ctx, resolveInspectionTarget(canvasInspectionState), {
-    debug: isRenderDebugEnabled(),
+  renderAllLayers(ctx, components, _frame, {
+    calibration: isHotspotCalibrationEnabled(),
+  });
+  traceRenderBoot('renderer-loop.renderFrame:after-renderAllLayers', {
+    ctx,
+    frame: _frame,
+    componentCount: components.length,
+    taskChipCount: components.filter((c) => c && c.componentType === 'task-chip').length,
+    agentCount: components.filter((c) => c && c.componentType === 'agent-sprite').length,
+    zoneCount: components.filter((c) => c && c.componentType === 'zone-background').length,
+    backgroundLoaded: Boolean(bootTraceBackground && bootTraceBackground.image),
+    backgroundSource: bootTraceBackground ? bootTraceBackground.filename : null,
+    bakedBackgroundActive: isBakedBackgroundActive(bootTraceBackground || loadedAssets),
+  });
+  renderHotspotHighlights(ctx, canvasInspectionState, {
+    debug: isRenderDebugEnabled() || isHotspotCalibrationEnabled(),
+    frame: _frame,
+    canvasSize: { width: canvas.width, height: canvas.height },
+    hotspots: calibratedHotspots,
+    hotspotComponents: workstationHotspotComponents,
+    calibration: hotspotCalibrationState,
+  });
+  const inspectionTarget = resolveInspectionTarget(canvasInspectionState);
+  renderInspectionPopover(ctx, inspectionTarget, {
+    debug: isRenderDebugEnabled() || isHotspotCalibrationEnabled(),
+    selected: Boolean(canvasInspectionState.selectedHit && inspectionTarget === canvasInspectionState.selectedHit),
   });
   _frame += 1;
 }

--- a/rendering/workstation-hotspots.js
+++ b/rendering/workstation-hotspots.js
@@ -5,115 +5,67 @@
  * Summaries are derived only from render component descriptors.
  */
 
-import { SCENE_ANCHORS } from './scene-anchors.js';
+import {
+  WORKSTATION_HOTSPOTS,
+  getWorkstationHotspotById,
+} from '../ui/hotspots/workstationHotspots.js';
+import {
+  buildWorkstationNormalSummaryRows,
+  buildWorkstationInspectionViewModel,
+  buildWorkstationPopoverViewModel,
+  buildWorkstationVisualStateViewModel,
+  getWorkstationSemanticMetadata,
+} from '../ui/hotspots/workstationSemantics.js';
 
-function hotspot(config) {
-  return Object.freeze({
-    id: config.id,
-    label: config.label,
-    worldZoneIds: Object.freeze(config.worldZoneIds || []),
-    zoneIds: Object.freeze(config.zoneIds || []),
-    bounds: Object.freeze({ ...config.bounds }),
-    feedbackAnchor: Object.freeze(config.feedbackAnchor || config.bounds),
-    feedbackKind: config.feedbackKind || 'monitor',
-  });
-}
-
-function boundsFrom(anchor, inflate = 0) {
-  const b = anchor.bounds || { x: anchor.x - 20, y: anchor.y - 20, width: 40, height: 40 };
-  return {
-    x: b.x - inflate,
-    y: b.y - inflate,
-    width: b.width + inflate * 2,
-    height: b.height + inflate * 2,
-  };
-}
-
-export const WORKSTATION_HOTSPOTS = Object.freeze([
-  hotspot({
-    id: 'engineCrystalHotspot',
-    label: 'Engine Core',
-    worldZoneIds: ['engineCrystal'],
-    zoneIds: ['ENQUEUED'],
-    bounds: { x: 454, y: 118, width: 78, height: 292 },
-    feedbackAnchor: SCENE_ANCHORS.crystal.engineCrystal,
-    feedbackKind: 'crystal',
-  }),
-  hotspot({
-    id: 'intakeDeskHotspot',
-    label: 'Intake Desk',
-    worldZoneIds: ['intakeDesk'],
-    zoneIds: ['CREATED'],
-    bounds: { x: 44, y: 116, width: 172, height: 126 },
-    feedbackAnchor: SCENE_ANCHORS.shelves.intakeShelf,
-    feedbackKind: 'shelf',
-  }),
-  hotspot({
-    id: 'researchMonitorHotspot',
-    label: 'Research Desk',
-    worldZoneIds: ['researchDesk'],
-    zoneIds: ['CLAIMED'],
-    bounds: boundsFrom(SCENE_ANCHORS.desks['desk-0'], -24),
-    feedbackAnchor: SCENE_ANCHORS.desks['desk-0'],
-  }),
-  hotspot({
-    id: 'shopifyMonitorHotspot',
-    label: 'Shopify Desk',
-    worldZoneIds: ['shopifyDesk'],
-    zoneIds: ['CLAIMED'],
-    bounds: boundsFrom(SCENE_ANCHORS.desks['desk-1'], -34),
-    feedbackAnchor: SCENE_ANCHORS.desks['desk-1'],
-  }),
-  hotspot({
-    id: 'renderMonitorHotspot',
-    label: 'Render Desk',
-    worldZoneIds: ['renderDesk'],
-    zoneIds: ['EXECUTE_FINISHED'],
-    bounds: boundsFrom(SCENE_ANCHORS.desks['desk-4'], -46),
-    feedbackAnchor: SCENE_ANCHORS.desks['desk-4'],
-  }),
-  hotspot({
-    id: 'supportMonitorHotspot',
-    label: 'Support Desk',
-    worldZoneIds: ['supportDesk'],
-    zoneIds: ['CLAIMED'],
-    bounds: boundsFrom(SCENE_ANCHORS.desks['desk-5'], -42),
-    feedbackAnchor: SCENE_ANCHORS.desks['desk-5'],
-  }),
-  hotspot({
-    id: 'approvalDeskHotspot',
-    label: 'Approval Desk',
-    worldZoneIds: ['approvalDesk'],
-    zoneIds: ['EXECUTE_FINISHED'],
-    bounds: boundsFrom(SCENE_ANCHORS.approvalDesk.deliveryDesk, 6),
-    feedbackAnchor: SCENE_ANCHORS.approvalDesk.deliveryDesk,
-    feedbackKind: 'shelf',
-  }),
-  hotspot({
-    id: 'archiveShelfHotspot',
-    label: 'Archive Shelf',
-    worldZoneIds: ['archiveLibrary'],
-    zoneIds: ['ACKED'],
-    bounds: { x: 850, y: 42, width: 160, height: 250 },
-    feedbackAnchor: SCENE_ANCHORS.decor.archiveShelf,
-    feedbackKind: 'shelf',
-  }),
-  hotspot({
-    id: 'anomalyShelfHotspot',
-    label: 'Anomaly Shelf',
-    worldZoneIds: ['anomalyShelf'],
-    zoneIds: ['ACKED'],
-    bounds: boundsFrom(SCENE_ANCHORS.warningShelf.anomalyShelf, 8),
-    feedbackAnchor: SCENE_ANCHORS.warningShelf.anomalyShelf,
-    feedbackKind: 'warning',
-  }),
-]);
+export { WORKSTATION_HOTSPOTS, getWorkstationHotspotById };
+export { buildWorkstationNormalSummaryRows };
 
 const WAITING_STATES = Object.freeze(['idle', 'waiting']);
 const ACTIVE_STATES = Object.freeze(['working', 'processing']);
+const PROCESSING_STATES = Object.freeze(['processing']);
+const COMPLETED_STATES = Object.freeze(['completed']);
 
 function matchesHotspot(component, hotspot) {
   return hotspot.worldZoneIds.includes(component.worldZoneId) || hotspot.zoneIds.includes(component.zoneId);
+}
+
+function textForSemanticMatch(component) {
+  return [
+    component.taskType,
+    component.title,
+  ]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join(' ')
+    .toLowerCase();
+}
+
+function matchesSemanticTokens(component, hotspot) {
+  const semantics = getWorkstationSemanticMetadata(hotspot.id);
+  if (!semantics || semantics.tokens.length === 0) return true;
+  const text = textForSemanticMatch(component);
+  return semantics.tokens.some((token) => text.includes(token));
+}
+
+function matchesPrimaryWorldZone(component, hotspot) {
+  return hotspot.worldZoneIds.includes(component.worldZoneId);
+}
+
+function safeStationWorkItems(hotspot, components) {
+  if (!hotspot || !Array.isArray(components)) return Object.freeze([]);
+  const items = [];
+  for (const component of components) {
+    if (!component || component.componentType !== 'task-chip') continue;
+    if (!matchesHotspot(component, hotspot)) continue;
+    if (!matchesPrimaryWorldZone(component, hotspot) && !matchesSemanticTokens(component, hotspot)) continue;
+    items.push(Object.freeze({
+      title: typeof component.title === 'string' ? component.title : null,
+      taskType: typeof component.taskType === 'string' ? component.taskType : null,
+      visualState: typeof component.visualState === 'string' ? component.visualState : 'unknown',
+      anomaly: Boolean(component.anomaly),
+    }));
+    if (items.length >= 6) break;
+  }
+  return Object.freeze(items);
 }
 
 export function summarizeHotspotFromComponents(hotspot, components) {
@@ -124,6 +76,15 @@ export function summarizeHotspotFromComponents(hotspot, components) {
     anomaly: false,
     activeAgents: 0,
     assignedAgents: 0,
+    createdTasks: 0,
+    processingTasks: 0,
+    completedTasks: 0,
+    semanticActiveTasks: 0,
+    focusedActiveTasks: 0,
+    focusedWaitingTasks: 0,
+    focusedProcessingTasks: 0,
+    focusedCompletedTasks: 0,
+    focusedFailedTasks: 0,
   };
 
   if (!hotspot || !Array.isArray(components)) return Object.freeze(summary);
@@ -134,8 +95,21 @@ export function summarizeHotspotFromComponents(hotspot, components) {
     if (component.componentType === 'task-chip') {
       if (ACTIVE_STATES.includes(component.visualState)) summary.activeTasks++;
       if (WAITING_STATES.includes(component.visualState)) summary.waitingTasks++;
+      if (component.visualState === 'idle') summary.createdTasks++;
+      if (PROCESSING_STATES.includes(component.visualState)) summary.processingTasks++;
+      if (COMPLETED_STATES.includes(component.visualState)) summary.completedTasks++;
       if (component.visualState === 'error') summary.failedTasks++;
       if (component.anomaly) summary.anomaly = true;
+      if (ACTIVE_STATES.includes(component.visualState) && matchesSemanticTokens(component, hotspot)) {
+        summary.semanticActiveTasks++;
+      }
+      if (matchesPrimaryWorldZone(component, hotspot)) {
+        if (component.visualState === 'working') summary.focusedActiveTasks++;
+        if (WAITING_STATES.includes(component.visualState)) summary.focusedWaitingTasks++;
+        if (PROCESSING_STATES.includes(component.visualState)) summary.focusedProcessingTasks++;
+        if (COMPLETED_STATES.includes(component.visualState)) summary.focusedCompletedTasks++;
+        if (component.visualState === 'error') summary.focusedFailedTasks++;
+      }
     }
 
     if (component.componentType === 'agent-sprite') {
@@ -150,18 +124,34 @@ export function summarizeHotspotFromComponents(hotspot, components) {
 
 export function componentForHotspot(hotspot, components) {
   const summary = summarizeHotspotFromComponents(hotspot, components);
-  return Object.freeze({
+  const stationWorkItems = safeStationWorkItems(hotspot, components);
+  const component = {
     componentType: 'workstation-hotspot',
     id: hotspot.id,
-    label: hotspot.label,
+    label: hotspot.label || hotspot.title,
+    title: hotspot.title || hotspot.label,
+    purpose: hotspot.purpose || null,
+    popoverAnchor: hotspot.popoverAnchor || null,
     worldZoneId: hotspot.worldZoneIds[0] || null,
     zoneId: hotspot.zoneIds[0] || null,
     summary,
+    stationWorkItems,
+  };
+  const visualStateViewModel = buildWorkstationVisualStateViewModel(component);
+  const enrichedComponent = {
+    ...component,
+    popoverViewModel: buildWorkstationPopoverViewModel(component),
+    visualStateViewModel,
+  };
+  return Object.freeze({
+    ...enrichedComponent,
+    inspectionViewModel: buildWorkstationInspectionViewModel(enrichedComponent),
   });
 }
 
-export function getWorkstationHotspotById(id) {
-  return WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === id) || null;
+export function buildWorkstationHotspotComponents(hotspots, components) {
+  const sourceHotspots = Array.isArray(hotspots) ? hotspots : WORKSTATION_HOTSPOTS;
+  return Object.freeze(sourceHotspots.map((hotspot) => componentForHotspot(hotspot, components)));
 }
 
 export function renderWorkstationHotspotDebug(ctx) {
@@ -185,7 +175,7 @@ export function renderWorkstationHotspotDebug(ctx) {
 }
 
 function anchorCenter(hotspot) {
-  const anchor = hotspot.feedbackAnchor || hotspot.bounds;
+  const anchor = hotspot.highlightAnchor || hotspot.feedbackAnchor || hotspot.bounds;
   const bounds = anchor.bounds || null;
   if (bounds) {
     return {

--- a/rendering/world-background-composition.js
+++ b/rendering/world-background-composition.js
@@ -10,6 +10,8 @@
  */
 
 import { WORLD_ZONES, WORLD_ZONE_IDS } from '../ui/config/worldZones.js';
+import { BACKGROUND_BOOT_POLICY } from './background-config.js';
+import { traceRenderBoot } from './debug.js';
 
 const CANVAS_BASE = Object.freeze({ width: 1060, height: 520 });
 
@@ -237,6 +239,15 @@ export function renderTreehouseBackdrop(ctx, frame = 0) {
   if (!ctx || !ctx.canvas) return;
   const cw = ctx.canvas.width;
   const ch = ctx.canvas.height;
+  traceRenderBoot('world-background-composition.renderTreehouseBackdrop:procedural-fallback-scene', {
+    ctx,
+    frame,
+    backgroundLoaded: false,
+    backgroundSource: null,
+    drawsDarkBrownGreenBackground: true,
+    drawsCurvedTreeBranchArcs: true,
+    arcFunction: 'ctx.bezierCurveTo',
+  });
 
   const room = ctx.createLinearGradient(0, 0, 0, ch);
   addColorStop(room, 0, '#1d1207');
@@ -288,11 +299,44 @@ export function renderWorldCompositionLayer(ctx, options = {}) {
   if (!ctx) return;
   const debug = options.debug === true;
   const bakedBackground = options.bakedBackground === true;
+  const bootPolicy = options.bootPolicy || null;
   const frame = Number.isFinite(options.frame) ? options.frame : 0;
 
-  if (bakedBackground && !debug) {
+  if (bootPolicy === BACKGROUND_BOOT_POLICY.BAKED_PENDING) {
+    traceRenderBoot('world-background-composition.renderWorldCompositionLayer:skip-baked-pending', {
+      ctx,
+      frame,
+      backgroundLoaded: false,
+      bakedBackgroundActive: false,
+      bootPolicy,
+      debug,
+      zonePropCount: WORLD_COMPOSITION_ZONES.length,
+    });
     return;
   }
+
+  if (bakedBackground && !debug) {
+    traceRenderBoot('world-background-composition.renderWorldCompositionLayer:skip-baked-background', {
+      ctx,
+      frame,
+      backgroundLoaded: true,
+      bakedBackgroundActive: true,
+      debug,
+      zonePropCount: WORLD_COMPOSITION_ZONES.length,
+    });
+    return;
+  }
+
+  traceRenderBoot('world-background-composition.renderWorldCompositionLayer:semantic-zone-props', {
+    ctx,
+    frame,
+    backgroundLoaded: !bakedBackground ? false : null,
+    bakedBackgroundActive: bakedBackground,
+    debug,
+    zonePropCount: WORLD_COMPOSITION_ZONES.length,
+    drawsCentralTealCrystal: true,
+    drawsSimpleShelvesAndDesks: true,
+  });
 
   ctx.save();
   for (const zone of WORLD_COMPOSITION_ZONES) {

--- a/rendering/world-scene-adapter.js
+++ b/rendering/world-scene-adapter.js
@@ -74,6 +74,8 @@ function entityToTaskChipComponent(entity) {
   return {
     componentType: 'task-chip',
     id:            entity.id,
+    title:         entity.title    ?? null,
+    taskType:      entity.taskType ?? null,
     x:             entity.position ? entity.position.x : 0,
     y:             entity.position ? entity.position.y : 0,
     visualState:   entity.visualState ?? 'unknown',

--- a/rendering/world-scene-asset-renderer.js
+++ b/rendering/world-scene-asset-renderer.js
@@ -29,7 +29,12 @@ import { renderTreehouseBackdrop } from './world-background-composition.js';
 import { spriteConfigs } from '../core/constants.js';
 import { compareByDepthY } from './scene-anchors.js';
 import { drawRuntimePropAsset } from './prop-asset-renderer.js';
-import { selectLoadedBackground } from './background-config.js';
+import {
+  BACKGROUND_BOOT_POLICY,
+  getBackgroundBootPolicy,
+  selectLoadedBackground,
+} from './background-config.js';
+import { traceRenderBoot } from './debug.js';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -66,6 +71,21 @@ function drawIfLoaded(ctx, filename, x, y, w, h) {
   if (img) {
     ctx.drawImage(img, x, y, w, h);
   }
+}
+
+function drawBakedPendingBootBackground(ctx) {
+  const cw = ctx.canvas.width;
+  const ch = ctx.canvas.height;
+  const base = ctx.createLinearGradient(0, 0, 0, ch);
+  base.addColorStop(0, '#120d08');
+  base.addColorStop(0.58, '#1b130c');
+  base.addColorStop(1, '#17110a');
+  ctx.fillStyle = base;
+  ctx.fillRect(0, 0, cw, ch);
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.18)';
+  ctx.fillRect(0, 0, cw, Math.max(8, ch * 0.035));
+  ctx.fillRect(0, ch - Math.max(10, ch * 0.04), cw, Math.max(10, ch * 0.04));
 }
 
 function normalizeTrendResultItems(resultPayload) {
@@ -507,26 +527,55 @@ function drawRoomScene(ctx, frame) {
  * @param {CanvasRenderingContext2D} ctx
  * @param {number} frame  Current render frame counter
  */
-export function renderBackgroundLayer(ctx, frame) {
+export function renderBackgroundLayer(ctx, frame, options = {}) {
   const cw = ctx.canvas.width;
   const ch = ctx.canvas.height;
 
   const bg = selectLoadedBackground(loadedAssets);
   const bgImg = bg && bg.image;
+  const bootPolicy = options.bootPolicy || getBackgroundBootPolicy(loadedAssets, options);
 
-  if (bgImg) {
+  if (bootPolicy === BACKGROUND_BOOT_POLICY.BAKED_READY && bgImg) {
+    traceRenderBoot('baked-background', {
+      ctx,
+      frame,
+      backgroundLoaded: true,
+      backgroundSource: bg.filename,
+      imageNaturalSize: {
+        width: bgImg.naturalWidth || bgImg.width || null,
+        height: bgImg.naturalHeight || bgImg.height || null,
+      },
+    });
     // ── A. Image mode ────────────────────────────────────────────────────
     // The background image is the sole environmental visual. No overlays drawn.
     ctx.drawImage(bgImg, 0, 0, cw, ch);
-  } else {
-    // ── B. Preload hold frame ─────────────────────────────────────────────
-    // The background image is not yet in loadedAssets. Render a plain dark fill
-    // only — no procedural room, no teal stream — so there is no blue/teal flash
-    // during the asset loading window. drawRoomScene and the full stream body are
-    // kept for reference but suppressed here to avoid any premature colour bleed.
-    // Current fallback is the static treehouse projection in world-background-composition.js.
-    renderTreehouseBackdrop(ctx, frame);
+    return;
   }
+
+  if (bootPolicy === BACKGROUND_BOOT_POLICY.FALLBACK_ALLOWED) {
+    traceRenderBoot('procedural-fallback', {
+      ctx,
+      frame,
+      backgroundLoaded: false,
+      backgroundSource: null,
+      fallbackFunction: 'renderTreehouseBackdrop',
+    });
+    // ── B. Explicit procedural fallback ───────────────────────────────────
+    // Debug/calibration/opt-in modes can still inspect the legacy treehouse
+    // projection while normal baked boot suppresses it.
+    renderTreehouseBackdrop(ctx, frame);
+    return;
+  }
+
+  traceRenderBoot('baked-pending-blank', {
+    ctx,
+    frame,
+    backgroundLoaded: false,
+    backgroundSource: null,
+    bootPolicy,
+    fallbackSuppressed: true,
+  });
+  drawBakedPendingBootBackground(ctx);
 }
 
 // ---------------------------------------------------------------------------
@@ -708,14 +757,48 @@ export function renderCoreLayer(ctx, frame) {
  * @param {CanvasRenderingContext2D} ctx
  * @param {Array<object>} components
  */
-export function renderZoneLayer(ctx, components) {
+export function renderZoneLayer(ctx, components, options = {}) {
   // When the scene background image is loaded, all zone furniture (desks, benches,
   // shelves) is already baked into the image. Drawing zone sprites on top doubles
   // the furniture and produces floating blocks over the background.
   // Skip entirely in image mode — only run in procedural fallback mode.
   const bg = selectLoadedBackground(loadedAssets);
   const bgImg = bg && bg.image;
-  if (bgImg) return;
+  const bootPolicy = options.bootPolicy || getBackgroundBootPolicy(loadedAssets, options);
+  if (bgImg) {
+    traceRenderBoot('world-scene-asset-renderer.renderZoneLayer:skip-baked-background', {
+      ctx,
+      backgroundLoaded: true,
+      backgroundSource: bg.filename,
+      zoneCount: Array.isArray(components)
+        ? components.filter((c) => c && c.componentType === 'zone-background').length
+        : 0,
+    });
+    return;
+  }
+
+  if (bootPolicy === BACKGROUND_BOOT_POLICY.BAKED_PENDING) {
+    traceRenderBoot('world-scene-asset-renderer.renderZoneLayer:skip-baked-pending', {
+      ctx,
+      backgroundLoaded: false,
+      backgroundSource: null,
+      bootPolicy,
+      zoneCount: Array.isArray(components)
+        ? components.filter((c) => c && c.componentType === 'zone-background').length
+        : 0,
+    });
+    return;
+  }
+
+  traceRenderBoot('world-scene-asset-renderer.renderZoneLayer:procedural-zone-sprites', {
+    ctx,
+    backgroundLoaded: false,
+    backgroundSource: null,
+    zoneCount: Array.isArray(components)
+      ? components.filter((c) => c && c.componentType === 'zone-background').length
+      : 0,
+    staticDeskSprites: true,
+  });
 
   for (const c of components) {
     if (c.componentType !== 'zone-background') continue;
@@ -884,6 +967,10 @@ export function renderEffectLayer(ctx, components, entityPositions) {
 export function renderUIOverlayLayer(ctx, components, entityPositions, options = {}) {
   const now = Date.now();
   const bakedNormalMode = options.bakedBackground === true && options.debug !== true;
+  const activeBackground = selectLoadedBackground(loadedAssets);
+  const bootPolicy = options.bootPolicy
+    || (options.bakedBackground === true ? BACKGROUND_BOOT_POLICY.BAKED_READY : getBackgroundBootPolicy(loadedAssets, options));
+  const allowPendingOverlay = options.allowOverlayDuringBakedPending === true || options.debug === true;
 
   // ── Pass 1: collect panels currently reported by selectors ───────────────
   // taskId → { results, keyword, agentX, agentY, status }
@@ -925,6 +1012,23 @@ export function renderUIOverlayLayer(ctx, components, entityPositions, options =
       agentX: x,
       agentY: y,
     });
+  }
+
+  traceRenderBoot('world-scene-asset-renderer.renderUIOverlayLayer:task-result-overlay-state', {
+    ctx,
+    backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+    backgroundSource: activeBackground ? activeBackground.filename : null,
+    bakedBackgroundActive: options.bakedBackground === true,
+    debug: options.debug === true,
+    bakedNormalMode,
+    bootPolicy,
+    pendingOverlaySuppressed: bootPolicy === BACKGROUND_BOOT_POLICY.BAKED_PENDING && !allowPendingOverlay,
+    activePanelCount: activePanels.size,
+    cachedPanelCount: trendPanelUIState.size,
+  });
+
+  if (bootPolicy === BACKGROUND_BOOT_POLICY.BAKED_PENDING && !allowPendingOverlay) {
+    return;
   }
 
   // ── Pass 2: update renderer-local state ──────────────────────────────────

--- a/rendering/world-scene-layer-renderer.js
+++ b/rendering/world-scene-layer-renderer.js
@@ -34,9 +34,13 @@ import { renderAllTaskChips }       from './task-chip-renderer.js';
 import { renderDiegeticIndicators } from './diegetic-indicator-renderer.js';
 import { renderWorldCompositionLayer } from './world-background-composition.js';
 import { loadedAssets } from './assets.js';
-import { isBakedBackgroundActive, selectLoadedBackground } from './background-config.js';
-import { canvasInspectionState } from './canvas-inspection-state.js';
-import { renderWorkstationHotspotDebug, renderWorkstationHotspotFeedback } from './workstation-hotspots.js';
+import {
+  BACKGROUND_BOOT_POLICY,
+  getBackgroundBootPolicy,
+  isBakedBackgroundActive,
+  selectLoadedBackground,
+} from './background-config.js';
+import { isRenderDebugEnabled, traceRenderBoot } from './debug.js';
 import {
   renderBackgroundLayer,
   renderCoreLayer,
@@ -54,11 +58,33 @@ import {
  * @param {Array<object>}            components      — flat component list from toRenderableComponents()
  * @param {number}                   frame           — current render frame counter (integer, read-only)
  */
-export function renderAllLayers(ctx, components, frame) {
+export function renderAllLayers(ctx, components, frame, options = {}) {
+  const isRenderDebug = isRenderDebugEnabled();
   // Build entity position map once; shared across geometry and sprite layers
   const entityPositions = buildEntityPositionMap(components);
   const activeBackground = selectLoadedBackground(loadedAssets);
   const bakedBackgroundActive = isBakedBackgroundActive(activeBackground);
+  const bootPolicy = options.bootPolicy || getBackgroundBootPolicy(loadedAssets, {
+    debug: isRenderDebug,
+    calibration: options.calibration === true,
+    allowProceduralFallback: options.allowProceduralFallback === true,
+  });
+  const zoneCount = components.filter((c) => c && c.componentType === 'zone-background').length;
+  const taskChipCount = components.filter((c) => c && c.componentType === 'task-chip').length;
+  const agentCount = components.filter((c) => c && c.componentType === 'agent-sprite').length;
+
+  traceRenderBoot('world-scene-layer-renderer.renderAllLayers:start', {
+    ctx,
+    frame,
+    backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+    backgroundSource: activeBackground ? activeBackground.filename : null,
+    bakedBackgroundActive,
+    bootPolicy,
+    componentCount: components.length,
+    zoneCount,
+    taskChipCount,
+    agentCount,
+  });
 
   // Debug log — component counts + entity position map size
   if (typeof window !== 'undefined' && window.DEV_MODE) {
@@ -73,7 +99,11 @@ export function renderAllLayers(ctx, components, frame) {
 
 
   // ── Layer 1: background ─────────────────────────────────────────────────
-  renderBackgroundLayer(ctx, frame);
+  renderBackgroundLayer(ctx, frame, {
+    bootPolicy,
+    debug: isRenderDebug,
+    calibration: options.calibration === true,
+  });
 
   // ── Layer 2: core ───────────────────────────────────────────────────────
   renderCoreLayer(ctx, frame);
@@ -82,33 +112,52 @@ export function renderAllLayers(ctx, components, frame) {
   // Zone geometry (filled rect + id label from renderAllZones) is debug-only.
   // In normal mode the sprite assets in renderZoneLayer provide full zone coverage.
   // Enable via window.__SLOTHWORLD_RENDER_DEBUG__ = true  or ?renderDebug in the URL.
-  const isRenderDebug = typeof window !== 'undefined' &&
-    (window.__SLOTHWORLD_RENDER_DEBUG__ === true ||
-     (() => { try { return new URLSearchParams(window.location.search).has('renderDebug'); } catch (_) { return false; } })());
   if (isRenderDebug) {
+    traceRenderBoot('world-scene-layer-renderer.world-zone-render:debug-geometry', {
+      ctx,
+      frame,
+      backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+      backgroundSource: activeBackground ? activeBackground.filename : null,
+      bakedBackgroundActive,
+      bootPolicy,
+      zoneCount,
+    });
     renderAllZones(ctx, components);
   }
-  renderZoneLayer(ctx, components);
-  renderWorldCompositionLayer(ctx, { debug: isRenderDebug, frame, bakedBackground: bakedBackgroundActive });
+  traceRenderBoot('world-scene-layer-renderer.world-zone-render:asset-layer', {
+    ctx,
+    frame,
+    backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+    backgroundSource: activeBackground ? activeBackground.filename : null,
+    bakedBackgroundActive,
+    bootPolicy,
+    zoneCount,
+  });
+  renderZoneLayer(ctx, components, {
+    bootPolicy,
+    debug: isRenderDebug,
+    calibration: options.calibration === true,
+  });
+  traceRenderBoot('world-scene-layer-renderer.baked-scene-render:composition-layer', {
+    ctx,
+    frame,
+    backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+    backgroundSource: activeBackground ? activeBackground.filename : null,
+    bakedBackgroundActive,
+    bootPolicy,
+    debug: isRenderDebug,
+  });
+  renderWorldCompositionLayer(ctx, { debug: isRenderDebug, frame, bakedBackground: bakedBackgroundActive, bootPolicy });
 
   // ── Layer 3.5: zone labels (debug mode only) ───────────────────────────
   // Themed zone-name badges (Intake Nook, Task Engine, …). Shown only in
   // debug mode alongside raw zone IDs. In normal mode, in-world diegetic
   // indicators communicate state instead — no duplicate text labels.
   renderZoneLabels(ctx, components, isRenderDebug);
-  if (isRenderDebug) {
-    renderWorkstationHotspotDebug(ctx);
-  } else {
-    renderWorkstationHotspotFeedback(ctx, components, canvasInspectionState, {
-      debug: false,
-      bakedBackground: bakedBackgroundActive,
-    });
-  }
-
   // ── Layer 3.6: diegetic indicators (normal mode only) ──────────────────
   // In-world visual props (paper stacks, monitor glow, rune pulse, …) that
   // communicate zone activity without persistent text labels.
-  if (!isRenderDebug) {
+  if (!isRenderDebug && bootPolicy !== BACKGROUND_BOOT_POLICY.BAKED_PENDING) {
     renderDiegeticIndicators(ctx, components, Date.now(), { bakedBackground: bakedBackgroundActive });
   }
 
@@ -131,8 +180,19 @@ export function renderAllLayers(ctx, components, frame) {
   renderAllTaskChips(ctx, components, entityPositions, isRenderDebug);
 
   // renderPropLayer remains suppressed in image mode. renderEffectLayer is a hard no-op.
+  traceRenderBoot('world-scene-layer-renderer.task-result-overlay-render:ui-overlay', {
+    ctx,
+    frame,
+    backgroundLoaded: Boolean(activeBackground && activeBackground.image),
+    backgroundSource: activeBackground ? activeBackground.filename : null,
+    bakedBackgroundActive,
+    bootPolicy,
+    agentCount,
+  });
   renderUIOverlayLayer(ctx, components, entityPositions, {
     debug: isRenderDebug,
     bakedBackground: bakedBackgroundActive,
+    bootPolicy,
+    allowOverlayDuringBakedPending: options.allowOverlayDuringBakedPending === true,
   });
 }

--- a/rendering/world-scene.js
+++ b/rendering/world-scene.js
@@ -267,6 +267,8 @@ export function buildWorldScene(graph) {
         queueTime: meta.queueTime ?? null,
         latency:   meta.latency   ?? null,
       };
+      const taskType = typeof meta.taskType === 'string' ? meta.taskType : null;
+      const title = typeof meta.title === 'string' ? meta.title : null;
 
       const firstIncident = Array.isArray(meta.incidents) && meta.incidents.length > 0
         ? meta.incidents[0]
@@ -287,6 +289,8 @@ export function buildWorldScene(graph) {
       return {
         id: n.id,
         type: n.type,
+        taskType,
+        title,
         zoneId,
         worldZoneId: placed.zoneId,
         visualState,

--- a/tests/background-boot-gate.test.mjs
+++ b/tests/background-boot-gate.test.mjs
@@ -1,0 +1,217 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BACKGROUND_BOOT_POLICY } from '../rendering/background-config.js';
+import { loadedAssets } from '../rendering/assets.js';
+import {
+  renderBackgroundLayer,
+  renderUIOverlayLayer,
+} from '../rendering/world-scene-asset-renderer.js';
+import { renderWorldCompositionLayer } from '../rendering/world-background-composition.js';
+
+function clearBackgroundAssets() {
+  delete loadedAssets['scene_background_02.png'];
+  delete loadedAssets['scene_background_02.jpg'];
+  delete loadedAssets['scene_background_01.jpg'];
+}
+
+function makeGradient(log, kind) {
+  return {
+    addColorStop(offset, color) {
+      log.push({ method: `${kind}.addColorStop`, args: [offset, color] });
+    },
+  };
+}
+
+function makeMockCtx() {
+  const log = [];
+  const store = {
+    canvas: { width: 1060, height: 520 },
+    createLinearGradient(...args) {
+      log.push({ method: 'createLinearGradient', args });
+      return makeGradient(log, 'linearGradient');
+    },
+    createRadialGradient(...args) {
+      log.push({ method: 'createRadialGradient', args });
+      return makeGradient(log, 'radialGradient');
+    },
+    measureText(text) {
+      log.push({ method: 'measureText', args: [text] });
+      return { width: String(text).length * 6 };
+    },
+  };
+
+  const ctx = new Proxy(store, {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      return (...args) => {
+        log.push({ method: String(prop), args });
+      };
+    },
+    set(target, prop, value) {
+      target[prop] = value;
+      log.push({ method: 'set', prop: String(prop), value });
+      return true;
+    },
+  });
+
+  return { ctx, log };
+}
+
+function makePanelComponents() {
+  return [
+    {
+      componentType: 'agent-sprite',
+      id: 'agent-1',
+      x: 300,
+      y: 260,
+      trendPanelState: {
+        taskId: 'task-trends-1',
+        keyword: 'hats',
+        status: 'done',
+        results: [{ item: 'hats-green', score: 0.91 }],
+      },
+    },
+  ];
+}
+
+function withWindow(fakeWindow, fn) {
+  const previousWindow = globalThis.window;
+  globalThis.window = fakeWindow;
+  try {
+    return fn();
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  }
+}
+
+test('background boot gate: normal baked-pending does not call procedural fallback', () => {
+  clearBackgroundAssets();
+  const { ctx, log } = makeMockCtx();
+
+  renderBackgroundLayer(ctx, 1);
+
+  assert.equal(log.some((entry) => entry.method === 'bezierCurveTo'), false);
+});
+
+test('background boot gate: normal baked-pending draws neutral boot background', () => {
+  clearBackgroundAssets();
+  const { ctx, log } = makeMockCtx();
+
+  renderBackgroundLayer(ctx, 1);
+
+  assert.ok(log.some((entry) => entry.method === 'createLinearGradient'));
+  assert.ok(log.some((entry) => entry.method === 'fillRect'));
+});
+
+test('background boot gate: fallback flag allows procedural fallback', () => {
+  clearBackgroundAssets();
+  const { ctx, log } = makeMockCtx();
+  const localStorage = {
+    getItem(key) {
+      return key === 'slothworld.allowProceduralFallback' ? '1' : null;
+    },
+  };
+
+  withWindow({ localStorage }, () => renderBackgroundLayer(ctx, 2));
+
+  assert.ok(log.some((entry) => entry.method === 'bezierCurveTo'));
+});
+
+test('background boot gate: debug and calibration allow procedural fallback', () => {
+  clearBackgroundAssets();
+  const debug = makeMockCtx();
+  const calibration = makeMockCtx();
+
+  renderBackgroundLayer(debug.ctx, 3, { debug: true });
+  renderBackgroundLayer(calibration.ctx, 3, { calibration: true });
+
+  assert.ok(debug.log.some((entry) => entry.method === 'bezierCurveTo'));
+  assert.ok(calibration.log.some((entry) => entry.method === 'bezierCurveTo'));
+});
+
+test('background boot gate: baked-ready draws baked background', () => {
+  clearBackgroundAssets();
+  const image = { width: 1376, height: 768 };
+  loadedAssets['scene_background_02.png'] = image;
+  const { ctx, log } = makeMockCtx();
+
+  renderBackgroundLayer(ctx, 4);
+
+  assert.ok(log.some((entry) => entry.method === 'drawImage' && entry.args[0] === image));
+  assert.equal(log.some((entry) => entry.method === 'bezierCurveTo'), false);
+  clearBackgroundAssets();
+});
+
+test('background boot gate: world composition skips semantic props during baked-pending', () => {
+  const { ctx, log } = makeMockCtx();
+
+  renderWorldCompositionLayer(ctx, {
+    bootPolicy: BACKGROUND_BOOT_POLICY.BAKED_PENDING,
+    debug: false,
+    frame: 0,
+  });
+
+  assert.equal(log.some((entry) => entry.method === 'fillRect'), false);
+  assert.equal(log.some((entry) => entry.method === 'fillText'), false);
+});
+
+test('background boot gate: render boot trace reports selected path', () => {
+  clearBackgroundAssets();
+  const { ctx } = makeMockCtx();
+  const logs = [];
+  const previousLog = console.log;
+  console.log = (...args) => logs.push(args);
+
+  try {
+    withWindow({ __SLOTHWORLD_TRACE_RENDER_BOOT__: true }, () => renderBackgroundLayer(ctx, 5));
+  } finally {
+    console.log = previousLog;
+  }
+
+  const payload = logs.find((entry) => entry[0] === '[Slothworld render boot trace]')?.[1];
+  assert.equal(payload?.path, 'baked-pending-blank');
+});
+
+test('background boot gate: UI overlay is suppressed during baked-pending blank background', () => {
+  clearBackgroundAssets();
+  const { ctx, log } = makeMockCtx();
+
+  renderUIOverlayLayer(ctx, makePanelComponents(), new Map(), {
+    bootPolicy: BACKGROUND_BOOT_POLICY.BAKED_PENDING,
+    debug: false,
+  });
+
+  assert.equal(log.some((entry) => entry.method === 'fillText'), false);
+  assert.equal(log.some((entry) => entry.method === 'fillRect'), false);
+});
+
+test('background boot gate: UI overlay can be explicitly allowed during baked-pending', () => {
+  clearBackgroundAssets();
+  const { ctx, log } = makeMockCtx();
+  const previousNow = Date.now;
+  let now = 1000;
+  Date.now = () => now;
+
+  try {
+    renderUIOverlayLayer(ctx, makePanelComponents(), new Map(), {
+      bootPolicy: BACKGROUND_BOOT_POLICY.BAKED_PENDING,
+      debug: false,
+      allowOverlayDuringBakedPending: true,
+    });
+    now = 1300;
+    renderUIOverlayLayer(ctx, makePanelComponents(), new Map(), {
+      bootPolicy: BACKGROUND_BOOT_POLICY.BAKED_PENDING,
+      debug: false,
+      allowOverlayDuringBakedPending: true,
+    });
+  } finally {
+    Date.now = previousNow;
+  }
+
+  assert.ok(log.some((entry) => entry.method === 'fillText'));
+});

--- a/tests/background-config.test.mjs
+++ b/tests/background-config.test.mjs
@@ -6,8 +6,11 @@ import { fileURLToPath } from 'node:url';
 
 import { assetPaths } from '../rendering/assets.js';
 import {
+  BACKGROUND_BOOT_POLICY,
   BACKGROUND_ASSET_PREFERENCE,
+  getBackgroundBootPolicy,
   isBakedBackgroundActive,
+  isProceduralFallbackAllowed,
   selectLoadedBackground,
 } from '../rendering/background-config.js';
 
@@ -58,6 +61,23 @@ test('background config: baked background helper only matches scene_background_0
   assert.equal(isBakedBackgroundActive({ 'scene_background_01.jpg': { id: '01' } }), false);
   assert.equal(isBakedBackgroundActive({ filename: 'scene_background_02.png', isPreferredBakedPlate: true }), true);
   assert.equal(isBakedBackgroundActive(null), false);
+});
+
+test('background config: boot policy reports baked-ready when a background is loaded', () => {
+  assert.equal(
+    getBackgroundBootPolicy({ 'scene_background_02.png': { id: '02' } }),
+    BACKGROUND_BOOT_POLICY.BAKED_READY,
+  );
+});
+
+test('background config: boot policy reports baked-pending in normal mode with no background', () => {
+  assert.equal(getBackgroundBootPolicy({}), BACKGROUND_BOOT_POLICY.BAKED_PENDING);
+});
+
+test('background config: debug and calibration allow procedural fallback', () => {
+  assert.equal(getBackgroundBootPolicy({}, { debug: true }), BACKGROUND_BOOT_POLICY.FALLBACK_ALLOWED);
+  assert.equal(getBackgroundBootPolicy({}, { calibration: true }), BACKGROUND_BOOT_POLICY.FALLBACK_ALLOWED);
+  assert.equal(isProceduralFallbackAllowed({ allowProceduralFallback: true }), true);
 });
 
 test('background config: runtime modules do not reference docs uiendgoal path', () => {

--- a/tests/canvas-inspection.test.mjs
+++ b/tests/canvas-inspection.test.mjs
@@ -17,6 +17,7 @@ import {
 } from '../rendering/canvas-inspection-state.js';
 import {
   buildInspectionPopoverRows,
+  canRenderNormalPopover,
   renderInspectionPopover,
 } from '../rendering/inspection-popover-renderer.js';
 import {
@@ -27,9 +28,33 @@ import {
 import { renderWorldCompositionLayer } from '../rendering/world-background-composition.js';
 import { renderUIOverlayLayer } from '../rendering/world-scene-asset-renderer.js';
 import {
+  WORKSTATION_HOTSPOTS,
+  buildWorkstationHotspotComponents,
+  componentForHotspot,
+  buildWorkstationNormalSummaryRows,
   renderWorkstationHotspotDebug,
   renderWorkstationHotspotFeedback,
 } from '../rendering/workstation-hotspots.js';
+import {
+  WORKSTATION_SEMANTICS,
+  getWorkstationSemanticMetadata,
+} from '../ui/hotspots/workstationSemantics.js';
+import {
+  buildWorkstationPopoverViewModel,
+} from '../ui/selectors/workstationPopoverSelectors.js';
+import {
+  buildWorkstationVisualStateViewModel,
+} from '../ui/selectors/workstationVisualStateSelectors.js';
+import {
+  buildWorkstationInspectionViewModel,
+} from '../ui/selectors/workstationInspectionSelectors.js';
+import {
+  buildInteractionTargets,
+  getInteractionTargetAtPoint,
+} from '../ui/interactions/interactionTargets.js';
+import {
+  buildAgentInspectionViewModel,
+} from '../ui/selectors/agentInspectionSelectors.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -123,14 +148,14 @@ test('canvas inspection: hit-test returns stable result for known component posi
   assert.deepStrictEqual(hit.bounds, taskBounds);
 });
 
-test('canvas inspection: normal mode still hits task-chip and agent-sprite', () => {
+test('canvas inspection: normal mode hits task-chip but excludes default agent sprites', () => {
   const taskHit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null, { debug: false });
   assert.equal(taskHit.entityId, 'task-1');
   assert.equal(taskHit.componentType, 'task-chip');
 
   const agentHit = hitTestRenderableComponents(COMPONENTS, { x: 230, y: 225 }, null);
-  assert.equal(agentHit.entityId, 'agent-1');
-  assert.equal(agentHit.componentType, 'agent-sprite');
+  assert.equal(agentHit.componentType, 'workstation-hotspot');
+  assert.notEqual(agentHit.componentType, 'agent-sprite');
 });
 
 test('canvas inspection: normal mode skips idle agent hit and hits workstation hotspot', () => {
@@ -166,9 +191,7 @@ test('canvas inspection: debug mode can hit broad zone-background rectangles', (
 
 test('canvas inspection: normal mode hits small diegetic indicator anchors', () => {
   const zoneHit = hitTestRenderableComponents(COMPONENTS, { x: 126, y: 356 }, null, { debug: false });
-  assert.equal(zoneHit.entityId, 'ENQUEUED');
-  assert.equal(zoneHit.componentType, 'world-zone-indicator');
-  assert.deepStrictEqual(zoneHit.bounds, { x: 103, y: 333, width: 46, height: 46 });
+  assert.equal(zoneHit, null);
 });
 
 test('canvas inspection: hover and click state update deterministically', () => {
@@ -180,9 +203,9 @@ test('canvas inspection: hover and click state update deterministically', () => 
   assert.equal(state.hoveredComponentType, 'task-chip');
 
   const selection = updateInspectionSelection(state, COMPONENTS, { x: 230, y: 225 }, null);
-  assert.equal(selection.entityId, 'agent-1');
-  assert.equal(state.selectedEntityId, 'agent-1');
-  assert.equal(resolveInspectionTarget(state).entityId, 'agent-1');
+  assert.equal(selection.entityId, 'intakeDeskHotspot');
+  assert.equal(state.selectedEntityId, 'intakeDeskHotspot');
+  assert.equal(resolveInspectionTarget(state).entityId, 'intakeDeskHotspot');
 });
 
 test('canvas inspection: background click clears selection', () => {
@@ -199,13 +222,13 @@ test('canvas inspection: background click clears selection', () => {
 
 test('canvas inspection: selected component refreshes from latest descriptors', () => {
   const state = createCanvasInspectionState();
-  updateInspectionSelection(state, COMPONENTS, { x: 230, y: 225 }, null);
+  updateInspectionSelection(state, COMPONENTS, { x: 230, y: 225 }, null, { debug: true });
 
   const updated = COMPONENTS.map((component) => component.id === 'agent-1'
     ? { ...component, visualState: 'idle', currentTaskId: null }
     : component);
 
-  refreshInspectionSelection(state, updated, null);
+  refreshInspectionSelection(state, updated, null, { debug: true });
   assert.equal(state.selectedHit.component.visualState, 'idle');
   assert.equal(state.selectedHit.component.currentTaskId, null);
 });
@@ -214,11 +237,11 @@ test('canvas inspection: popover normal mode is compact and hides diagnostics', 
   const hit = hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null);
   const model = buildInspectionPopoverRows(hit, { debug: false });
 
-  assert.equal(model.title, 'Task Scroll');
-  assert.equal(model.rows.length, 3);
-  assert.ok(model.rows.includes('type: task'));
-  assert.ok(model.rows.includes('status: processing'));
-  assert.ok(model.rows.includes('zone: delivery-bay'));
+  assert.equal(model.title, 'Task');
+  assert.ok(model.rows.length <= 2);
+  assert.ok(model.rows.includes('Processing'));
+  assert.ok(!model.rows.some((row) => row.startsWith('type:')));
+  assert.ok(!model.rows.some((row) => row.startsWith('zone:')));
   assert.ok(!model.rows.some((row) => row.startsWith('duration:')));
   assert.ok(!model.rows.some((row) => row.startsWith('anomaly:')));
   assert.ok(!model.rows.some((row) => row.startsWith('id:')));
@@ -234,14 +257,14 @@ test('canvas inspection: popover normal mode hides unknown status', () => {
   };
   const model = buildInspectionPopoverRows(hit, { debug: false });
 
-  assert.deepStrictEqual(model.rows, ['type: task', 'zone: nook']);
+  assert.equal(model, null);
 });
 
 test('canvas inspection: workstation popover summarizes render-component data only', () => {
   const components = [
-    { componentType: 'task-chip', id: 'task-active', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: null },
-    { componentType: 'task-chip', id: 'task-waiting', visualState: 'waiting', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: null },
-    { componentType: 'task-chip', id: 'task-failed', visualState: 'error', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: { severity: 'high', type: 'stalled_tasks' } },
+    { componentType: 'task-chip', id: 'task-active', title: 'Trend scan', taskType: 'TREND_RESEARCH', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: null },
+    { componentType: 'task-chip', id: 'task-waiting', title: 'Trend waiting', taskType: 'TREND_RESEARCH', visualState: 'waiting', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: null },
+    { componentType: 'task-chip', id: 'task-failed', title: 'Trend failure', taskType: 'TREND_RESEARCH', visualState: 'error', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', anomaly: { severity: 'high', type: 'stalled_tasks' } },
     { componentType: 'agent-sprite', id: 'agent-active', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED', currentTaskId: 'task-active' },
   ];
   const hit = hitTestRenderableComponents(components, { x: 330, y: 210 }, null, { debug: false });
@@ -249,11 +272,10 @@ test('canvas inspection: workstation popover summarizes render-component data on
 
   assert.equal(model.title, 'Research Desk');
   assert.ok(!model.rows.includes('type: workstation'));
-  assert.ok(model.rows.includes('active tasks: 1'));
-  assert.ok(model.rows.includes('waiting tasks: 1'));
-  assert.ok(model.rows.includes('attention: yes'));
-  assert.ok(model.rows.includes('assigned agents: 1'));
+  assert.ok(model.rows.includes('1 scan active'));
+  assert.ok(model.rows.includes('attention needed'));
   assert.ok(!model.rows.some((row) => row.startsWith('id:')));
+  assert.ok(model.rows.length <= 3);
 });
 
 test('canvas inspection: baked normal workstation popover omits zero-count and type rows', () => {
@@ -261,6 +283,7 @@ test('canvas inspection: baked normal workstation popover omits zero-count and t
   const model = buildInspectionPopoverRows(hit, { debug: false });
 
   assert.equal(model.title, 'Research Desk');
+  assert.deepStrictEqual(model.rows, ['Ready to scan trends']);
   assert.ok(!model.rows.includes('type: workstation'));
   assert.ok(!model.rows.includes('active tasks: 0'));
   assert.ok(!model.rows.includes('waiting tasks: 0'));
@@ -273,16 +296,728 @@ test('canvas inspection: debug workstation popover keeps detailed rows', () => {
   assert.ok(model.rows.includes('type: workstation'));
   assert.ok(model.rows.includes('active tasks: 0'));
   assert.ok(model.rows.includes('waiting tasks: 0'));
+  assert.ok(model.rows.includes('created tasks: 0'));
+  assert.ok(model.rows.includes('processing tasks: 0'));
+  assert.ok(model.rows.includes('completed tasks: 0'));
+  assert.ok(model.rows.includes('failed tasks: 0'));
+  assert.ok(model.rows.includes('semantic active: 0'));
+  assert.ok(model.rows.includes('station active: 0'));
+  assert.ok(model.rows.includes('station waiting: 0'));
+  assert.ok(model.rows.includes('station processing: 0'));
+  assert.ok(model.rows.includes('station completed: 0'));
+  assert.ok(model.rows.includes('station failed: 0'));
+  assert.ok(model.rows.includes('world zone: researchDesk'));
+  assert.ok(model.rows.includes('lifecycle zone: CLAIMED'));
   assert.ok(model.rows.some((row) => row.startsWith('id:')));
+});
+
+test('canvas inspection: each workstation returns a friendly normal summary', () => {
+  const components = [
+    { componentType: 'task-chip', id: 'engine-waiting', title: 'Queue item', taskType: 'standard', visualState: 'waiting', worldZoneId: 'engineCrystal', zoneId: 'ENQUEUED' },
+    { componentType: 'task-chip', id: 'intake-created', title: 'Fresh request', taskType: 'standard', visualState: 'idle', worldZoneId: 'intakeDesk', zoneId: 'CREATED' },
+    { componentType: 'task-chip', id: 'research-active', title: 'Trend scan', taskType: 'TREND_RESEARCH', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'shopify-active', title: 'Product listing', taskType: 'shopify', visualState: 'working', worldZoneId: 'shopifyDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'render-active', title: 'Render product image', taskType: 'image_render', visualState: 'processing', worldZoneId: 'renderDesk', zoneId: 'EXECUTE_FINISHED' },
+    { componentType: 'task-chip', id: 'support-active', title: 'Discord reply', taskType: 'discord', visualState: 'working', worldZoneId: 'supportDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'approval-active', title: 'Approve output', taskType: 'standard', visualState: 'processing', worldZoneId: 'approvalDesk', zoneId: 'EXECUTE_FINISHED' },
+    { componentType: 'task-chip', id: 'archive-complete', title: 'Finished task', taskType: 'standard', visualState: 'completed', worldZoneId: 'archiveLibrary', zoneId: 'ACKED' },
+    { componentType: 'task-chip', id: 'anomaly-failed', title: 'Needs review', taskType: 'standard', visualState: 'error', worldZoneId: 'anomalyShelf', zoneId: 'ACKED', anomaly: { severity: 'high', type: 'timeout' } },
+  ];
+  const expected = new Map([
+    ['engineCrystalHotspot', '1 queued'],
+    ['intakeDeskHotspot', '1 waiting'],
+    ['researchMonitorHotspot', '1 scan active'],
+    ['shopifyMonitorHotspot', '1 listing active'],
+    ['renderMonitorHotspot', '1 render active'],
+    ['supportMonitorHotspot', '1 message active'],
+    ['approvalDeskHotspot', '1 awaiting approval'],
+    ['archiveShelfHotspot', 'archive: 1 complete'],
+    ['anomalyShelfHotspot', 'attention needed'],
+  ]);
+
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const component = componentForHotspot(hotspot, components);
+    const rows = buildWorkstationNormalSummaryRows(component);
+    assert.ok(rows.includes(expected.get(hotspot.id)), `${hotspot.id} missing friendly row`);
+    assert.ok(rows.length <= 3, `${hotspot.id} should keep normal rows compact`);
+    assert.ok(!rows.some((row) => row.startsWith('type:') || row.startsWith('id:')));
+  }
+});
+
+test('canvas inspection: workstation normal summary omits zero-count rows', () => {
+  const research = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+  const component = componentForHotspot(research, []);
+  const rows = buildWorkstationNormalSummaryRows(component);
+
+  assert.deepStrictEqual(rows, ['Ready to scan trends']);
+  assert.ok(!rows.includes('0 scan active'));
+});
+
+test('canvas inspection: workstation semantic summaries use render component descriptors', () => {
+  const research = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+  const rows = buildWorkstationNormalSummaryRows(componentForHotspot(research, [
+    { componentType: 'task-chip', id: 'visible-render-component', title: 'Trend research scan', taskType: 'TREND_RESEARCH', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'wrong-domain', title: 'Discord reply', taskType: 'discord', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED' },
+  ]));
+
+  assert.deepStrictEqual(rows, ['1 scan active']);
+});
+
+test('canvas inspection: every hotspot has matching semantic metadata', () => {
+  const stationKeys = new Set([
+    'engine_core',
+    'intake_desk',
+    'research_desk',
+    'shopify_desk',
+    'render_desk',
+    'support_desk',
+    'approval_desk',
+    'archive_shelf',
+    'anomaly_shelf',
+  ]);
+
+  assert.equal(Object.keys(WORKSTATION_SEMANTICS).length, WORKSTATION_HOTSPOTS.length);
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const metadata = getWorkstationSemanticMetadata(hotspot.id);
+    assert.ok(metadata, `${hotspot.id} is missing semantic metadata`);
+    assert.ok(stationKeys.has(metadata.stationKey));
+    assert.equal(typeof metadata.title, 'string');
+    assert.equal(typeof metadata.purpose, 'string');
+    assert.equal(typeof metadata.idleText, 'string');
+    assert.equal(typeof metadata.role, 'string');
+  }
+});
+
+test('canvas inspection: workstation popover view models stay compact and friendly', () => {
+  const rawPatterns = [
+    /\btask-[\w-]+\b/,
+    /\bagent-[\w-]+\b/,
+    /\bCREATED\b/,
+    /\bENQUEUED\b/,
+    /\bCLAIMED\b/,
+    /\bEXECUTE_FINISHED\b/,
+    /\bACKED\b/,
+    /\bbounds\b/,
+    /\bworld zone\b/,
+    /\bevent\b/i,
+  ];
+
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const viewModel = buildWorkstationPopoverViewModel(componentForHotspot(hotspot, []));
+    assert.equal(viewModel.hotspotId, hotspot.id);
+    assert.equal(typeof viewModel.title, 'string');
+    assert.ok(viewModel.lines.length >= 1);
+    assert.ok(viewModel.lines.length <= 2);
+    assert.equal(viewModel.maxLines, 2);
+    for (const text of [viewModel.title, ...viewModel.lines]) {
+      assert.ok(!rawPatterns.some((pattern) => pattern.test(text)), `${hotspot.id} leaked raw text: ${text}`);
+    }
+  }
+});
+
+test('canvas inspection: renderer consumes workstation popover view model copy', () => {
+  const hit = hitTestRenderableComponents([], { x: 330, y: 210 }, null, { debug: false, bakedBackground: true });
+  const model = buildInspectionPopoverRows(hit, { debug: false });
+  const viewModel = buildWorkstationPopoverViewModel(hit.component);
+
+  assert.equal(model.title, viewModel.title);
+  assert.deepStrictEqual(model.rows, viewModel.lines);
+  assert.ok(model.rows.length <= viewModel.maxLines);
+});
+
+test('canvas inspection: every workstation render component gets a visualState model', () => {
+  const components = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, []);
+  const allowedStates = new Set(['idle', 'queued', 'working', 'awaiting', 'completed', 'failed']);
+  const allowedEffects = new Set(['none', 'pulse', 'shimmer', 'sparkle', 'glint']);
+
+  assert.equal(components.length, WORKSTATION_HOTSPOTS.length);
+  for (const component of components) {
+    assert.equal(component.visualStateViewModel.hotspotId, component.id);
+    assert.ok(allowedStates.has(component.visualStateViewModel.visualState));
+    assert.ok(allowedEffects.has(component.visualStateViewModel.effect));
+    assert.equal(typeof component.visualStateViewModel.tone, 'string');
+    assert.equal(typeof component.visualStateViewModel.intensity, 'number');
+  }
+});
+
+test('canvas inspection: workstation visualState selector falls back to idle without safe data', () => {
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const component = componentForHotspot(hotspot, []);
+    const model = buildWorkstationVisualStateViewModel(component);
+    assert.equal(model.visualState, 'idle', `${hotspot.id} should be idle without render data`);
+    assert.equal(model.effect, 'none');
+  }
+});
+
+test('canvas inspection: workstation visualState selector maps safe station summaries', () => {
+  const components = [
+    { componentType: 'task-chip', id: 'engine-waiting', title: 'Queue item', taskType: 'standard', visualState: 'waiting', worldZoneId: 'engineCrystal', zoneId: 'ENQUEUED' },
+    { componentType: 'task-chip', id: 'research-active', title: 'Trend scan', taskType: 'TREND_RESEARCH', visualState: 'working', worldZoneId: 'researchDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'shopify-publish', title: 'Publish listing', taskType: 'shopify', visualState: 'processing', worldZoneId: 'shopifyDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'render-active', title: 'Image render', taskType: 'image_render', visualState: 'working', worldZoneId: 'renderDesk', zoneId: 'EXECUTE_FINISHED' },
+    { componentType: 'task-chip', id: 'approval-active', title: 'Approve output', taskType: 'standard', visualState: 'processing', worldZoneId: 'approvalDesk', zoneId: 'EXECUTE_FINISHED' },
+    { componentType: 'task-chip', id: 'archive-complete', title: 'Finished task', taskType: 'standard', visualState: 'completed', worldZoneId: 'archiveLibrary', zoneId: 'ACKED' },
+    { componentType: 'task-chip', id: 'support-active', title: 'Discord reply', taskType: 'discord', visualState: 'working', worldZoneId: 'supportDesk', zoneId: 'CLAIMED' },
+  ];
+  const expected = new Map([
+    ['engineCrystalHotspot', 'queued'],
+    ['researchMonitorHotspot', 'working'],
+    ['shopifyMonitorHotspot', 'awaiting'],
+    ['renderMonitorHotspot', 'working'],
+    ['approvalDeskHotspot', 'awaiting'],
+    ['archiveShelfHotspot', 'completed'],
+    ['supportMonitorHotspot', 'working'],
+  ]);
+
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    if (!expected.has(hotspot.id)) continue;
+    const model = componentForHotspot(hotspot, components).visualStateViewModel;
+    assert.equal(model.visualState, expected.get(hotspot.id));
+    assert.notEqual(model.effect, 'none');
+  }
+});
+
+test('canvas inspection: anomaly station visualState maps to failed from safe anomaly data', () => {
+  const hotspot = WORKSTATION_HOTSPOTS.find((candidate) => candidate.id === 'anomalyShelfHotspot');
+  const component = componentForHotspot(hotspot, [
+    { componentType: 'task-chip', id: 'task-anomaly', title: 'Needs review', taskType: 'standard', visualState: 'error', worldZoneId: 'anomalyShelf', zoneId: 'ACKED', anomaly: { severity: 'high', type: 'timeout' } },
+  ]);
+
+  assert.equal(component.visualStateViewModel.visualState, 'failed');
+  assert.equal(component.visualStateViewModel.effect, 'glint');
+});
+
+test('canvas inspection: every workstation render component gets an inspectionViewModel', () => {
+  const components = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, []);
+
+  assert.equal(components.length, WORKSTATION_HOTSPOTS.length);
+  for (const component of components) {
+    assert.equal(component.inspectionViewModel.hotspotId, component.id);
+    assert.equal(typeof component.inspectionViewModel.stationId, 'string');
+    assert.equal(typeof component.inspectionViewModel.title, 'string');
+    assert.equal(typeof component.inspectionViewModel.statusLabel, 'string');
+    assert.ok(Array.isArray(component.inspectionViewModel.lines));
+    assert.ok(Array.isArray(component.inspectionViewModel.taskSummaries));
+  }
+});
+
+test('canvas inspection: workstation inspection has idle fallback for every station', () => {
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const model = componentForHotspot(hotspot, []).inspectionViewModel;
+    assert.equal(model.statusLabel, 'Idle');
+    assert.ok(model.lines.length >= 1, `${hotspot.id} needs idle copy`);
+    assert.deepStrictEqual(model.taskSummaries, []);
+  }
+});
+
+test('canvas inspection: workstation inspection stays compact and avoids raw task/event text', () => {
+  const components = [
+    { componentType: 'task-chip', id: 'task-raw-123', title: 'Render product image', taskType: 'image_render', visualState: 'working', worldZoneId: 'renderDesk', zoneId: 'EXECUTE_FINISHED' },
+    { componentType: 'task-chip', id: 'task-event-456', title: 'Discord reply', taskType: 'discord', visualState: 'working', worldZoneId: 'supportDesk', zoneId: 'CLAIMED' },
+    { componentType: 'task-chip', id: 'task-error-789', title: 'Needs review', taskType: 'standard', visualState: 'error', worldZoneId: 'anomalyShelf', zoneId: 'ACKED', anomaly: { severity: 'high', type: 'timeout' } },
+  ];
+  const rawPatterns = [
+    /\btask-[\w-]+\b/,
+    /\bCREATED\b/,
+    /\bENQUEUED\b/,
+    /\bCLAIMED\b/,
+    /\bEXECUTE_FINISHED\b/,
+    /\bACKED\b/,
+    /\bevent\b/i,
+    /\bbounds\b/i,
+  ];
+
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    const model = componentForHotspot(hotspot, components).inspectionViewModel;
+    assert.ok(model.lines.length <= 3);
+    assert.ok(model.taskSummaries.length <= 3);
+    for (const text of [model.title, model.statusLabel, ...model.lines, ...model.taskSummaries]) {
+      assert.ok(!rawPatterns.some((pattern) => pattern.test(text)), `${hotspot.id} leaked raw text: ${text}`);
+    }
+  }
+});
+
+test('canvas inspection: workstation inspection summarizes active attached work', () => {
+  const renderHotspot = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  const model = componentForHotspot(renderHotspot, [
+    { componentType: 'task-chip', id: 'task-render-active', title: 'Render product image', taskType: 'image_render', visualState: 'working', worldZoneId: 'renderDesk', zoneId: 'EXECUTE_FINISHED' },
+  ]).inspectionViewModel;
+
+  assert.equal(model.title, 'Render Desk');
+  assert.equal(model.statusLabel, 'Active');
+  assert.ok(model.lines.includes('1 active'));
+  assert.ok(model.taskSummaries.includes('Image render: active'));
+});
+
+test('canvas inspection: selected station prefers inspectionViewModel while hover uses semantic popover', () => {
+  const components = [
+    { componentType: 'task-chip', id: 'task-render-active', title: 'Render product image', taskType: 'image_render', visualState: 'working', worldZoneId: 'renderDesk', zoneId: 'EXECUTE_FINISHED' },
+  ];
+  const hit = hitTestRenderableComponents(components, { x: 620, y: 455 }, null, { debug: false, bakedBackground: true });
+  const hoverModel = buildInspectionPopoverRows(hit, { debug: false, selected: false });
+  const selectedModel = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+
+  assert.equal(hit.component.inspectionViewModel.statusLabel, 'Active');
+  assert.ok(hoverModel.rows.includes('1 render active'));
+  assert.ok(!hoverModel.rows.includes('Active'));
+  assert.ok(selectedModel.rows.includes('Active'));
+  assert.ok(selectedModel.rows.includes('Image render: active'));
+});
+
+test('canvas inspection: task result interaction target beats overlapping station', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-result',
+    x: 700,
+    y: 430,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-result',
+    trendPanelState: {
+      taskId: 'task-result',
+      keyword: 'cozy',
+      status: 'done',
+      results: [{ item: 'Tree lamp', score: 0.95 }],
+    },
+  }];
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, components);
+  const targets = buildInteractionTargets(components, { hotspots: WORKSTATION_HOTSPOTS, stationComponents, bakedBackground: true });
+  const hit = getInteractionTargetAtPoint(targets, { x: 700, y: 386 });
+
+  assert.equal(hit.type, 'taskResult');
+});
+
+test('canvas inspection: task marker interaction target beats overlapping station', () => {
+  const components = [{
+    componentType: 'task-chip',
+    id: 'task-marker',
+    title: 'Render product image',
+    taskType: 'image_render',
+    x: 700,
+    y: 420,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    zoneId: 'EXECUTE_FINISHED',
+  }];
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, components);
+  const hit = getInteractionTargetAtPoint(
+    buildInteractionTargets(components, { hotspots: WORKSTATION_HOTSPOTS, stationComponents }),
+    { x: 700, y: 420 }
+  );
+
+  assert.equal(hit.type, 'taskMarker');
+});
+
+test('canvas inspection: debug agent interaction target beats overlapping station', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-active',
+    x: 700,
+    y: 420,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-active',
+  }];
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, components);
+  const hit = getInteractionTargetAtPoint(
+    buildInteractionTargets(components, { hotspots: WORKSTATION_HOTSPOTS, stationComponents, bakedBackground: false, debug: true }),
+    { x: 620, y: 455 }
+  );
+
+  assert.equal(hit.type, 'agent');
+});
+
+test('canvas inspection: normal mode excludes default agent targets from hit testing', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-default',
+    x: 620,
+    y: 455,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-active',
+  }];
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, components);
+  const targets = buildInteractionTargets(components, {
+    hotspots: WORKSTATION_HOTSPOTS,
+    stationComponents,
+    bakedBackground: false,
+    debug: false,
+  });
+
+  assert.ok(!targets.some((target) => target.type === 'agent'));
+});
+
+test('canvas inspection: normal mode station wins over overlapping default agent geometry', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-default',
+    x: 620,
+    y: 455,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-active',
+  }];
+  const hit = hitTestRenderableComponents(components, { x: 620, y: 455 }, null, {
+    debug: false,
+    bakedBackground: false,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.equal(hit.interactionTarget.type, 'station');
+  assert.equal(model.title, 'Render Desk');
+  assert.ok(!model.rows.some((row) => /type:|target:|priority:|zone:|id:|bounds:/i.test(row)));
+});
+
+test('canvas inspection: station interaction target works as fallback', () => {
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, []);
+  const hit = getInteractionTargetAtPoint(
+    buildInteractionTargets([], { hotspots: WORKSTATION_HOTSPOTS, stationComponents }),
+    { x: 620, y: 455 }
+  );
+
+  assert.equal(hit.type, 'station');
+});
+
+test('canvas inspection: unified interaction hit testing clears on empty background', () => {
+  const stationComponents = buildWorkstationHotspotComponents(WORKSTATION_HOTSPOTS, []);
+  const hit = getInteractionTargetAtPoint(
+    buildInteractionTargets([], { hotspots: WORKSTATION_HOTSPOTS, stationComponents }),
+    { x: 20, y: 500 }
+  );
+
+  assert.equal(hit, null);
+});
+
+test('canvas inspection: task result selection routes to result popover view model', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-result',
+    x: 700,
+    y: 430,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-result',
+    trendPanelState: {
+      taskId: 'task-result',
+      keyword: 'cozy',
+      status: 'done',
+      results: [{ item: 'Tree lamp', score: 0.95 }],
+    },
+  }];
+  const hit = hitTestRenderableComponents(components, { x: 700, y: 386 }, null, {
+    debug: false,
+    bakedBackground: true,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+
+  assert.equal(hit.componentType, 'task-result');
+  assert.equal(model.title, 'Task Result');
+  assert.ok(model.rows.includes('Trend: cozy'));
+  assert.ok(model.rows.includes('Tree lamp'));
+});
+
+test('canvas inspection: normal selected agent uses friendly agent inspection view model', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-render',
+    x: 620,
+    y: 455,
+    visualState: 'working',
+    deskId: 'desk-4',
+    worldZoneId: 'renderDesk',
+    currentTaskId: 'task-secret-123',
+    normalInteractive: true,
+  }];
+  const hit = hitTestRenderableComponents(components, { x: 620, y: 455 }, null, {
+    debug: false,
+    bakedBackground: false,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+
+  assert.equal(hit.componentType, 'agent-sprite');
+  assert.equal(model.title, 'Render Sloth');
+  assert.ok(model.rows.includes('Working'));
+  assert.ok(model.rows.includes('Assigned to a task'));
+  assert.ok(!model.rows.includes('type: agent'));
+  assert.ok(!model.rows.some((row) => row.startsWith('zone:')));
+  assert.ok(![model.title, ...model.rows].some((row) => /engineCrystal|renderDesk|task-secret|currentTaskId/.test(row)));
+});
+
+test('canvas inspection: normal mode does not show Agent Desk diagnostic popover for default agent', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'sloth-3',
+    x: 620,
+    y: 455,
+    visualState: 'unknown',
+    deskId: 'desk-4',
+    worldZoneId: 'engineCrystal',
+  }];
+  const hit = hitTestRenderableComponents(components, { x: 620, y: 455 }, null, {
+    debug: false,
+    bakedBackground: false,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+  const text = [model?.title, ...(model?.rows || [])].filter(Boolean).join('\n');
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.ok(!/Agent Desk|type: agent|target: agent|priority: 70|zone: engineCrystal|id: sloth-3|bounds:/i.test(text));
+});
+
+test('canvas inspection: missing agent data falls back to friendly idle sloth copy', () => {
+  const model = buildAgentInspectionViewModel({});
+
+  assert.equal(model.title, 'Sloth Worker');
+  assert.equal(model.statusLabel, 'Idle');
+  assert.deepStrictEqual(model.lines, ['Waiting for work']);
+});
+
+test('canvas inspection: normal agent popover hides raw zone and camelCase internals', () => {
+  const hit = {
+    entityId: 'agent-core',
+    componentType: 'agent-sprite',
+    component: {
+      componentType: 'agent-sprite',
+      id: 'agent-core',
+      visualState: 'idle',
+      worldZoneId: 'engineCrystal',
+      normalInteractive: true,
+      agentInspectionViewModel: buildAgentInspectionViewModel({ visualState: 'idle', worldZoneId: 'engineCrystal' }),
+    },
+    bounds: { x: 450, y: 220, width: 50, height: 50 },
+  };
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+
+  assert.equal(model.title, 'Engine Sloth');
+  assert.ok(!model.rows.includes('type: agent'));
+  assert.ok(!model.rows.some((row) => row.startsWith('zone:')));
+  assert.ok(![model.title, ...model.rows].some((row) => /engineCrystal|worldZoneId|zoneId/.test(row)));
+});
+
+test('canvas inspection: debug agent popover can show target diagnostics', () => {
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-debug',
+    x: 700,
+    y: 420,
+    visualState: 'working',
+    deskId: 'desk-4',
+    worldZoneId: 'renderDesk',
+    currentTaskId: 'task-debug',
+  }];
+  const hit = hitTestRenderableComponents(components, { x: 700, y: 420 }, null, {
+    debug: true,
+    bakedBackground: false,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const model = buildInspectionPopoverRows(hit, { debug: true, selected: true });
+
+  assert.ok(model.rows.includes('type: agent'));
+  assert.ok(model.rows.includes('target: agent'));
+  assert.ok(model.rows.includes('priority: 70'));
+  assert.ok(model.rows.includes('zone: renderDesk'));
+});
+
+test('canvas inspection: hover tracks unified interaction target for pointer routing', () => {
+  const state = createCanvasInspectionState();
+  const components = [{
+    componentType: 'agent-sprite',
+    id: 'agent-result',
+    x: 700,
+    y: 430,
+    visualState: 'working',
+    worldZoneId: 'renderDesk',
+    deskId: 'desk-4',
+    currentTaskId: 'task-result',
+    trendPanelState: {
+      taskId: 'task-result',
+      keyword: 'cozy',
+      status: 'done',
+      results: [{ item: 'Tree lamp', score: 0.95 }],
+    },
+  }];
+
+  const hit = updateInspectionHover(state, components, { x: 700, y: 386 }, null, {
+    debug: false,
+    bakedBackground: true,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+
+  assert.equal(hit.componentType, 'task-result');
+  assert.equal(state.hoveredTargetType, 'taskResult');
+  assert.equal(state.hoveredHotspotId, null);
+});
+
+test('canvas inspection: renderer consumes workstation inspection view model copy', () => {
+  const hit = hitTestRenderableComponents([], { x: 330, y: 210 }, null, { debug: false, bakedBackground: true });
+  const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+  const viewModel = buildWorkstationInspectionViewModel(hit.component);
+
+  assert.equal(model.title, viewModel.title);
+  assert.equal(model.rows[0], viewModel.statusLabel);
+  assert.ok(model.rows.includes(viewModel.lines[0]));
 });
 
 test('canvas inspection: zone popover uses friendly zone title without unknown status', () => {
   const hit = hitTestRenderableComponents(COMPONENTS, { x: 126, y: 356 }, null, { debug: false });
   const model = buildInspectionPopoverRows(hit, { debug: false });
 
+  assert.equal(hit, null);
+  assert.equal(model, null);
+});
+
+test('canvas inspection: normal mode does not render popover for world-zone-only target', () => {
+  const hit = {
+    entityId: 'ENQUEUED',
+    componentType: 'world-zone-indicator',
+    component: { componentType: 'zone-background', id: 'ENQUEUED', visualState: 'unknown' },
+    bounds: { x: 103, y: 333, width: 46, height: 46 },
+  };
+  const ctx = createMockContext();
+
+  assert.equal(buildInspectionPopoverRows(hit, { debug: false }), null);
+  renderInspectionPopover(ctx, hit, { debug: false });
+
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+});
+
+test('canvas inspection: normal mode never renders raw target metadata rows', () => {
+  const hits = [
+    hitTestRenderableComponents(COMPONENTS, { x: 300, y: 260 }, null, { debug: false }),
+    hitTestRenderableComponents([], { x: 330, y: 210 }, null, { debug: false, bakedBackground: true }),
+    {
+      entityId: 'agent-safe',
+      componentType: 'agent-sprite',
+      component: {
+        componentType: 'agent-sprite',
+        id: 'agent-safe',
+        visualState: 'working',
+        worldZoneId: 'engineCrystal',
+        normalInteractive: true,
+        agentInspectionViewModel: buildAgentInspectionViewModel({
+          componentType: 'agent-sprite',
+          id: 'agent-safe',
+          visualState: 'working',
+          worldZoneId: 'engineCrystal',
+        }),
+      },
+      bounds: { x: 450, y: 220, width: 50, height: 50 },
+    },
+  ];
+  const forbidden = [/type:/i, /zone:/i, /priority:/i, /bounds:/i, /world-zone/i, /engineCrystal/];
+
+  for (const hit of hits) {
+    const model = buildInspectionPopoverRows(hit, { debug: false, selected: true });
+    assert.ok(model, `expected friendly model for ${hit?.componentType}`);
+    const text = [model.title, ...model.rows].join('\n');
+    assert.ok(!forbidden.some((pattern) => pattern.test(text)), text);
+  }
+});
+
+test('canvas inspection: normal mode has no generic target fallback popover', () => {
+  const rawTargetHit = {
+    entityId: 'raw-target',
+    componentType: 'debug-target',
+    component: { componentType: 'debug-target', id: 'raw-target', type: 'agent', worldZoneId: 'engineCrystal' },
+    interactionTarget: {
+      id: 'debug:raw-target',
+      type: 'debug',
+      priority: 5,
+      viewModel: null,
+      source: { id: 'raw-target' },
+    },
+    bounds: { x: 1, y: 2, width: 3, height: 4 },
+  };
+
+  assert.equal(canRenderNormalPopover(rawTargetHit), false);
+  assert.equal(buildInspectionPopoverRows(rawTargetHit, { debug: false, selected: true }), null);
+});
+
+test('canvas inspection: normal-mode popover draw output has no legacy diagnostic text', () => {
+  const taskMarkerHit = hitTestRenderableComponents([{
+    componentType: 'task-chip',
+    id: 'sloth-task-marker',
+    title: 'Pack listing draft',
+    taskType: 'shopify',
+    x: 620,
+    y: 455,
+    visualState: 'working',
+    worldZoneId: 'engineCrystal',
+    zoneId: 'CLAIMED',
+  }], { x: 620, y: 455 }, null, { debug: false, hotspots: WORKSTATION_HOTSPOTS });
+  const taskResultHit = hitTestRenderableComponents([{
+    componentType: 'agent-sprite',
+    id: 'sloth-result',
+    x: 700,
+    y: 430,
+    visualState: 'working',
+    worldZoneId: 'engineCrystal',
+    deskId: 'desk-4',
+    trendPanelState: {
+      taskId: 'TASK_INTERNAL_1',
+      keyword: 'cozy lamp',
+      status: 'done',
+      results: [{ item: 'Moss lamp' }],
+    },
+  }], { x: 700, y: 386 }, null, { debug: false, bakedBackground: true, hotspots: WORKSTATION_HOTSPOTS });
+  const stationHit = hitTestRenderableComponents([], { x: 620, y: 455 }, null, {
+    debug: false,
+    bakedBackground: true,
+    hotspots: WORKSTATION_HOTSPOTS,
+  });
+  const explicitAgentHit = hitTestRenderableComponents([{
+    componentType: 'agent-sprite',
+    id: 'sloth-explicit',
+    x: 620,
+    y: 455,
+    visualState: 'working',
+    worldZoneId: 'engineCrystal',
+    deskId: 'desk-4',
+    normalInteractive: true,
+    agentInspectionViewModel: buildAgentInspectionViewModel({
+      componentType: 'agent-sprite',
+      id: 'sloth-explicit',
+      visualState: 'working',
+      worldZoneId: 'engineCrystal',
+      deskId: 'desk-4',
+      normalInteractive: true,
+    }),
+  }], { x: 620, y: 455 }, null, { debug: false, hotspots: WORKSTATION_HOTSPOTS });
+  const hits = [taskMarkerHit, taskResultHit, stationHit, explicitAgentHit];
+  const forbidden = /Agent Desk|World Zone|type:|target:|priority:|zone:|bounds:|world-zone|sloth-|engineCrystal|TASK_|AGENT_/i;
+
+  for (const hit of hits) {
+    assert.equal(canRenderNormalPopover(hit), true, `expected normal-eligible ${hit?.componentType}`);
+    const ctx = createMockContext();
+    renderInspectionPopover(ctx, hit, { debug: false, selected: true });
+    const text = ctx.calls
+      .filter((call) => call[0] === 'fillText')
+      .map((call) => call[1])
+      .join('\n');
+    assert.ok(text.length > 0, `expected popover text for ${hit?.componentType}`);
+    assert.ok(!forbidden.test(text), text);
+  }
+});
+
+test('canvas inspection: debug mode still renders world-zone diagnostics', () => {
+  const hit = hitTestRenderableComponents(COMPONENTS, { x: 126, y: 356 }, null, { debug: true });
+  const model = buildInspectionPopoverRows(hit, { debug: true });
+
+  assert.equal(hit.componentType, 'world-zone-indicator');
   assert.equal(model.title, 'Task Engine');
   assert.ok(model.rows.includes('type: world-zone'));
-  assert.ok(!model.rows.includes('status: unknown'));
+  assert.ok(model.rows.some((row) => row.startsWith('bounds: ')));
 });
 
 test('canvas inspection: popover debug mode shows full diagnostics', () => {
@@ -296,11 +1031,32 @@ test('canvas inspection: popover debug mode shows full diagnostics', () => {
 });
 
 test('canvas inspection: popover renderer runs on a mock canvas context', () => {
-  const hit = hitTestRenderableComponents(COMPONENTS, { x: 230, y: 225 }, null);
+  const hit = {
+    entityId: 'agent-1',
+    componentType: 'agent-sprite',
+    component: {
+      componentType: 'agent-sprite',
+      id: 'agent-1',
+      visualState: 'working',
+      deskId: 'desk-0',
+      worldZoneId: 'researchDesk',
+      currentTaskId: 'task-1',
+      normalInteractive: true,
+      agentInspectionViewModel: buildAgentInspectionViewModel({
+        componentType: 'agent-sprite',
+        id: 'agent-1',
+        visualState: 'working',
+        deskId: 'desk-0',
+        worldZoneId: 'researchDesk',
+        currentTaskId: 'task-1',
+      }),
+    },
+    bounds: { x: 210, y: 175, width: 180, height: 170 },
+  };
   const ctx = createMockContext();
 
   assert.doesNotThrow(() => renderInspectionPopover(ctx, hit, { debug: false }));
-  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'Agent Desk'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'Research Sloth'));
   assert.ok(!ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'current task: task-1'));
   assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
 });
@@ -546,6 +1302,19 @@ test('canvas inspection: inspection modules do not access raw event sources', ()
     'rendering/canvas-inspection-state.js',
     'rendering/inspection-popover-renderer.js',
     'rendering/workstation-hotspots.js',
+    'rendering/world-scene.js',
+    'rendering/world-scene-adapter.js',
+    'rendering/hotspot-highlight-renderer.js',
+    'ui/hotspots/workstationHotspots.js',
+    'ui/hotspots/hitTestHotspots.js',
+    'ui/hotspots/hotspotGeometry.js',
+    'ui/hotspots/hotspotCalibration.js',
+    'ui/hotspots/workstationSemantics.js',
+    'ui/selectors/workstationPopoverSelectors.js',
+    'ui/selectors/workstationVisualStateSelectors.js',
+    'ui/selectors/workstationInspectionSelectors.js',
+    'ui/selectors/agentInspectionSelectors.js',
+    'ui/interactions/interactionTargets.js',
   ];
   const forbidden = [
     /\beventsByTaskId\b/,

--- a/tests/canvas-interaction-contract.test.mjs
+++ b/tests/canvas-interaction-contract.test.mjs
@@ -1,0 +1,254 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hitTestRenderableComponents } from '../rendering/canvas-hit-test.js';
+import {
+  buildInspectionPopoverRows,
+  canRenderNormalPopover,
+  renderInspectionPopover,
+} from '../rendering/inspection-popover-renderer.js';
+import { renderBackgroundLayer } from '../rendering/world-scene-asset-renderer.js';
+import { loadedAssets } from '../rendering/assets.js';
+import { traceRenderBoot } from '../rendering/debug.js';
+
+function makeGradient(log, kind) {
+  return {
+    addColorStop(offset, color) {
+      log.push([`${kind}.addColorStop`, offset, color]);
+    },
+  };
+}
+
+function createMockContext() {
+  const calls = [];
+  const ctx = {
+    canvas: { width: 1060, height: 520 },
+    calls,
+    save: () => calls.push(['save']),
+    restore: () => calls.push(['restore']),
+    beginPath: () => calls.push(['beginPath']),
+    closePath: () => calls.push(['closePath']),
+    moveTo: (...args) => calls.push(['moveTo', ...args]),
+    lineTo: (...args) => calls.push(['lineTo', ...args]),
+    quadraticCurveTo: (...args) => calls.push(['quadraticCurveTo', ...args]),
+    bezierCurveTo: (...args) => calls.push(['bezierCurveTo', ...args]),
+    arc: (...args) => calls.push(['arc', ...args]),
+    ellipse: (...args) => calls.push(['ellipse', ...args]),
+    fill: () => calls.push(['fill']),
+    stroke: () => calls.push(['stroke']),
+    fillRect: (...args) => calls.push(['fillRect', ...args]),
+    strokeRect: (...args) => calls.push(['strokeRect', ...args]),
+    drawImage: (...args) => calls.push(['drawImage', ...args]),
+    fillText: (...args) => calls.push(['fillText', ...args]),
+    setLineDash: (...args) => calls.push(['setLineDash', ...args]),
+    createLinearGradient: (...args) => {
+      calls.push(['createLinearGradient', ...args]);
+      return makeGradient(calls, 'linearGradient');
+    },
+    createRadialGradient: (...args) => {
+      calls.push(['createRadialGradient', ...args]);
+      return makeGradient(calls, 'radialGradient');
+    },
+    measureText: (text) => ({ width: String(text).length * 6 }),
+  };
+  return ctx;
+}
+
+function clearBackgroundAssets() {
+  delete loadedAssets['scene_background_02.png'];
+  delete loadedAssets['scene_background_02.jpg'];
+  delete loadedAssets['scene_background_01.jpg'];
+}
+
+function textFrom(ctx) {
+  return ctx.calls
+    .filter((call) => call[0] === 'fillText')
+    .map((call) => String(call[1]))
+    .join('\n');
+}
+
+function withWindow(fakeWindow, fn) {
+  const previousWindow = globalThis.window;
+  globalThis.window = fakeWindow;
+  try {
+    return fn();
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  }
+}
+
+const DEFAULT_AGENT = Object.freeze({
+  componentType: 'agent-sprite',
+  id: 'sloth-default-1',
+  x: 352,
+  y: 224,
+  visualState: 'working',
+  deskId: 'desk-0',
+  worldZoneId: 'researchDesk',
+  zoneId: 'CLAIMED',
+  currentTaskId: 'TASK_INTERNAL_1',
+});
+
+test('canvas interaction contract: normal mode target priority excludes default agents', () => {
+  const hit = hitTestRenderableComponents([DEFAULT_AGENT], { x: 330, y: 210 }, null, {
+    debug: false,
+    bakedBackground: true,
+  });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.notEqual(hit.componentType, 'agent-sprite');
+});
+
+test('canvas interaction contract: taskResult beats station hotspot', () => {
+  const hit = hitTestRenderableComponents([{
+    componentType: 'agent-sprite',
+    id: 'trend-agent-contract',
+    x: 330,
+    y: 258,
+    visualState: 'working',
+    trendPanelState: {
+      taskId: 'trend-task-contract',
+      keyword: 'cozy',
+      status: 'done',
+      results: [{ item: 'treehouse', score: 0.98 }],
+    },
+  }], { x: 330, y: 215 }, null, { debug: false });
+
+  assert.equal(hit.componentType, 'task-result');
+  assert.equal(hit.interactionTarget.type, 'taskResult');
+});
+
+test('canvas interaction contract: taskMarker beats station hotspot', () => {
+  const hit = hitTestRenderableComponents([{
+    componentType: 'task-chip',
+    id: 'TASK_MARKER_CONTRACT',
+    x: 330,
+    y: 210,
+    visualState: 'working',
+    title: 'Active task',
+  }], { x: 330, y: 210 }, null, { debug: false });
+
+  assert.equal(hit.componentType, 'task-chip');
+  assert.equal(hit.interactionTarget.type, 'taskMarker');
+});
+
+test('canvas interaction contract: station works as forgiving fallback', () => {
+  const hit = hitTestRenderableComponents([], { x: 330, y: 210 }, null, { debug: false });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.equal(hit.interactionTarget.type, 'station');
+});
+
+test('canvas interaction contract: world-zone/debug target does not render normal popover', () => {
+  const hit = {
+    componentType: 'world-zone-indicator',
+    component: { componentType: 'zone-background', id: 'ENQUEUED', zoneId: 'ENQUEUED' },
+    bounds: { x: 102, y: 332, width: 48, height: 48 },
+  };
+
+  assert.equal(canRenderNormalPopover(hit), false);
+  assert.equal(buildInspectionPopoverRows(hit, { debug: false }), null);
+});
+
+test('canvas interaction contract: normal popover guard rejects raw fields', () => {
+  const banned = [
+    'type: workstation',
+    'target: station',
+    'priority: 40',
+    'zone: CLAIMED',
+    'bounds: 1,2 3x4',
+    'world-zone',
+    'sloth-raw-1',
+    'engineCrystal',
+    'TASK_CREATED',
+    'AGENT_ASSIGNED',
+  ];
+
+  for (const text of banned) {
+    const ctx = createMockContext();
+    const hit = {
+      componentType: 'workstation-hotspot',
+      component: {
+        componentType: 'workstation-hotspot',
+        id: 'researchMonitorHotspot',
+        inspectionViewModel: {
+          title: 'Research Desk',
+          statusLabel: 'Ready',
+          lines: [text],
+          taskSummaries: [],
+          tone: 'quiet',
+        },
+      },
+      bounds: { x: 300, y: 190, width: 120, height: 80 },
+    };
+
+    assert.equal(canRenderNormalPopover(hit), true);
+    renderInspectionPopover(ctx, hit, { debug: false, selected: true });
+    assert.equal(textFrom(ctx), '', `normal popover leaked ${text}`);
+  }
+});
+
+test('canvas interaction contract: debug mode can still show diagnostics', () => {
+  const hit = hitTestRenderableComponents([{
+    componentType: 'task-chip',
+    id: 'TASK_DEBUG_CONTRACT',
+    x: 330,
+    y: 210,
+    visualState: 'processing',
+    metrics: { duration: 1200 },
+  }], { x: 330, y: 210 }, null, { debug: true });
+  const model = buildInspectionPopoverRows(hit, { debug: true });
+
+  assert.ok(model.rows.includes('type: task'));
+  assert.ok(model.rows.includes('target: taskMarker'));
+  assert.ok(model.rows.some((row) => row.startsWith('priority: ')));
+  assert.ok(model.rows.includes('id: TASK_DEBUG_CONTRACT'));
+});
+
+test('canvas interaction contract: baked-pending normal mode uses blank boot background', () => {
+  clearBackgroundAssets();
+  const ctx = createMockContext();
+
+  renderBackgroundLayer(ctx, 1);
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillRect'));
+  assert.equal(ctx.calls.some((call) => call[0] === 'bezierCurveTo'), false);
+});
+
+test('canvas interaction contract: procedural fallback allowed by debug, calibration, or explicit flag', () => {
+  clearBackgroundAssets();
+
+  const debugCtx = createMockContext();
+  renderBackgroundLayer(debugCtx, 2, { debug: true });
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'bezierCurveTo'));
+
+  const calibrationCtx = createMockContext();
+  renderBackgroundLayer(calibrationCtx, 2, { calibration: true });
+  assert.ok(calibrationCtx.calls.some((call) => call[0] === 'bezierCurveTo'));
+
+  const explicitCtx = createMockContext();
+  withWindow({ __SLOTHWORLD_ALLOW_PROCEDURAL_FALLBACK__: true }, () => {
+    renderBackgroundLayer(explicitCtx, 2);
+  });
+  assert.ok(explicitCtx.calls.some((call) => call[0] === 'bezierCurveTo'));
+});
+
+test('canvas interaction contract: render boot tracing remains gated off by default', () => {
+  const previousLog = console.log;
+  const logs = [];
+  console.log = (...args) => logs.push(args);
+
+  try {
+    withWindow({}, () => {
+      traceRenderBoot('contract-test-path', { frame: 1, canvasSize: { width: 1, height: 1 } });
+    });
+  } finally {
+    console.log = previousLog;
+  }
+
+  assert.deepStrictEqual(logs, []);
+});

--- a/tests/canvas-interaction-contract.test.mjs
+++ b/tests/canvas-interaction-contract.test.mjs
@@ -3,6 +3,11 @@ import assert from 'node:assert/strict';
 
 import { hitTestRenderableComponents } from '../rendering/canvas-hit-test.js';
 import {
+  createCanvasInspectionState,
+  refreshInspectionSelection,
+  updateInspectionSelection,
+} from '../rendering/canvas-inspection-state.js';
+import {
   buildInspectionPopoverRows,
   canRenderNormalPopover,
   renderInspectionPopover,
@@ -143,6 +148,47 @@ test('canvas interaction contract: station works as forgiving fallback', () => {
   assert.equal(hit.interactionTarget.type, 'station');
 });
 
+test('canvas interaction contract: station selection refresh defaults to workstation hotspots', () => {
+  const state = createCanvasInspectionState();
+  const selected = updateInspectionSelection(state, [], { x: 330, y: 210 }, null, { debug: false });
+
+  assert.equal(selected.componentType, 'workstation-hotspot');
+  assert.equal(state.selectedTargetType, 'station');
+
+  const refreshed = refreshInspectionSelection(state, [], null);
+
+  assert.equal(refreshed.componentType, 'workstation-hotspot');
+  assert.equal(refreshed.interactionTarget.type, 'station');
+  assert.equal(state.selectedTargetType, 'station');
+});
+
+test('canvas interaction contract: rect interaction targets accept w/h schema', () => {
+  const hit = hitTestRenderableComponents([], { x: 15, y: 20 }, null, {
+    debug: false,
+    hotspots: [{
+      id: 'contractRectWH',
+      title: 'Contract Station',
+      worldZoneIds: [],
+      zoneIds: [],
+      hitArea: { type: 'rect', x: 10, y: 10, w: 30, h: 24 },
+      popoverAnchor: { x: 10, y: 10 },
+    }],
+    stationComponents: [{
+      componentType: 'workstation-hotspot',
+      id: 'contractRectWH',
+      inspectionViewModel: {
+        title: 'Contract Station',
+        statusLabel: 'Ready',
+        lines: ['Ready'],
+        taskSummaries: [],
+      },
+    }],
+  });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.deepStrictEqual(hit.bounds, { x: 10, y: 10, width: 30, height: 24 });
+});
+
 test('canvas interaction contract: world-zone/debug target does not render normal popover', () => {
   const hit = {
     componentType: 'world-zone-indicator',
@@ -166,6 +212,8 @@ test('canvas interaction contract: normal popover guard rejects raw fields', () 
     'engineCrystal',
     'TASK_CREATED',
     'AGENT_ASSIGNED',
+    'id: sloth-public',
+    'debug: true',
   ];
 
   for (const text of banned) {

--- a/tests/ui-hotspot-hit-testing.test.mjs
+++ b/tests/ui-hotspot-hit-testing.test.mjs
@@ -1,0 +1,707 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CANONICAL_WORKSTATION_HOTSPOT_CONFIGS,
+  WORKSTATION_HOTSPOTS,
+  validateWorkstationHotspotGeometry,
+} from '../ui/hotspots/workstationHotspots.js';
+import { CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY } from '../ui/hotspots/workstationHotspotGeometry.generated.js';
+import { hitTestWorkstationHotspots } from '../ui/hotspots/hitTestHotspots.js';
+import {
+  HOTSPOT_CANONICAL_SIZE,
+  getShapeBounds,
+  pointInCircle,
+  pointInPolygon,
+  pointInRect,
+  scaleShape,
+} from '../ui/hotspots/hotspotGeometry.js';
+import {
+  createCanvasInspectionState,
+  updateInspectionHover,
+  updateInspectionSelection,
+} from '../rendering/canvas-inspection-state.js';
+import { renderHotspotHighlights } from '../rendering/hotspot-highlight-renderer.js';
+import {
+  getCalibratedHotspots,
+  exportAllCalibratedHotspots,
+  exportAllCalibratedHotspotsDebug,
+  exportCalibratedHotspotGeometryModule,
+  handleHotspotCalibrationPointerDown,
+  handleHotspotCalibrationPointerMove,
+  handleHotspotCalibrationPointerUp,
+  hotspotCalibrationState,
+  isHotspotCalibrationEditMode,
+  copyAllCalibratedHotspotsToClipboard,
+  nudgeSelectedHotspot,
+  copySelectedHotspotJsonToClipboard,
+  downloadAllCalibratedHotspots,
+  attemptDevSaveAllCalibratedHotspots,
+  selectedHotspotCalibrationJson,
+  selectHotspotForCalibration,
+  setHotspotCalibrationEditLayer,
+  setHotspotCalibrationEditMode,
+  setHotspotCalibrationEnabled,
+} from '../ui/hotspots/hotspotCalibration.js';
+
+function createMockContext() {
+  const calls = [];
+  const ctx = {
+    canvas: { width: 1060, height: 520 },
+    calls,
+    save: () => calls.push(['save']),
+    restore: () => calls.push(['restore']),
+    beginPath: () => calls.push(['beginPath']),
+    moveTo: (...args) => calls.push(['moveTo', ...args]),
+    lineTo: (...args) => calls.push(['lineTo', ...args]),
+    quadraticCurveTo: (...args) => calls.push(['quadraticCurveTo', ...args]),
+    closePath: () => calls.push(['closePath']),
+    rect: (...args) => calls.push(['rect', ...args]),
+    arc: (...args) => calls.push(['arc', ...args]),
+    fill: () => calls.push(['fill']),
+    stroke: () => calls.push(['stroke']),
+    fillText: (...args) => calls.push(['fillText', ...args]),
+    fillRect: (...args) => calls.push(['fillRect', ...args]),
+    strokeRect: (...args) => calls.push(['strokeRect', ...args]),
+  };
+  return new Proxy(ctx, {
+    set(target, prop, value) {
+      target[prop] = value;
+      calls.push(['set', String(prop), value]);
+      return true;
+    },
+  });
+}
+
+function rgbaAlpha(value) {
+  const match = String(value).match(/rgba\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\)/);
+  return match ? Number(match[1]) : null;
+}
+
+function resetCalibration() {
+  hotspotCalibrationState.enabled = false;
+  hotspotCalibrationState.selectedHotspotId = null;
+  hotspotCalibrationState.offsetsById = Object.create(null);
+  hotspotCalibrationState.editedHotspotsById = Object.create(null);
+  hotspotCalibrationState.editsById = hotspotCalibrationState.editedHotspotsById;
+  hotspotCalibrationState.editMode = false;
+  hotspotCalibrationState.editLayer = 'hitArea';
+  hotspotCalibrationState.dragging = null;
+  hotspotCalibrationState.dragStart = null;
+  hotspotCalibrationState.originalGeometry = null;
+  hotspotCalibrationState.selectedVertexIndex = null;
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_HOTSPOT_CALIBRATION__ = false;
+    delete window.__SLOTHWORLD_LAST_HOTSPOT_JSON__;
+    delete window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__;
+  }
+}
+
+test('ui hotspots: rect geometry hit testing includes interior and excludes exterior points', () => {
+  const rect = { type: 'rect', x: 10, y: 20, width: 40, height: 30 };
+  assert.equal(pointInRect({ x: 20, y: 30 }, rect), true);
+  assert.equal(pointInRect({ x: 5, y: 30 }, rect), false);
+});
+
+test('ui hotspots: circle geometry hit testing includes interior and excludes exterior points', () => {
+  const circle = { type: 'circle', cx: 50, cy: 50, radius: 20 };
+  assert.equal(pointInCircle({ x: 60, y: 50 }, circle), true);
+  assert.equal(pointInCircle({ x: 75, y: 50 }, circle), false);
+});
+
+test('ui hotspots: polygon geometry hit testing includes interior and excludes exterior points', () => {
+  const polygon = { type: 'polygon', points: [{ x: 10, y: 10 }, { x: 60, y: 10 }, { x: 40, y: 50 }] };
+  assert.equal(pointInPolygon({ x: 35, y: 24 }, polygon), true);
+  assert.equal(pointInPolygon({ x: 55, y: 45 }, polygon), false);
+});
+
+test('ui hotspots: canonical coordinate scaling scales shape coordinates consistently', () => {
+  const scaled = scaleShape(
+    { type: 'circle', cx: 100, cy: 50, radius: 10 },
+    { width: HOTSPOT_CANONICAL_SIZE.width * 2, height: HOTSPOT_CANONICAL_SIZE.height * 2 }
+  );
+
+  assert.deepStrictEqual(scaled, { type: 'circle', cx: 200, cy: 100, radius: 20 });
+});
+
+test('ui hotspots: registry includes every workstation click area with friendly metadata', () => {
+  assert.equal(WORKSTATION_HOTSPOTS.length, 9);
+  for (const hotspot of WORKSTATION_HOTSPOTS) {
+    assert.equal(typeof hotspot.id, 'string');
+    assert.equal(typeof hotspot.title, 'string');
+    assert.equal(typeof hotspot.purpose, 'string');
+    assert.ok(hotspot.hitArea);
+    assert.ok(hotspot.highlightShape);
+    assert.ok(hotspot.popoverAnchor);
+    assert.ok(hotspot.bounds.width > 0);
+    assert.ok(hotspot.bounds.height > 0);
+    assert.equal(typeof hotspot.visualStyle.tint, 'string');
+    assert.equal(typeof hotspot.visualStyle.intensity, 'number');
+    assert.equal(typeof hotspot.visualStyle.pulse, 'boolean');
+    assert.equal(typeof hotspot.visualStyle.sparkle, 'boolean');
+  }
+});
+
+test('ui hotspots: generated geometry validates against canonical metadata', () => {
+  assert.equal(validateWorkstationHotspotGeometry(
+    CANONICAL_WORKSTATION_HOTSPOT_CONFIGS,
+    CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY
+  ), true);
+});
+
+test('ui hotspots: generated geometry cannot overwrite station semantics', () => {
+  assert.throws(
+    () => validateWorkstationHotspotGeometry(
+      CANONICAL_WORKSTATION_HOTSPOT_CONFIGS,
+      {
+        ...CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY,
+        engineCrystalHotspot: {
+          ...CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY.engineCrystalHotspot,
+          title: 'Rewrite Attempt',
+        },
+      }
+    ),
+    /forbidden metadata key: title/
+  );
+});
+
+test('ui hotspots: geometry overrides merge correctly with canonical metadata', () => {
+  const canonical = CANONICAL_WORKSTATION_HOTSPOT_CONFIGS.find((hotspot) => hotspot.id === 'engineCrystalHotspot');
+  const merged = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'engineCrystalHotspot');
+  const geometry = CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY.engineCrystalHotspot;
+
+  assert.equal(merged.title, canonical.title);
+  assert.equal(merged.purpose, canonical.purpose);
+  assert.deepStrictEqual(merged.worldZoneIds, canonical.worldZoneIds);
+  assert.deepStrictEqual(merged.hitArea, geometry.hitArea);
+  assert.deepStrictEqual(merged.highlightShape, geometry.highlightShape);
+  assert.deepStrictEqual(merged.popoverAnchor, geometry.popoverAnchor);
+});
+
+test('ui hotspots: canonical configs keep calibration geometry out of station semantics', () => {
+  for (const config of CANONICAL_WORKSTATION_HOTSPOT_CONFIGS) {
+    assert.equal(config.hitArea, undefined);
+    assert.equal(config.highlightShape, undefined);
+    assert.equal(config.popoverAnchor, undefined);
+    assert.equal(config.visualStyle, undefined);
+  }
+});
+
+test('ui hotspots: hitArea can be forgiving while highlightShape stays visually precise', () => {
+  const hotspot = WORKSTATION_HOTSPOTS.find((candidate) => candidate.id === 'engineCrystalHotspot');
+  const hitBounds = getShapeBounds(hotspot.hitArea);
+  const highlightBounds = getShapeBounds(hotspot.highlightShape);
+  const forgivingCorePoint = { x: 532, y: 350 };
+
+  assert.ok(hitBounds.width > highlightBounds.width);
+  assert.ok(hitBounds.height > highlightBounds.height);
+  assert.equal(
+    hitTestWorkstationHotspots(forgivingCorePoint, [hotspot])?.id,
+    hotspot.id
+  );
+});
+
+test('ui hotspots: full scene calibration uses shaped geometry and tight render desk highlight', () => {
+  const renderDesk = WORKSTATION_HOTSPOTS.find((candidate) => candidate.id === 'renderMonitorHotspot');
+  const engineCore = WORKSTATION_HOTSPOTS.find((candidate) => candidate.id === 'engineCrystalHotspot');
+  const archiveShelf = WORKSTATION_HOTSPOTS.find((candidate) => candidate.id === 'archiveShelfHotspot');
+  const renderHitBounds = getShapeBounds(renderDesk.hitArea);
+  const renderHighlightBounds = getShapeBounds(renderDesk.highlightShape);
+
+  assert.equal(engineCore.hitArea.type, 'polygon');
+  assert.equal(archiveShelf.hitArea.type, 'polygon');
+  assert.equal(renderDesk.hitArea.type, 'polygon');
+  assert.equal(renderDesk.highlightShape.type, 'polygon');
+  assert.ok(renderHighlightBounds.width < renderHitBounds.width);
+  assert.ok(renderHighlightBounds.height < renderHitBounds.height);
+  assert.ok(renderHighlightBounds.y + renderHighlightBounds.height < 505);
+});
+
+test('ui hotspots: pure hit testing returns topmost workstation and ignores empty background', () => {
+  const research = hitTestWorkstationHotspots({ x: 330, y: 210 });
+  assert.equal(research?.id, 'researchMonitorHotspot');
+
+  const empty = hitTestWorkstationHotspots({ x: 20, y: 500 });
+  assert.equal(empty, null);
+});
+
+test('ui hotspots: hover state tracks hoveredHotspotId for workstation points', () => {
+  const state = createCanvasInspectionState();
+  const hit = updateInspectionHover(state, [], { x: 330, y: 210 }, null, {
+    debug: false,
+    bakedBackground: true,
+  });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.equal(state.hoveredHotspotId, 'researchMonitorHotspot');
+  assert.equal(state.hoveredEntityId, 'researchMonitorHotspot');
+});
+
+test('ui hotspots: click selects hotspot and background click clears selection', () => {
+  const state = createCanvasInspectionState();
+  const hit = updateInspectionSelection(state, [], { x: 330, y: 210 }, null, {
+    debug: false,
+    bakedBackground: true,
+  });
+
+  assert.equal(hit.componentType, 'workstation-hotspot');
+  assert.equal(state.selectedHotspotId, 'researchMonitorHotspot');
+
+  const cleared = updateInspectionSelection(state, [], { x: 20, y: 500 }, null, {
+    debug: false,
+    bakedBackground: true,
+  });
+  assert.equal(cleared, null);
+  assert.equal(state.selectedHotspotId, null);
+  assert.equal(state.selectedEntityId, null);
+});
+
+test('ui hotspots: normal highlight layer draws cyan affordance without raw IDs or hitbox rectangles', () => {
+  const ctx = createMockContext();
+  const state = createCanvasInspectionState();
+  state.hoveredHotspotId = 'researchMonitorHotspot';
+
+  renderHotspotHighlights(ctx, state, { debug: false, frame: 12 });
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'stroke'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+});
+
+test('ui hotspots: selected highlight draws stronger outline and remains visible without hover', () => {
+  const ctx = createMockContext();
+  const state = createCanvasInspectionState();
+  state.selectedHotspotId = 'researchMonitorHotspot';
+
+  renderHotspotHighlights(ctx, state, { debug: false, frame: 24 });
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'stroke'));
+});
+
+test('ui hotspots: normal selected fill opacity remains subtle', () => {
+  const ctx = createMockContext();
+  const state = createCanvasInspectionState();
+  state.selectedHotspotId = 'renderMonitorHotspot';
+
+  renderHotspotHighlights(ctx, state, { debug: false, frame: 24 });
+
+  const fillAlphas = ctx.calls
+    .filter((call) => call[0] === 'set' && call[1] === 'fillStyle')
+    .map((call) => rgbaAlpha(call[2]))
+    .filter(Number.isFinite);
+
+  assert.ok(fillAlphas.some((alpha) => alpha > 0 && alpha <= 0.056));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+});
+
+test('ui hotspots: normal selected render desk omits calibration anchor dots and labels', () => {
+  const ctx = createMockContext();
+  const state = createCanvasInspectionState();
+  state.selectedHotspotId = 'renderMonitorHotspot';
+
+  renderHotspotHighlights(ctx, state, { debug: false, frame: 24 });
+
+  assert.ok(!ctx.calls.some((call) => call[0] === 'arc'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+});
+
+test('ui hotspots: ambient state glow renders from visualState view model without interaction labels', () => {
+  const ctx = createMockContext();
+  const state = createCanvasInspectionState();
+
+  renderHotspotHighlights(ctx, state, {
+    debug: false,
+    frame: 12,
+    hotspotComponents: [{
+      id: 'researchMonitorHotspot',
+      visualStateViewModel: {
+        hotspotId: 'researchMonitorHotspot',
+        visualState: 'working',
+        tone: 'curious',
+        intensity: 0.6,
+        effect: 'shimmer',
+      },
+    }],
+  });
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'stroke'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillText'));
+  assert.ok(!ctx.calls.some((call) => call[0] === 'fillRect' || call[0] === 'strokeRect'));
+  assert.equal(state.hoveredHotspotId, null);
+  assert.equal(state.selectedHotspotId, null);
+});
+
+test('ui hotspots: idle visualState does not draw ambient glow without hover or selection', () => {
+  const ctx = createMockContext();
+
+  renderHotspotHighlights(ctx, createCanvasInspectionState(), {
+    debug: false,
+    frame: 12,
+    hotspotComponents: [{
+      id: 'researchMonitorHotspot',
+      visualStateViewModel: {
+        hotspotId: 'researchMonitorHotspot',
+        visualState: 'idle',
+        tone: 'curious',
+        intensity: 0,
+        effect: 'none',
+      },
+    }],
+  });
+
+  assert.deepStrictEqual(ctx.calls, [['save'], ['restore']]);
+});
+
+test('ui hotspots: hover and selected highlights remain separate from ambient visualState', () => {
+  const ambientCtx = createMockContext();
+  const ambientState = createCanvasInspectionState();
+  renderHotspotHighlights(ambientCtx, ambientState, {
+    debug: false,
+    frame: 12,
+    hotspotComponents: [{
+      id: 'renderMonitorHotspot',
+      visualStateViewModel: {
+        hotspotId: 'renderMonitorHotspot',
+        visualState: 'working',
+        tone: 'creative',
+        intensity: 0.6,
+        effect: 'shimmer',
+      },
+    }],
+  });
+
+  const selectedCtx = createMockContext();
+  const selectedState = createCanvasInspectionState();
+  selectedState.selectedHotspotId = 'renderMonitorHotspot';
+  renderHotspotHighlights(selectedCtx, selectedState, { debug: false, frame: 12 });
+
+  assert.ok(ambientCtx.calls.some((call) => call[0] === 'fill'));
+  assert.ok(selectedCtx.calls.some((call) => call[0] === 'fill'));
+  assert.equal(ambientState.selectedHotspotId, null);
+  assert.equal(selectedState.selectedHotspotId, 'renderMonitorHotspot');
+});
+
+test('ui hotspots: debug highlight layer renders hitboxes and hotspot IDs', () => {
+  const ctx = createMockContext();
+
+  renderHotspotHighlights(ctx, createCanvasInspectionState(), {
+    debug: true,
+    frame: 0,
+    hotspotComponents: [{
+      id: 'researchMonitorHotspot',
+      visualStateViewModel: {
+        hotspotId: 'researchMonitorHotspot',
+        visualState: 'working',
+        tone: 'curious',
+        intensity: 0.6,
+        effect: 'shimmer',
+      },
+    }],
+  });
+
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillRect'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'arc'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'researchMonitorHotspot'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fillText' && call[1] === 'state: working'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'fill'));
+  assert.ok(ctx.calls.some((call) => call[0] === 'stroke'));
+});
+
+test('ui hotspots: scaled hit testing keeps workstations clickable after canvas resize', () => {
+  const scaled = hitTestWorkstationHotspots(
+    { x: 660, y: 420 },
+    WORKSTATION_HOTSPOTS,
+    { canvasSize: { width: HOTSPOT_CANONICAL_SIZE.width * 2, height: HOTSPOT_CANONICAL_SIZE.height * 2 } }
+  );
+
+  assert.equal(scaled?.id, 'researchMonitorHotspot');
+});
+
+test('ui hotspots: calibration mode nudges selected hotspot metadata without mutating registry', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('researchMonitorHotspot');
+  nudgeSelectedHotspot(3, -2);
+
+  const original = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+  const calibrated = getCalibratedHotspots().find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+  const json = selectedHotspotCalibrationJson();
+
+  assert.equal(original.hitArea.points[0].x + 3, calibrated.hitArea.points[0].x);
+  assert.equal(original.hitArea.points[0].y - 2, calibrated.hitArea.points[0].y);
+  assert.ok(json.includes('"researchMonitorHotspot"'));
+  assert.equal(original.hitArea.points[0].x, CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY.researchMonitorHotspot.hitArea.points[0].x);
+  resetCalibration();
+});
+
+test('ui hotspots: calibration edit mode is disabled in normal mode', () => {
+  resetCalibration();
+
+  assert.equal(setHotspotCalibrationEditMode(true), false);
+  assert.equal(isHotspotCalibrationEditMode(), false);
+});
+
+test('ui hotspots: calibration pointer selection updates selectedHotspotId', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  setHotspotCalibrationEditMode(true);
+
+  assert.equal(handleHotspotCalibrationPointerDown({ x: 620, y: 455 }), true);
+  assert.equal(hotspotCalibrationState.selectedHotspotId, 'renderMonitorHotspot');
+  handleHotspotCalibrationPointerUp();
+  resetCalibration();
+});
+
+test('ui hotspots: dragging popover anchor changes only popoverAnchor', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('popoverAnchor');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+
+  assert.equal(handleHotspotCalibrationPointerDown(before.popoverAnchor), true);
+  assert.equal(handleHotspotCalibrationPointerMove({ x: before.popoverAnchor.x + 12, y: before.popoverAnchor.y + 5 }), true);
+  handleHotspotCalibrationPointerUp();
+  const after = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+
+  assert.deepStrictEqual(after.hitArea, before.hitArea);
+  assert.deepStrictEqual(after.highlightShape, before.highlightShape);
+  assert.deepStrictEqual(after.popoverAnchor, { x: before.popoverAnchor.x + 12, y: before.popoverAnchor.y + 5 });
+  resetCalibration();
+});
+
+test('ui hotspots: calibration edits update edited hotspot override map', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('popoverAnchor');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+
+  handleHotspotCalibrationPointerDown(before.popoverAnchor);
+  handleHotspotCalibrationPointerMove({ x: before.popoverAnchor.x + 4, y: before.popoverAnchor.y + 2 });
+  handleHotspotCalibrationPointerUp();
+
+  assert.ok(hotspotCalibrationState.editedHotspotsById.renderMonitorHotspot);
+  assert.deepStrictEqual(
+    hotspotCalibrationState.editedHotspotsById.renderMonitorHotspot.popoverAnchor,
+    { x: before.popoverAnchor.x + 4, y: before.popoverAnchor.y + 2 }
+  );
+  assert.equal(hotspotCalibrationState.editsById, hotspotCalibrationState.editedHotspotsById);
+  resetCalibration();
+});
+
+test('ui hotspots: dragging highlightShape moves highlightShape but not hitArea', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('highlightShape');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  const start = { x: before.highlightShape.points[0].x + 4, y: before.highlightShape.points[0].y + 4 };
+
+  assert.equal(handleHotspotCalibrationPointerDown(start), true);
+  assert.equal(handleHotspotCalibrationPointerMove({ x: start.x + 8, y: start.y + 3 }), true);
+  handleHotspotCalibrationPointerUp();
+  const after = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+
+  assert.deepStrictEqual(after.hitArea, before.hitArea);
+  assert.notDeepStrictEqual(after.highlightShape, before.highlightShape);
+  assert.deepStrictEqual(after.popoverAnchor, before.popoverAnchor);
+  resetCalibration();
+});
+
+test('ui hotspots: edit layer all moves hitArea highlightShape and popoverAnchor together', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('all');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  const start = { x: 620, y: 455 };
+
+  assert.equal(handleHotspotCalibrationPointerDown(start), true);
+  assert.equal(handleHotspotCalibrationPointerMove({ x: start.x + 6, y: start.y + 4 }), true);
+  handleHotspotCalibrationPointerUp();
+  const after = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+
+  assert.equal(after.hitArea.points[0].x, before.hitArea.points[0].x + 6);
+  assert.equal(after.highlightShape.points[0].y, before.highlightShape.points[0].y + 4);
+  assert.equal(after.popoverAnchor.x, before.popoverAnchor.x + 6);
+  assert.equal(after.popoverAnchor.y, before.popoverAnchor.y + 4);
+  resetCalibration();
+});
+
+test('ui hotspots: copied calibration JSON contains updated geometry and window fallback', async () => {
+  resetCalibration();
+  globalThis.window = { __SLOTHWORLD_HOTSPOT_CALIBRATION__: false };
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('popoverAnchor');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  handleHotspotCalibrationPointerDown(before.popoverAnchor);
+  handleHotspotCalibrationPointerMove({ x: before.popoverAnchor.x + 2, y: before.popoverAnchor.y + 3 });
+  handleHotspotCalibrationPointerUp();
+
+  const copied = await copySelectedHotspotJsonToClipboard();
+  const json = selectedHotspotCalibrationJson();
+
+  assert.equal(copied, false);
+  assert.ok(json.includes('"renderMonitorHotspot"'));
+  assert.ok(json.includes('"popoverAnchor"'));
+  assert.equal(globalThis.window.__SLOTHWORLD_LAST_HOTSPOT_JSON__, json);
+  resetCalibration();
+});
+
+test('ui hotspots: selected export still exports one hotspot only', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+
+  const json = selectedHotspotCalibrationJson();
+  const parsed = JSON.parse(json);
+
+  assert.equal(Array.isArray(parsed), false);
+  assert.equal(parsed.id, 'renderMonitorHotspot');
+  assert.ok(!json.includes('researchMonitorHotspot'));
+  resetCalibration();
+});
+
+test('ui hotspots: geometry export includes every calibrated hotspot and preserves unedited geometry', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('popoverAnchor');
+  const before = getCalibratedHotspots().find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  handleHotspotCalibrationPointerDown(before.popoverAnchor);
+  handleHotspotCalibrationPointerMove({ x: before.popoverAnchor.x + 9, y: before.popoverAnchor.y + 7 });
+  handleHotspotCalibrationPointerUp();
+
+  const parsed = JSON.parse(exportAllCalibratedHotspots(WORKSTATION_HOTSPOTS, hotspotCalibrationState.editedHotspotsById));
+  const edited = parsed.find((hotspot) => hotspot.id === 'renderMonitorHotspot');
+  const unedited = parsed.find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+  const originalUnedited = WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === 'researchMonitorHotspot');
+
+  assert.equal(parsed.length, WORKSTATION_HOTSPOTS.length);
+  assert.deepStrictEqual(edited.popoverAnchor, { x: before.popoverAnchor.x + 9, y: before.popoverAnchor.y + 7 });
+  assert.deepStrictEqual(unedited.hitArea, originalUnedited.hitArea);
+  assert.equal(unedited.title, undefined);
+  assert.equal(unedited.purpose, undefined);
+  assert.equal(unedited.worldZoneIds, undefined);
+  assert.equal(unedited.feedbackKind, undefined);
+  assert.equal(unedited.visualStyle.tint, originalUnedited.visualStyle.tint);
+  resetCalibration();
+});
+
+test('ui hotspots: full debug export remains available separately', () => {
+  const parsed = JSON.parse(exportAllCalibratedHotspotsDebug(WORKSTATION_HOTSPOTS, Object.create(null)));
+  const engine = parsed.find((hotspot) => hotspot.id === 'engineCrystalHotspot');
+
+  assert.equal(parsed.length, WORKSTATION_HOTSPOTS.length);
+  assert.equal(engine.title, 'Engine Core');
+  assert.deepStrictEqual(engine.worldZoneIds, ['engineCrystal']);
+  assert.equal(engine.feedbackKind, 'crystal');
+});
+
+test('ui hotspots: all calibration export rounds coordinates', () => {
+  const text = exportAllCalibratedHotspots([{
+    id: 'roundingHotspot',
+    title: 'Rounding Desk',
+    label: 'Rounding Desk',
+    purpose: 'Rounding test',
+    worldZoneIds: [],
+    zoneIds: [],
+    hitArea: { type: 'rect', x: 1.234, y: 2.26, width: 3.05, height: 4.04 },
+    highlightShape: { type: 'circle', cx: 5.55, cy: 6.66, radius: 7.77 },
+    popoverAnchor: { x: 8.88, y: 9.99 },
+  }], Object.create(null));
+
+  const [hotspot] = JSON.parse(text);
+  assert.deepStrictEqual(hotspot.hitArea, { type: 'rect', x: 1.2, y: 2.3, width: 3.1, height: 4 });
+  assert.deepStrictEqual(hotspot.highlightShape, { type: 'circle', cx: 5.6, cy: 6.7, radius: 7.8 });
+  assert.deepStrictEqual(hotspot.popoverAnchor, { x: 8.9, y: 10 });
+});
+
+test('ui hotspots: all calibration clipboard and download set all-export fallback', async () => {
+  resetCalibration();
+  globalThis.window = { __SLOTHWORLD_HOTSPOT_CALIBRATION__: false };
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+
+  const copied = await copyAllCalibratedHotspotsToClipboard();
+  const copiedJson = globalThis.window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__;
+
+  assert.equal(copied, false);
+  assert.equal(JSON.parse(copiedJson).length, WORKSTATION_HOTSPOTS.length);
+  assert.equal(JSON.parse(copiedJson)[0].title, undefined);
+  assert.equal(downloadAllCalibratedHotspots(), false);
+  assert.ok(globalThis.window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__.includes('CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY'));
+  resetCalibration();
+});
+
+test('ui hotspots: generated module export is geometry-only', () => {
+  const text = exportCalibratedHotspotGeometryModule(WORKSTATION_HOTSPOTS, Object.create(null));
+
+  assert.ok(text.includes('CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY'));
+  assert.ok(text.includes('engineCrystalHotspot'));
+  assert.ok(!text.includes('Engine Core'));
+  assert.ok(!text.includes('worldZoneIds'));
+  assert.ok(!text.includes('feedbackKind'));
+});
+
+test('ui hotspots: dev save fallback does not write without endpoint', async () => {
+  resetCalibration();
+  globalThis.window = { __SLOTHWORLD_HOTSPOT_CALIBRATION__: false };
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = undefined;
+    const saved = await attemptDevSaveAllCalibratedHotspots();
+
+    assert.equal(saved, false);
+    assert.ok(globalThis.window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__.includes('CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY'));
+  } finally {
+    globalThis.fetch = originalFetch;
+    resetCalibration();
+  }
+});
+
+test('ui hotspots: calibration edit mode renders handles and HUD only in debug', () => {
+  resetCalibration();
+  setHotspotCalibrationEnabled(true);
+  selectHotspotForCalibration('renderMonitorHotspot');
+  setHotspotCalibrationEditMode(true);
+  setHotspotCalibrationEditLayer('highlightShape');
+  const debugCtx = createMockContext();
+
+  renderHotspotHighlights(debugCtx, createCanvasInspectionState(), {
+    debug: true,
+    frame: 0,
+    hotspots: getCalibratedHotspots(),
+    calibration: hotspotCalibrationState,
+  });
+
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'fillText' && String(call[1]).startsWith('edit: ')));
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'fillText' && call[1] === 'layer: highlightShape'));
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'fillText' && String(call[1]).includes('Shift+Ctrl+C all')));
+  assert.ok(debugCtx.calls.some((call) => call[0] === 'fillText' && String(call[1]).includes('Ctrl+S dev save')));
+
+  const normalCtx = createMockContext();
+  renderHotspotHighlights(normalCtx, createCanvasInspectionState(), {
+    debug: false,
+    frame: 0,
+    hotspots: getCalibratedHotspots(),
+    calibration: hotspotCalibrationState,
+  });
+
+  assert.ok(!normalCtx.calls.some((call) => call[0] === 'fillText'));
+  assert.ok(!normalCtx.calls.some((call) => call[0] === 'fillText' && String(call[1]).includes('download')));
+  resetCalibration();
+});

--- a/tests/world-scene-e2e.test.mjs
+++ b/tests/world-scene-e2e.test.mjs
@@ -303,7 +303,7 @@ describe('E2E — no semantic leakage', () => {
 
   it('task-chip components have only the expected structural keys', () => {
     const { components } = runFullPipeline(clone(GRAPH));
-    const expected = 'anomaly,componentType,id,metrics,visualState,worldZoneId,x,y,zoneId';
+    const expected = 'anomaly,componentType,id,metrics,taskType,title,visualState,worldZoneId,x,y,zoneId';
     for (const c of components.filter(c => c.componentType === 'task-chip')) {
       const keys = Object.keys(c).sort().join(',');
       assert.equal(keys, expected, `unexpected keys on task-chip "${c.id}": ${keys}`);

--- a/ui/hotspots/hitTestHotspots.js
+++ b/ui/hotspots/hitTestHotspots.js
@@ -1,0 +1,34 @@
+/**
+ * Pure hotspot hit testing for fixed workstation interaction areas.
+ */
+
+import { WORKSTATION_HOTSPOTS } from './workstationHotspots.js';
+import {
+  HOTSPOT_CANONICAL_SIZE,
+  pointInRect,
+  pointInShape,
+  scaleShape,
+} from './hotspotGeometry.js';
+
+function isFinitePoint(point) {
+  return Number.isFinite(point?.x) && Number.isFinite(point?.y);
+}
+
+export function rectContainsPoint(rect, point) {
+  return pointInRect(point, rect);
+}
+
+export function hitTestWorkstationHotspots(point, hotspots = WORKSTATION_HOTSPOTS, options = {}) {
+  if (!isFinitePoint(point) || !Array.isArray(hotspots)) return null;
+  const targetSize = options.canvasSize || HOTSPOT_CANONICAL_SIZE;
+
+  for (let i = hotspots.length - 1; i >= 0; i--) {
+    const hotspot = hotspots[i];
+    const hitArea = hotspot?.hitArea || hotspot?.bounds;
+    const shape = scaleShape(hitArea?.type ? hitArea : { type: 'rect', ...hitArea }, targetSize);
+    if (pointInShape(point, shape)) {
+      return hotspot;
+    }
+  }
+  return null;
+}

--- a/ui/hotspots/hotspotCalibration.js
+++ b/ui/hotspots/hotspotCalibration.js
@@ -1,0 +1,616 @@
+/**
+ * Lightweight workstation hotspot calibration mode.
+ *
+ * Runtime-only UI state. It never mutates the canonical registry; nudge offsets
+ * are applied as temporary interaction metadata and can be copied as JSON.
+ */
+
+import { WORKSTATION_HOTSPOTS } from './workstationHotspots.js';
+import { pointInShape } from './hotspotGeometry.js';
+
+const initialEditedHotspotsById = Object.create(null);
+
+export const hotspotCalibrationState = {
+  enabled: false,
+  editMode: false,
+  editLayer: 'hitArea',
+  selectedVertexIndex: null,
+  dragging: null,
+  dragStart: null,
+  originalGeometry: null,
+  selectedHotspotId: null,
+  offsetsById: Object.create(null),
+  editedHotspotsById: initialEditedHotspotsById,
+  editsById: initialEditedHotspotsById,
+};
+
+const EDIT_LAYERS = Object.freeze(['hitArea', 'highlightShape', 'popoverAnchor', 'all']);
+const HANDLE_RADIUS = 7;
+
+function cloneShape(shape) {
+  if (!shape) return shape;
+  if (shape.type === 'polygon') {
+    return { ...shape, points: Array.isArray(shape.points) ? shape.points.map((point) => ({ x: point.x, y: point.y })) : [] };
+  }
+  return { ...shape };
+}
+
+function cloneHotspotGeometry(hotspot) {
+  return {
+    hitArea: cloneShape(hotspot.hitArea),
+    highlightShape: cloneShape(hotspot.highlightShape),
+    popoverAnchor: { x: hotspot.popoverAnchor?.x ?? 0, y: hotspot.popoverAnchor?.y ?? 0 },
+    visualStyle: hotspot.visualStyle ? { ...hotspot.visualStyle } : undefined,
+  };
+}
+
+function roundNumber(value) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 10) / 10;
+}
+
+function roundedPoint(point) {
+  return {
+    x: roundNumber(point?.x),
+    y: roundNumber(point?.y),
+  };
+}
+
+function roundedShape(shape) {
+  if (!shape) return shape;
+  if (shape.type === 'polygon') {
+    return {
+      type: 'polygon',
+      points: Array.isArray(shape.points) ? shape.points.map(roundedPoint) : [],
+    };
+  }
+  if (shape.type === 'circle') {
+    return {
+      type: 'circle',
+      cx: roundNumber(shape.cx),
+      cy: roundNumber(shape.cy),
+      radius: roundNumber(shape.radius),
+    };
+  }
+  return {
+    type: 'rect',
+    x: roundNumber(shape.x),
+    y: roundNumber(shape.y),
+    width: roundNumber(shape.width),
+    height: roundNumber(shape.height),
+  };
+}
+
+function roundedHotspotGeometry(hotspot) {
+  const geometry = {
+    hitArea: roundedShape(hotspot.hitArea),
+    highlightShape: roundedShape(hotspot.highlightShape),
+    popoverAnchor: roundedPoint(hotspot.popoverAnchor),
+  };
+  if (hotspot.visualStyle) {
+    geometry.visualStyle = { ...hotspot.visualStyle };
+  }
+  return geometry;
+}
+
+function editedHotspotsById() {
+  if (!hotspotCalibrationState.editedHotspotsById) {
+    hotspotCalibrationState.editedHotspotsById = hotspotCalibrationState.editsById || Object.create(null);
+  }
+  if (hotspotCalibrationState.editsById !== hotspotCalibrationState.editedHotspotsById) {
+    hotspotCalibrationState.editsById = hotspotCalibrationState.editedHotspotsById;
+  }
+  return hotspotCalibrationState.editedHotspotsById;
+}
+
+function clonePoint(point, offset) {
+  return {
+    x: (point?.x ?? 0) + offset.x,
+    y: (point?.y ?? 0) + offset.y,
+  };
+}
+
+function offsetShape(shape, offset) {
+  if (!shape) return shape;
+  if (shape.type === 'circle') {
+    return { ...shape, cx: shape.cx + offset.x, cy: shape.cy + offset.y };
+  }
+  if (shape.type === 'polygon') {
+    return {
+      ...shape,
+      points: Array.isArray(shape.points) ? shape.points.map((point) => clonePoint(point, offset)) : [],
+    };
+  }
+  return { ...shape, x: shape.x + offset.x, y: shape.y + offset.y };
+}
+
+function offsetRect(rect, offset) {
+  return { ...rect, x: rect.x + offset.x, y: rect.y + offset.y };
+}
+
+function offsetFor(id) {
+  const offset = hotspotCalibrationState.offsetsById[id];
+  return offset || { x: 0, y: 0 };
+}
+
+function editFor(id) {
+  return editedHotspotsById()[id] || null;
+}
+
+function applyGeometryEdit(hotspot) {
+  const edit = editFor(hotspot.id);
+  if (!edit) return hotspot;
+  return Object.freeze({
+    ...hotspot,
+    hitArea: Object.freeze(cloneShape(edit.hitArea || hotspot.hitArea)),
+    highlightShape: Object.freeze(cloneShape(edit.highlightShape || hotspot.highlightShape)),
+    popoverAnchor: Object.freeze({ ...(edit.popoverAnchor || hotspot.popoverAnchor) }),
+  });
+}
+
+export function isHotspotCalibrationEnabled() {
+  if (typeof window !== 'undefined' && window.__SLOTHWORLD_HOTSPOT_CALIBRATION__ === true) {
+    return true;
+  }
+  return hotspotCalibrationState.enabled === true;
+}
+
+export function setHotspotCalibrationEnabled(enabled) {
+  hotspotCalibrationState.enabled = Boolean(enabled);
+  if (!hotspotCalibrationState.enabled) {
+    hotspotCalibrationState.editMode = false;
+    hotspotCalibrationState.dragging = null;
+    hotspotCalibrationState.selectedVertexIndex = null;
+  }
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_HOTSPOT_CALIBRATION__ = hotspotCalibrationState.enabled;
+  }
+  if (hotspotCalibrationState.enabled && !hotspotCalibrationState.selectedHotspotId) {
+    hotspotCalibrationState.selectedHotspotId = WORKSTATION_HOTSPOTS[0]?.id || null;
+  }
+  return hotspotCalibrationState.enabled;
+}
+
+export function setHotspotCalibrationEditMode(enabled) {
+  if (!isHotspotCalibrationEnabled()) {
+    hotspotCalibrationState.editMode = false;
+    return false;
+  }
+  hotspotCalibrationState.editMode = Boolean(enabled);
+  hotspotCalibrationState.dragging = null;
+  hotspotCalibrationState.selectedVertexIndex = null;
+  return hotspotCalibrationState.editMode;
+}
+
+export function isHotspotCalibrationEditMode() {
+  return isHotspotCalibrationEnabled() && hotspotCalibrationState.editMode === true;
+}
+
+export function setHotspotCalibrationEditLayer(layer) {
+  if (!EDIT_LAYERS.includes(layer)) return hotspotCalibrationState.editLayer;
+  hotspotCalibrationState.editLayer = layer;
+  hotspotCalibrationState.selectedVertexIndex = null;
+  return hotspotCalibrationState.editLayer;
+}
+
+export function cycleHotspotCalibrationSelection(direction = 1) {
+  if (WORKSTATION_HOTSPOTS.length === 0) return null;
+  const currentIndex = WORKSTATION_HOTSPOTS.findIndex((hotspot) => hotspot.id === hotspotCalibrationState.selectedHotspotId);
+  const nextIndex = (Math.max(0, currentIndex) + direction + WORKSTATION_HOTSPOTS.length) % WORKSTATION_HOTSPOTS.length;
+  hotspotCalibrationState.selectedHotspotId = WORKSTATION_HOTSPOTS[nextIndex].id;
+  return hotspotCalibrationState.selectedHotspotId;
+}
+
+export function selectHotspotForCalibration(id) {
+  if (!WORKSTATION_HOTSPOTS.some((hotspot) => hotspot.id === id)) return null;
+  hotspotCalibrationState.selectedHotspotId = id;
+  return id;
+}
+
+export function nudgeSelectedHotspot(dx, dy) {
+  const id = hotspotCalibrationState.selectedHotspotId;
+  if (!id) return null;
+  const geometry = ensureEdit(id);
+  if (!geometry) return null;
+  moveLayerGeometry(geometry, 'all', dx, dy);
+  return { x: dx, y: dy };
+}
+
+export function getCalibratedHotspots(hotspots = WORKSTATION_HOTSPOTS) {
+  if (!isHotspotCalibrationEnabled()) return hotspots;
+  return hotspots.map((hotspot) => {
+    const edited = applyGeometryEdit(hotspot);
+    hotspot = edited;
+    const offset = offsetFor(hotspot.id);
+    if (offset.x === 0 && offset.y === 0) return hotspot;
+    return Object.freeze({
+      ...hotspot,
+      bounds: Object.freeze(offsetRect(hotspot.bounds, offset)),
+      hitArea: Object.freeze(offsetShape(hotspot.hitArea, offset)),
+      highlightShape: Object.freeze(offsetShape(hotspot.highlightShape, offset)),
+      popoverAnchor: Object.freeze(clonePoint(hotspot.popoverAnchor, offset)),
+    });
+  });
+}
+
+function selectedHotspot() {
+  const id = hotspotCalibrationState.selectedHotspotId;
+  return getCalibratedHotspots().find((candidate) => candidate.id === id) || null;
+}
+
+function ensureEdit(id) {
+  const current = getCalibratedHotspots().find((candidate) => candidate.id === id);
+  if (!current) return null;
+  const edits = editedHotspotsById();
+  if (!edits[id]) {
+    edits[id] = cloneHotspotGeometry(current);
+  }
+  return edits[id];
+}
+
+function moveShape(shape, dx, dy) {
+  if (!shape) return shape;
+  if (shape.type === 'circle') return { ...shape, cx: shape.cx + dx, cy: shape.cy + dy };
+  if (shape.type === 'polygon') {
+    return { ...shape, points: shape.points.map((point) => ({ x: point.x + dx, y: point.y + dy })) };
+  }
+  return { ...shape, x: shape.x + dx, y: shape.y + dy };
+}
+
+function moveLayerGeometry(geometry, layer, dx, dy) {
+  if (layer === 'hitArea' || layer === 'all') geometry.hitArea = moveShape(geometry.hitArea, dx, dy);
+  if (layer === 'highlightShape' || layer === 'all') geometry.highlightShape = moveShape(geometry.highlightShape, dx, dy);
+  if (layer === 'popoverAnchor' || layer === 'all') {
+    geometry.popoverAnchor = { x: geometry.popoverAnchor.x + dx, y: geometry.popoverAnchor.y + dy };
+  }
+}
+
+function pointDistance(a, b) {
+  const dx = (a?.x ?? 0) - (b?.x ?? 0);
+  const dy = (a?.y ?? 0) - (b?.y ?? 0);
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function shapeVertexAt(shape, point) {
+  if (!shape || !point) return null;
+  if (shape.type === 'polygon') {
+    for (let i = 0; i < shape.points.length; i++) {
+      if (pointDistance(shape.points[i], point) <= HANDLE_RADIUS) return { kind: 'polygonVertex', index: i };
+    }
+  }
+  if (shape.type === 'circle') {
+    const center = { x: shape.cx, y: shape.cy };
+    const radiusHandle = { x: shape.cx + shape.radius, y: shape.cy };
+    if (pointDistance(center, point) <= HANDLE_RADIUS) return { kind: 'circleCenter' };
+    if (pointDistance(radiusHandle, point) <= HANDLE_RADIUS) return { kind: 'circleRadius' };
+  }
+  if (shape.type === 'rect') {
+    const handles = [
+      { name: 'nw', x: shape.x, y: shape.y },
+      { name: 'ne', x: shape.x + shape.width, y: shape.y },
+      { name: 'se', x: shape.x + shape.width, y: shape.y + shape.height },
+      { name: 'sw', x: shape.x, y: shape.y + shape.height },
+    ];
+    for (const handle of handles) {
+      if (pointDistance(handle, point) <= HANDLE_RADIUS) return { kind: 'rectCorner', corner: handle.name };
+    }
+  }
+  return null;
+}
+
+function editableShapeFor(hotspot, layer) {
+  if (layer === 'hitArea') return hotspot.hitArea;
+  if (layer === 'highlightShape') return hotspot.highlightShape;
+  return hotspot.highlightShape || hotspot.hitArea;
+}
+
+function pointerDragKind(hotspot, point, layer) {
+  if (!hotspot || !point) return null;
+  if ((layer === 'popoverAnchor' || layer === 'all') && pointDistance(hotspot.popoverAnchor, point) <= HANDLE_RADIUS) {
+    return { kind: 'popoverAnchor' };
+  }
+  if (layer === 'all' && (pointInShape(point, hotspot.hitArea) || pointInShape(point, hotspot.highlightShape))) {
+    return { kind: 'moveLayer', layer: 'all' };
+  }
+  const vertexLayer = layer === 'all' ? 'highlightShape' : layer;
+  if (vertexLayer === 'hitArea' || vertexLayer === 'highlightShape') {
+    const shape = editableShapeFor(hotspot, vertexLayer);
+    const vertex = shapeVertexAt(shape, point);
+    if (vertex) return { ...vertex, layer: vertexLayer };
+    if (pointInShape(point, shape)) return { kind: 'moveLayer', layer: vertexLayer };
+  }
+  return null;
+}
+
+function applyVertexDrag(geometry, drag, point) {
+  const shape = geometry[drag.layer];
+  if (!shape) return;
+  if (drag.kind === 'polygonVertex' && shape.type === 'polygon') {
+    shape.points[drag.index] = { x: point.x, y: point.y };
+  }
+  if (drag.kind === 'circleCenter' && shape.type === 'circle') {
+    shape.cx = point.x;
+    shape.cy = point.y;
+  }
+  if (drag.kind === 'circleRadius' && shape.type === 'circle') {
+    shape.radius = Math.max(1, Math.abs(point.x - shape.cx));
+  }
+  if (drag.kind === 'rectCorner' && shape.type === 'rect') {
+    const right = shape.x + shape.width;
+    const bottom = shape.y + shape.height;
+    if (drag.corner.includes('w')) {
+      shape.width = Math.max(1, right - point.x);
+      shape.x = point.x;
+    }
+    if (drag.corner.includes('e')) shape.width = Math.max(1, point.x - shape.x);
+    if (drag.corner.includes('n')) {
+      shape.height = Math.max(1, bottom - point.y);
+      shape.y = point.y;
+    }
+    if (drag.corner.includes('s')) shape.height = Math.max(1, point.y - shape.y);
+  }
+}
+
+export function handleHotspotCalibrationPointerDown(point, options = {}) {
+  if (!isHotspotCalibrationEditMode() || !point) return false;
+  const hotspots = options.hotspots || getCalibratedHotspots();
+  const selected = selectedHotspot();
+  const layer = options.shiftKey ? 'all' : hotspotCalibrationState.editLayer;
+  if (selected) {
+    const drag = pointerDragKind(selected, point, layer);
+    if (drag) {
+      const geometry = ensureEdit(selected.id);
+      hotspotCalibrationState.dragging = drag;
+      hotspotCalibrationState.dragStart = { x: point.x, y: point.y };
+      hotspotCalibrationState.originalGeometry = cloneHotspotGeometry({ ...selected, ...geometry });
+      hotspotCalibrationState.selectedVertexIndex = Number.isInteger(drag.index) ? drag.index : null;
+      return true;
+    }
+  }
+  const clicked = hotspots.find((hotspot) => pointInShape(point, hotspot.hitArea));
+  if (clicked) {
+    selectHotspotForCalibration(clicked.id);
+    ensureEdit(clicked.id);
+    return true;
+  }
+  return false;
+}
+
+export function handleHotspotCalibrationPointerMove(point, options = {}) {
+  if (!isHotspotCalibrationEditMode() || !hotspotCalibrationState.dragging || !point) return false;
+  const id = hotspotCalibrationState.selectedHotspotId;
+  const geometry = ensureEdit(id);
+  const original = hotspotCalibrationState.originalGeometry;
+  const drag = hotspotCalibrationState.dragging;
+  if (!geometry || !original) return false;
+  const fine = options.altKey ? 0.25 : 1;
+  const dx = (point.x - hotspotCalibrationState.dragStart.x) * fine;
+  const dy = (point.y - hotspotCalibrationState.dragStart.y) * fine;
+  geometry.hitArea = cloneShape(original.hitArea);
+  geometry.highlightShape = cloneShape(original.highlightShape);
+  geometry.popoverAnchor = { ...original.popoverAnchor };
+  if (drag.kind === 'moveLayer') moveLayerGeometry(geometry, drag.layer, dx, dy);
+  if (drag.kind === 'popoverAnchor') geometry.popoverAnchor = { x: original.popoverAnchor.x + dx, y: original.popoverAnchor.y + dy };
+  if (drag.kind !== 'moveLayer' && drag.kind !== 'popoverAnchor') applyVertexDrag(geometry, drag, point);
+  return true;
+}
+
+export function handleHotspotCalibrationPointerUp() {
+  if (!hotspotCalibrationState.dragging) return false;
+  hotspotCalibrationState.dragging = null;
+  hotspotCalibrationState.dragStart = null;
+  hotspotCalibrationState.originalGeometry = null;
+  return true;
+}
+
+export function selectedHotspotCalibrationJson() {
+  const id = hotspotCalibrationState.selectedHotspotId;
+  const hotspot = getCalibratedHotspots().find((candidate) => candidate.id === id);
+  if (!hotspot) return null;
+  return JSON.stringify({
+    id: hotspot.id,
+    ...roundedHotspotGeometry(hotspot),
+  }, null, 2);
+}
+
+function exportableHotspot(hotspot, override) {
+  const merged = {
+    ...hotspot,
+    ...(override || {}),
+  };
+  const exported = {
+    id: hotspot.id,
+    title: hotspot.title,
+    label: hotspot.label,
+    purpose: hotspot.purpose,
+    semanticType: hotspot.semanticType,
+    worldZoneIds: Array.isArray(hotspot.worldZoneIds) ? [...hotspot.worldZoneIds] : [],
+    zoneIds: Array.isArray(hotspot.zoneIds) ? [...hotspot.zoneIds] : [],
+    feedbackKind: hotspot.feedbackKind,
+    ...roundedHotspotGeometry(merged),
+  };
+  return Object.fromEntries(Object.entries(exported).filter(([, value]) => value !== undefined));
+}
+
+function exportableGeometryEntry(hotspot, override) {
+  const merged = {
+    ...hotspot,
+    ...(override || {}),
+  };
+  return {
+    id: hotspot.id,
+    ...roundedHotspotGeometry(merged),
+  };
+}
+
+export function exportAllCalibratedHotspotsDebug(baseHotspots = WORKSTATION_HOTSPOTS, editedHotspots = editedHotspotsById()) {
+  const entries = baseHotspots.map((hotspot) => exportableHotspot(hotspot, editedHotspots?.[hotspot.id]));
+  return JSON.stringify(entries, null, 2);
+}
+
+export function exportAllCalibratedHotspots(baseHotspots = WORKSTATION_HOTSPOTS, editedHotspots = editedHotspotsById()) {
+  const entries = baseHotspots.map((hotspot) => exportableGeometryEntry(hotspot, editedHotspots?.[hotspot.id]));
+  return JSON.stringify(entries, null, 2);
+}
+
+function jsLiteral(value, indent = 2) {
+  const json = JSON.stringify(value, null, indent);
+  return json.replace(/"([A-Za-z_$][\w$]*)":/g, '$1:');
+}
+
+export function exportCalibratedHotspotGeometryModule(baseHotspots = WORKSTATION_HOTSPOTS, editedHotspots = editedHotspotsById()) {
+  const entries = Object.fromEntries(baseHotspots.map((hotspot) => {
+    const geometry = exportableGeometryEntry(hotspot, editedHotspots?.[hotspot.id]);
+    const { id, ...geometryOnly } = geometry;
+    return [id, geometryOnly];
+  }));
+  return [
+    '/**',
+    ' * Generated workstation hotspot calibration geometry.',
+    ' *',
+    ' * Geometry-only: station names, purposes, zones, and feedback semantics live in',
+    ' * workstationHotspots.js so calibration exports cannot rewrite meaning.',
+    ' */',
+    '',
+    `export const CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY = Object.freeze(${jsLiteral(entries, 2)});`,
+    '',
+  ].join('\n');
+}
+
+export async function copySelectedHotspotJsonToClipboard() {
+  const json = selectedHotspotCalibrationJson();
+  if (!json) return false;
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_LAST_HOTSPOT_JSON__ = json;
+  }
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(json);
+    return true;
+  }
+  return false;
+}
+
+export async function copyAllCalibratedHotspotsToClipboard(baseHotspots = WORKSTATION_HOTSPOTS) {
+  const json = exportAllCalibratedHotspots(baseHotspots, editedHotspotsById());
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__ = json;
+  }
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(json);
+    return true;
+  }
+  return false;
+}
+
+export function downloadAllCalibratedHotspots(baseHotspots = WORKSTATION_HOTSPOTS) {
+  const text = exportCalibratedHotspotGeometryModule(baseHotspots, editedHotspotsById());
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__ = text;
+  }
+  if (typeof document === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined') {
+    return false;
+  }
+  const blob = new Blob([text], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'workstationHotspotGeometry.generated.js';
+  link.style.display = 'none';
+  document.body?.appendChild?.(link);
+  link.click?.();
+  link.remove?.();
+  URL.revokeObjectURL?.(url);
+  return true;
+}
+
+export async function attemptDevSaveAllCalibratedHotspots(baseHotspots = WORKSTATION_HOTSPOTS) {
+  const text = exportCalibratedHotspotGeometryModule(baseHotspots, editedHotspotsById());
+  if (typeof window !== 'undefined') {
+    window.__SLOTHWORLD_LAST_HOTSPOT_EXPORT__ = text;
+  }
+  if (typeof fetch !== 'function') {
+    console.info?.('[Slothworld] Dev hotspot save is unavailable; use Shift+Ctrl+C or S to export geometry.');
+    return false;
+  }
+  try {
+    const response = await fetch('/dev/hotspots/save', {
+      method: 'POST',
+      headers: { 'content-type': 'text/javascript' },
+      body: text,
+    });
+    if (!response.ok) {
+      console.info?.('[Slothworld] Dev hotspot save endpoint is disabled; use Shift+Ctrl+C or S to export geometry.');
+      return false;
+    }
+    return true;
+  } catch {
+    console.info?.('[Slothworld] Dev hotspot save endpoint is unavailable; use Shift+Ctrl+C or S to export geometry.');
+    return false;
+  }
+}
+
+export function handleHotspotCalibrationKeydown(event) {
+  if (!event) return false;
+  const key = String(event.key || '');
+  if (event.ctrlKey && event.altKey && key.toLowerCase() === 'h') {
+    setHotspotCalibrationEnabled(!isHotspotCalibrationEnabled());
+    event.preventDefault?.();
+    return true;
+  }
+  if (!isHotspotCalibrationEnabled()) return false;
+
+  if (key.toLowerCase() === 'e') {
+    setHotspotCalibrationEditMode(!isHotspotCalibrationEditMode());
+    event.preventDefault?.();
+    return true;
+  }
+
+  const layerKeys = { 1: 'hitArea', 2: 'highlightShape', 3: 'popoverAnchor', 4: 'all' };
+  if (layerKeys[key]) {
+    setHotspotCalibrationEditLayer(layerKeys[key]);
+    event.preventDefault?.();
+    return true;
+  }
+
+  if (key === 'Tab') {
+    cycleHotspotCalibrationSelection(event.shiftKey ? -1 : 1);
+    event.preventDefault?.();
+    return true;
+  }
+
+  const step = event.shiftKey ? 10 : 1;
+  const nudges = {
+    ArrowLeft: [-step, 0],
+    ArrowRight: [step, 0],
+    ArrowUp: [0, -step],
+    ArrowDown: [0, step],
+  };
+  if (nudges[key]) {
+    nudgeSelectedHotspot(nudges[key][0], nudges[key][1]);
+    event.preventDefault?.();
+    return true;
+  }
+
+  if (event.ctrlKey && key.toLowerCase() === 'c') {
+    if (event.shiftKey) {
+      copyAllCalibratedHotspotsToClipboard();
+    } else {
+      copySelectedHotspotJsonToClipboard();
+    }
+    event.preventDefault?.();
+    return true;
+  }
+
+  if (event.ctrlKey && key.toLowerCase() === 's') {
+    attemptDevSaveAllCalibratedHotspots();
+    event.preventDefault?.();
+    return true;
+  }
+
+  if (!event.ctrlKey && key.toLowerCase() === 's') {
+    downloadAllCalibratedHotspots();
+    event.preventDefault?.();
+    return true;
+  }
+  return false;
+}

--- a/ui/hotspots/hotspotGeometry.js
+++ b/ui/hotspots/hotspotGeometry.js
@@ -1,0 +1,148 @@
+/**
+ * Geometry helpers for hotspot interaction metadata.
+ */
+
+export const HOTSPOT_CANONICAL_SIZE = Object.freeze({ width: 1060, height: 520 });
+
+function finite(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function scaleX(value, targetSize, sourceSize) {
+  return finite(value) * finite(targetSize?.width, HOTSPOT_CANONICAL_SIZE.width) / finite(sourceSize?.width, HOTSPOT_CANONICAL_SIZE.width);
+}
+
+function scaleY(value, targetSize, sourceSize) {
+  return finite(value) * finite(targetSize?.height, HOTSPOT_CANONICAL_SIZE.height) / finite(sourceSize?.height, HOTSPOT_CANONICAL_SIZE.height);
+}
+
+export function rectShape(rect) {
+  return Object.freeze({
+    type: 'rect',
+    x: finite(rect?.x),
+    y: finite(rect?.y),
+    width: Math.max(0, finite(rect?.width)),
+    height: Math.max(0, finite(rect?.height)),
+  });
+}
+
+export function pointInRect(point, rect) {
+  return Boolean(point && rect
+    && Number.isFinite(point.x)
+    && Number.isFinite(point.y)
+    && point.x >= rect.x
+    && point.x <= rect.x + rect.width
+    && point.y >= rect.y
+    && point.y <= rect.y + rect.height);
+}
+
+export function pointInCircle(point, circle) {
+  if (!point || !circle || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return false;
+  const dx = point.x - circle.cx;
+  const dy = point.y - circle.cy;
+  return dx * dx + dy * dy <= circle.radius * circle.radius;
+}
+
+export function pointInPolygon(point, polygon) {
+  if (!point || !Array.isArray(polygon?.points) || polygon.points.length < 3) return false;
+  if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) return false;
+
+  let inside = false;
+  const points = polygon.points;
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const pi = points[i];
+    const pj = points[j];
+    const yi = finite(pi?.y);
+    const yj = finite(pj?.y);
+    const intersects = (yi > point.y) !== (yj > point.y)
+      && point.x < (finite(pj?.x) - finite(pi?.x)) * (point.y - yi) / ((yj - yi) || 1) + finite(pi?.x);
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function scaleShape(shape, targetSize = HOTSPOT_CANONICAL_SIZE, sourceSize = HOTSPOT_CANONICAL_SIZE) {
+  if (!shape || typeof shape !== 'object') return null;
+  if (shape.type === 'circle') {
+    const sx = finite(targetSize?.width, HOTSPOT_CANONICAL_SIZE.width) / finite(sourceSize?.width, HOTSPOT_CANONICAL_SIZE.width);
+    const sy = finite(targetSize?.height, HOTSPOT_CANONICAL_SIZE.height) / finite(sourceSize?.height, HOTSPOT_CANONICAL_SIZE.height);
+    return {
+      type: 'circle',
+      cx: scaleX(shape.cx, targetSize, sourceSize),
+      cy: scaleY(shape.cy, targetSize, sourceSize),
+      radius: finite(shape.radius) * Math.max(sx, sy),
+    };
+  }
+  if (shape.type === 'polygon') {
+    return {
+      type: 'polygon',
+      points: Array.isArray(shape.points)
+        ? shape.points.map((point) => ({
+            x: scaleX(point?.x, targetSize, sourceSize),
+            y: scaleY(point?.y, targetSize, sourceSize),
+          }))
+        : [],
+    };
+  }
+  return {
+    type: 'rect',
+    x: scaleX(shape.x, targetSize, sourceSize),
+    y: scaleY(shape.y, targetSize, sourceSize),
+    width: scaleX(shape.width, targetSize, sourceSize),
+    height: scaleY(shape.height, targetSize, sourceSize),
+  };
+}
+
+export function pointInShape(point, shape) {
+  if (!shape) return false;
+  if (shape.type === 'circle') return pointInCircle(point, shape);
+  if (shape.type === 'polygon') return pointInPolygon(point, shape);
+  return pointInRect(point, shape);
+}
+
+export function drawShapePath(ctx, shape) {
+  if (!ctx || !shape) return;
+  ctx.beginPath();
+  if (shape.type === 'circle') {
+    ctx.arc(shape.cx, shape.cy, shape.radius, 0, Math.PI * 2);
+    ctx.closePath();
+    return;
+  }
+  if (shape.type === 'polygon' && Array.isArray(shape.points) && shape.points.length > 0) {
+    ctx.moveTo(shape.points[0].x, shape.points[0].y);
+    for (let i = 1; i < shape.points.length; i++) {
+      ctx.lineTo(shape.points[i].x, shape.points[i].y);
+    }
+    ctx.closePath();
+    return;
+  }
+  ctx.rect(shape.x, shape.y, shape.width, shape.height);
+  ctx.closePath();
+}
+
+export function getShapeBounds(shape) {
+  if (!shape) return null;
+  if (shape.type === 'circle') {
+    return {
+      x: shape.cx - shape.radius,
+      y: shape.cy - shape.radius,
+      width: shape.radius * 2,
+      height: shape.radius * 2,
+    };
+  }
+  if (shape.type === 'polygon' && Array.isArray(shape.points) && shape.points.length > 0) {
+    const xs = shape.points.map((point) => finite(point?.x));
+    const ys = shape.points.map((point) => finite(point?.y));
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  }
+  return {
+    x: finite(shape.x),
+    y: finite(shape.y),
+    width: Math.max(0, finite(shape.width)),
+    height: Math.max(0, finite(shape.height)),
+  };
+}

--- a/ui/hotspots/hotspotGeometry.js
+++ b/ui/hotspots/hotspotGeometry.js
@@ -21,19 +21,21 @@ export function rectShape(rect) {
     type: 'rect',
     x: finite(rect?.x),
     y: finite(rect?.y),
-    width: Math.max(0, finite(rect?.width)),
-    height: Math.max(0, finite(rect?.height)),
+    width: Math.max(0, finite(Number.isFinite(rect?.width) ? rect.width : rect?.w)),
+    height: Math.max(0, finite(Number.isFinite(rect?.height) ? rect.height : rect?.h)),
   });
 }
 
 export function pointInRect(point, rect) {
+  const width = Number.isFinite(rect?.width) ? rect.width : rect?.w;
+  const height = Number.isFinite(rect?.height) ? rect.height : rect?.h;
   return Boolean(point && rect
     && Number.isFinite(point.x)
     && Number.isFinite(point.y)
     && point.x >= rect.x
-    && point.x <= rect.x + rect.width
+    && point.x <= rect.x + width
     && point.y >= rect.y
-    && point.y <= rect.y + rect.height);
+    && point.y <= rect.y + height);
 }
 
 export function pointInCircle(point, circle) {
@@ -88,8 +90,8 @@ export function scaleShape(shape, targetSize = HOTSPOT_CANONICAL_SIZE, sourceSiz
     type: 'rect',
     x: scaleX(shape.x, targetSize, sourceSize),
     y: scaleY(shape.y, targetSize, sourceSize),
-    width: scaleX(shape.width, targetSize, sourceSize),
-    height: scaleY(shape.height, targetSize, sourceSize),
+    width: scaleX(Number.isFinite(shape.width) ? shape.width : shape.w, targetSize, sourceSize),
+    height: scaleY(Number.isFinite(shape.height) ? shape.height : shape.h, targetSize, sourceSize),
   };
 }
 
@@ -116,7 +118,12 @@ export function drawShapePath(ctx, shape) {
     ctx.closePath();
     return;
   }
-  ctx.rect(shape.x, shape.y, shape.width, shape.height);
+  ctx.rect(
+    shape.x,
+    shape.y,
+    Number.isFinite(shape.width) ? shape.width : shape.w,
+    Number.isFinite(shape.height) ? shape.height : shape.h
+  );
   ctx.closePath();
 }
 
@@ -142,7 +149,7 @@ export function getShapeBounds(shape) {
   return {
     x: finite(shape.x),
     y: finite(shape.y),
-    width: Math.max(0, finite(shape.width)),
-    height: Math.max(0, finite(shape.height)),
+    width: Math.max(0, finite(Number.isFinite(shape.width) ? shape.width : shape.w)),
+    height: Math.max(0, finite(Number.isFinite(shape.height) ? shape.height : shape.h)),
   };
 }

--- a/ui/hotspots/workstationHotspotGeometry.generated.js
+++ b/ui/hotspots/workstationHotspotGeometry.generated.js
@@ -1,0 +1,63 @@
+/**
+ * Generated workstation hotspot calibration geometry.
+ *
+ * Geometry-only: station names, purposes, zones, and feedback semantics live in
+ * workstationHotspots.js so calibration exports cannot rewrite meaning.
+ */
+
+export const CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY = Object.freeze({
+  engineCrystalHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 539.1, y: 46.8 }, { x: 617.1, y: 62.8 }, { x: 641.1, y: 180.8 }, { x: 619.1, y: 332.8 }, { x: 585.1, y: 382.8 }, { x: 533.1, y: 360.8 }, { x: 505.1, y: 230.8 }, { x: 513.1, y: 92.8 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 551.1, y: 74.8 }, { x: 599.1, y: 88.8 }, { x: 613.1, y: 188.8 }, { x: 595.1, y: 342.8 }, { x: 567.1, y: 370.8 }, { x: 537.1, y: 342.8 }, { x: 523.1, y: 228.8 }, { x: 529.1, y: 104.8 }]) }),
+    popoverAnchor: Object.freeze({ x: 519, y: 97.5 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  intakeDeskHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 92.2, y: 130 }, { x: 238.2, y: 120 }, { x: 264.2, y: 213 }, { x: 234.2, y: 250 }, { x: 116.2, y: 254 }, { x: 82.2, y: 192 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 116.2, y: 146 }, { x: 222.2, y: 140 }, { x: 240.2, y: 210 }, { x: 218.2, y: 232 }, { x: 130.2, y: 234 }, { x: 106.2, y: 184 }]) }),
+    popoverAnchor: Object.freeze({ x: 70.7, y: 147.1 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  researchMonitorHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 391, y: 163.3 }, { x: 453.3, y: 145.9 }, { x: 459, y: 248.7 }, { x: 336.7, y: 316 }, { x: 293.2, y: 272.6 }, { x: 296.1, y: 213.9 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 389.5, y: 178.5 }, { x: 443.1, y: 162.5 }, { x: 444.6, y: 245.1 }, { x: 339.6, y: 297.2 }, { x: 310.6, y: 266.8 }, { x: 310.6, y: 221.9 }]) }),
+    popoverAnchor: Object.freeze({ x: 325.2, y: 203.4 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  shopifyMonitorHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 687.1, y: 145.2 }, { x: 876.1, y: 227.7 }, { x: 912.3, y: 282 }, { x: 837.8, y: 325.7 }, { x: 648, y: 248.7 }, { x: 646.6, y: 210.3 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 692.9, y: 164 }, { x: 867.4, y: 237.8 }, { x: 892.7, y: 278.4 }, { x: 832.6, y: 311.7 }, { x: 660.3, y: 243.6 }, { x: 662.5, y: 211 }]) }),
+    popoverAnchor: Object.freeze({ x: 726.6, y: 205.7 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  renderMonitorHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 632.8, y: 376.1 }, { x: 687.1, y: 395 }, { x: 721.9, y: 465.9 }, { x: 715.2, y: 513.6 }, { x: 498.9, y: 510.8 }, { x: 501, y: 436.9 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 635, y: 395 }, { x: 676.3, y: 411.6 }, { x: 700.9, y: 471.7 }, { x: 700.9, y: 496.3 }, { x: 516.2, y: 496.3 }, { x: 517, y: 445.6 }]) }),
+    popoverAnchor: Object.freeze({ x: 576.7, y: 451.1 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  supportMonitorHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 759.5, y: 369.6 }, { x: 915.2, y: 292.1 }, { x: 1005.7, y: 354.4 }, { x: 1008.6, y: 413.8 }, { x: 776.2, y: 516.6 }, { x: 719.7, y: 430.4 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 776.9, y: 386.3 }, { x: 917.4, y: 325.4 }, { x: 984.7, y: 368.9 }, { x: 986.1, y: 405.8 }, { x: 787.8, y: 481.1 }, { x: 748.7, y: 432.6 }]) }),
+    popoverAnchor: Object.freeze({ x: 831.5, y: 411.4 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  approvalDeskHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 198, y: 391.4 }, { x: 256, y: 383.4 }, { x: 276, y: 423.4 }, { x: 248, y: 455.4 }, { x: 204, y: 447.4 }, { x: 184, y: 413.4 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 212, y: 399.4 }, { x: 250, y: 395.4 }, { x: 264, y: 421.4 }, { x: 244, y: 443.4 }, { x: 214, y: 437.4 }, { x: 200, y: 415.4 }]) }),
+    popoverAnchor: Object.freeze({ x: 274, y: 387.4 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  archiveShelfHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 1023.1, y: 81.4 }, { x: 1049.9, y: 124.2 }, { x: 1037.5, y: 355.9 }, { x: 1000.6, y: 275.5 }, { x: 820.3, y: 195.1 }, { x: 825.4, y: 20.6 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 1012.2, y: 98.1 }, { x: 1037.5, y: 130.7 }, { x: 1030.3, y: 314.6 }, { x: 1001.3, y: 261 }, { x: 836.3, y: 185.7 }, { x: 839.9, y: 43.8 }]) }),
+    popoverAnchor: Object.freeze({ x: 856.9, y: 67.4 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+  anomalyShelfHotspot: Object.freeze({
+    hitArea: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 719.4, y: 43.1 }, { x: 775.4, y: 43.1 }, { x: 789.4, y: 89.1 }, { x: 763.4, y: 121.1 }, { x: 721.4, y: 109.1 }, { x: 707.4, y: 71.1 }]) }),
+    highlightShape: Object.freeze({ type: 'polygon', points: Object.freeze([{ x: 731.4, y: 55.1 }, { x: 767.4, y: 55.1 }, { x: 777.4, y: 83.1 }, { x: 759.4, y: 105.1 }, { x: 729.4, y: 97.1 }, { x: 719.4, y: 73.1 }]) }),
+    popoverAnchor: Object.freeze({ x: 785.4, y: 49.1 }),
+    visualStyle: Object.freeze({ tint: 'cyan', intensity: 1, pulse: true, sparkle: false }),
+  }),
+});

--- a/ui/hotspots/workstationHotspots.js
+++ b/ui/hotspots/workstationHotspots.js
@@ -1,0 +1,195 @@
+/**
+ * Workstation hotspot registry.
+ *
+ * Interaction metadata only: fixed canvas hit areas, friendly station titles,
+ * short semantic purposes, and render anchors for hover highlights.
+ */
+
+import { SCENE_ANCHORS } from '../../rendering/scene-anchors.js';
+import { HOTSPOT_CANONICAL_SIZE, getShapeBounds, rectShape } from './hotspotGeometry.js';
+import { CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY } from './workstationHotspotGeometry.generated.js';
+
+export { HOTSPOT_CANONICAL_SIZE };
+
+const GEOMETRY_KEYS = Object.freeze(['hitArea', 'highlightShape', 'popoverAnchor', 'visualStyle']);
+const FORBIDDEN_GENERATED_GEOMETRY_KEYS = Object.freeze([
+  'id',
+  'title',
+  'label',
+  'purpose',
+  'zoneIds',
+  'worldZoneIds',
+  'feedbackKind',
+  'semanticType',
+]);
+
+function boundsFrom(anchor, inflate = 0) {
+  const b = anchor.bounds || { x: anchor.x - 20, y: anchor.y - 20, width: 40, height: 40 };
+  return {
+    x: b.x - inflate,
+    y: b.y - inflate,
+    width: b.width + inflate * 2,
+    height: b.height + inflate * 2,
+  };
+}
+
+function generatedGeometryFor(id) {
+  const geometry = CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY[id] || null;
+  if (!geometry) return null;
+  return Object.fromEntries(GEOMETRY_KEYS
+    .filter((key) => geometry[key] !== undefined)
+    .map((key) => [key, geometry[key]]));
+}
+
+function hotspot(config) {
+  const geometry = generatedGeometryFor(config.id) || {};
+  const legacyBounds = rectShape(config.bounds || getShapeBounds(geometry.hitArea));
+  const hitArea = geometry.hitArea ? Object.freeze(geometry.hitArea) : config.hitArea ? Object.freeze(config.hitArea) : legacyBounds;
+  const highlightShape = geometry.highlightShape ? Object.freeze(geometry.highlightShape) : config.highlightShape ? Object.freeze(config.highlightShape) : hitArea;
+  const bounds = config.bounds ? legacyBounds : rectShape(getShapeBounds(hitArea));
+  const popoverAnchor = geometry.popoverAnchor || config.popoverAnchor || {
+    x: bounds.x + bounds.width / 2,
+    y: bounds.y,
+  };
+  const visualStyle = geometry.visualStyle || config.visualStyle || {};
+  return Object.freeze({
+    id: config.id,
+    title: config.title,
+    label: config.title,
+    purpose: config.purpose,
+    worldZoneIds: Object.freeze(config.worldZoneIds || []),
+    zoneIds: Object.freeze(config.zoneIds || []),
+    bounds,
+    hitArea,
+    highlightShape,
+    popoverAnchor: Object.freeze({ x: popoverAnchor.x, y: popoverAnchor.y }),
+    highlightAnchor: Object.freeze(config.highlightAnchor || config.bounds),
+    feedbackAnchor: Object.freeze(config.highlightAnchor || config.bounds),
+    feedbackKind: config.feedbackKind || 'monitor',
+    visualStyle: Object.freeze({
+      tint: typeof visualStyle.tint === 'string' ? visualStyle.tint : 'cyan',
+      intensity: Number.isFinite(visualStyle.intensity) ? visualStyle.intensity : 1,
+      pulse: visualStyle.pulse !== false,
+      sparkle: visualStyle.sparkle === true,
+    }),
+  });
+}
+
+export function validateWorkstationHotspotGeometry(
+  canonicalConfigs,
+  generatedGeometry = CALIBRATED_WORKSTATION_HOTSPOT_GEOMETRY
+) {
+  const errors = [];
+  const ids = new Set();
+  for (const config of canonicalConfigs || []) {
+    if (!config?.id) {
+      errors.push('Canonical hotspot is missing an id');
+      continue;
+    }
+    if (ids.has(config.id)) errors.push(`Duplicate canonical hotspot id: ${config.id}`);
+    ids.add(config.id);
+    if (!generatedGeometry[config.id]) errors.push(`Missing generated geometry for canonical hotspot: ${config.id}`);
+  }
+
+  for (const [id, geometry] of Object.entries(generatedGeometry || {})) {
+    if (!ids.has(id)) errors.push(`Generated geometry id has no canonical hotspot: ${id}`);
+    for (const key of FORBIDDEN_GENERATED_GEOMETRY_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(geometry || {}, key)) {
+        errors.push(`Generated geometry for ${id} contains forbidden metadata key: ${key}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid workstation hotspot geometry:\n${errors.join('\n')}`);
+  }
+  return true;
+}
+
+export const CANONICAL_WORKSTATION_HOTSPOT_CONFIGS = Object.freeze([
+  Object.freeze({
+    id: 'engineCrystalHotspot',
+    title: 'Engine Core',
+    purpose: 'Queue and engine state',
+    worldZoneIds: ['engineCrystal'],
+    zoneIds: ['ENQUEUED'],
+    highlightAnchor: SCENE_ANCHORS.crystal.engineCrystal,
+    feedbackKind: 'crystal',
+  }),
+  Object.freeze({
+    id: 'intakeDeskHotspot',
+    title: 'Intake Desk',
+    purpose: 'New work intake',
+    worldZoneIds: ['intakeDesk'],
+    zoneIds: ['CREATED'],
+    highlightAnchor: SCENE_ANCHORS.shelves.intakeShelf,
+    feedbackKind: 'shelf',
+  }),
+  Object.freeze({
+    id: 'researchMonitorHotspot',
+    title: 'Research Desk',
+    purpose: 'Trend and product scans',
+    worldZoneIds: ['researchDesk'],
+    zoneIds: ['CLAIMED'],
+    highlightAnchor: SCENE_ANCHORS.desks['desk-0'],
+  }),
+  Object.freeze({
+    id: 'shopifyMonitorHotspot',
+    title: 'Shopify Desk',
+    purpose: 'Listings and product work',
+    worldZoneIds: ['shopifyDesk'],
+    zoneIds: ['CLAIMED'],
+    highlightAnchor: SCENE_ANCHORS.desks['desk-1'],
+  }),
+  Object.freeze({
+    id: 'renderMonitorHotspot',
+    title: 'Render Desk',
+    purpose: 'Images and design renders',
+    worldZoneIds: ['renderDesk'],
+    zoneIds: ['EXECUTE_FINISHED'],
+    highlightAnchor: SCENE_ANCHORS.desks['desk-4'],
+  }),
+  Object.freeze({
+    id: 'supportMonitorHotspot',
+    title: 'Support Desk',
+    purpose: 'Messages and support replies',
+    worldZoneIds: ['supportDesk'],
+    zoneIds: ['CLAIMED'],
+    highlightAnchor: SCENE_ANCHORS.desks['desk-5'],
+  }),
+  Object.freeze({
+    id: 'approvalDeskHotspot',
+    title: 'Approval Desk',
+    purpose: 'Review before delivery',
+    worldZoneIds: ['approvalDesk'],
+    zoneIds: ['EXECUTE_FINISHED'],
+    highlightAnchor: SCENE_ANCHORS.approvalDesk.deliveryDesk,
+    feedbackKind: 'shelf',
+  }),
+  Object.freeze({
+    id: 'archiveShelfHotspot',
+    title: 'Archive Shelf',
+    purpose: 'Completed work archive',
+    worldZoneIds: ['archiveLibrary'],
+    zoneIds: ['ACKED'],
+    highlightAnchor: SCENE_ANCHORS.decor.archiveShelf,
+    feedbackKind: 'shelf',
+  }),
+  Object.freeze({
+    id: 'anomalyShelfHotspot',
+    title: 'Anomaly Shelf',
+    purpose: 'Work needing attention',
+    worldZoneIds: ['anomalyShelf'],
+    zoneIds: ['ACKED'],
+    highlightAnchor: SCENE_ANCHORS.warningShelf.anomalyShelf,
+    feedbackKind: 'warning',
+  }),
+]);
+
+validateWorkstationHotspotGeometry(CANONICAL_WORKSTATION_HOTSPOT_CONFIGS);
+
+export const WORKSTATION_HOTSPOTS = Object.freeze(CANONICAL_WORKSTATION_HOTSPOT_CONFIGS.map(hotspot));
+
+export function getWorkstationHotspotById(id) {
+  return WORKSTATION_HOTSPOTS.find((hotspot) => hotspot.id === id) || null;
+}

--- a/ui/hotspots/workstationSemantics.js
+++ b/ui/hotspots/workstationSemantics.js
@@ -1,0 +1,408 @@
+/**
+ * Friendly workstation semantics.
+ *
+ * Static station copy and matching hints only. Geometry stays in
+ * workstationHotspots.js; renderer-facing status should come from view models.
+ */
+
+export const WORKSTATION_SEMANTICS = Object.freeze({
+  engineCrystalHotspot: Object.freeze({
+    stationKey: 'engine_core',
+    title: 'Engine Core',
+    purpose: 'Keeps the queue moving through the workshop.',
+    idleText: 'Queue is healthy',
+    role: 'orchestration',
+    tone: 'core',
+    statusLabel: 'engine',
+    tokens: Object.freeze([]),
+  }),
+  intakeDeskHotspot: Object.freeze({
+    stationKey: 'intake_desk',
+    title: 'Intake Desk',
+    purpose: 'Collects new requests before work begins.',
+    idleText: 'Ready for new requests',
+    role: 'intake',
+    tone: 'quiet',
+    statusLabel: 'request',
+    tokens: Object.freeze([]),
+  }),
+  researchMonitorHotspot: Object.freeze({
+    stationKey: 'research_desk',
+    title: 'Research Desk',
+    purpose: 'Scans trends, signals, and product ideas.',
+    idleText: 'Ready to scan trends',
+    role: 'research',
+    tone: 'curious',
+    statusLabel: 'scan',
+    tokens: Object.freeze(['trend', 'research', 'scan', 'signal', 'candidate']),
+  }),
+  shopifyMonitorHotspot: Object.freeze({
+    stationKey: 'shopify_desk',
+    title: 'Shopify Desk',
+    purpose: 'Prepares listings, products, and publishing work.',
+    idleText: 'Listings are quiet',
+    role: 'commerce',
+    tone: 'shop',
+    statusLabel: 'listing',
+    tokens: Object.freeze(['shopify', 'listing', 'product', 'order', 'publish']),
+  }),
+  renderMonitorHotspot: Object.freeze({
+    stationKey: 'render_desk',
+    title: 'Render Desk',
+    purpose: 'Shapes image, render, and design work.',
+    idleText: 'Render table is idle',
+    role: 'rendering',
+    tone: 'creative',
+    statusLabel: 'render',
+    tokens: Object.freeze(['image', 'render', 'design', 'prompt']),
+  }),
+  supportMonitorHotspot: Object.freeze({
+    stationKey: 'support_desk',
+    title: 'Support Desk',
+    purpose: 'Watches Discord, messages, and support replies.',
+    idleText: 'No messages waiting',
+    role: 'support',
+    tone: 'social',
+    statusLabel: 'message',
+    tokens: Object.freeze(['discord', 'support', 'message', 'reply', 'notification']),
+  }),
+  approvalDeskHotspot: Object.freeze({
+    stationKey: 'approval_desk',
+    title: 'Approval Desk',
+    purpose: 'Reviews finished work before delivery.',
+    idleText: 'Nothing awaiting review',
+    role: 'approval',
+    tone: 'review',
+    statusLabel: 'approval',
+    tokens: Object.freeze([]),
+  }),
+  archiveShelfHotspot: Object.freeze({
+    stationKey: 'archive_shelf',
+    title: 'Archive Shelf',
+    purpose: 'Stores completed results and history.',
+    idleText: 'Archive is quiet',
+    role: 'archive',
+    tone: 'archive',
+    statusLabel: 'archive',
+    tokens: Object.freeze([]),
+  }),
+  anomalyShelfHotspot: Object.freeze({
+    stationKey: 'anomaly_shelf',
+    title: 'Anomaly Shelf',
+    purpose: 'Flags work that needs attention.',
+    idleText: 'No alerts right now',
+    role: 'attention',
+    tone: 'warning',
+    statusLabel: 'attention',
+    tokens: Object.freeze([]),
+  }),
+});
+
+export function getWorkstationSemanticMetadata(hotspotId) {
+  return WORKSTATION_SEMANTICS[hotspotId] || null;
+}
+
+const MAX_BODY_LINES = 2;
+
+function count(summary, key) {
+  const value = summary?.[key];
+  return Number.isFinite(value) ? value : 0;
+}
+
+function pushLine(lines, text) {
+  if (text && lines.length < MAX_BODY_LINES) lines.push(text);
+}
+
+function pushInspectionLine(lines, text) {
+  if (text && lines.length < MAX_INSPECTION_LINES) lines.push(text);
+}
+
+function plural(countValue, singular, pluralValue = `${singular}s`) {
+  return countValue === 1 ? singular : pluralValue;
+}
+
+function countLine(countValue, label) {
+  if (countValue <= 0) return null;
+  return `${countValue} ${label}`;
+}
+
+function genericActiveLine(summary, metadata) {
+  const active = count(summary, 'semanticActiveTasks');
+  if (active <= 0) return null;
+  const label = metadata?.statusLabel || 'task';
+  return `${active} ${label} ${plural(active, 'active', 'active')}`;
+}
+
+function buildStatusLines(hotspotId, summary, metadata) {
+  const lines = [];
+
+  if (hotspotId === 'engineCrystalHotspot') {
+    pushLine(lines, countLine(count(summary, 'focusedWaitingTasks'), 'queued'));
+    pushLine(lines, countLine(count(summary, 'focusedActiveTasks'), 'active'));
+    pushLine(lines, countLine(count(summary, 'focusedProcessingTasks'), 'processing'));
+    if (count(summary, 'focusedFailedTasks') > 0) pushLine(lines, 'attention needed');
+    return lines;
+  }
+
+  if (hotspotId === 'intakeDeskHotspot') {
+    pushLine(lines, countLine(count(summary, 'focusedWaitingTasks'), 'waiting'));
+    return lines;
+  }
+
+  if (hotspotId === 'approvalDeskHotspot') {
+    pushLine(lines, countLine(count(summary, 'focusedProcessingTasks'), 'awaiting approval'));
+    pushLine(lines, countLine(count(summary, 'focusedActiveTasks'), 'approval active'));
+    return lines;
+  }
+
+  if (hotspotId === 'archiveShelfHotspot') {
+    const completed = count(summary, 'focusedCompletedTasks');
+    if (completed > 0) pushLine(lines, `archive: ${completed} complete`);
+    return lines;
+  }
+
+  if (hotspotId === 'anomalyShelfHotspot') {
+    const failed = count(summary, 'focusedFailedTasks');
+    if (failed > 0 || summary?.anomaly) pushLine(lines, 'attention needed');
+    pushLine(lines, countLine(failed, 'failed'));
+    return lines;
+  }
+
+  pushLine(lines, genericActiveLine(summary, metadata));
+  if (count(summary, 'failedTasks') > 0 || summary?.anomaly) pushLine(lines, 'attention needed');
+  return lines;
+}
+
+export function buildWorkstationPopoverViewModel(component) {
+  const hotspotId = component?.id || null;
+  const metadata = getWorkstationSemanticMetadata(hotspotId);
+  const summary = component?.summary && typeof component.summary === 'object' ? component.summary : {};
+  const lines = buildStatusLines(hotspotId, summary, metadata);
+  const fallback = metadata?.idleText || metadata?.purpose || component?.purpose || 'Workstation is idle';
+
+  if (lines.length === 0) pushLine(lines, fallback);
+
+  return Object.freeze({
+    hotspotId,
+    title: metadata?.title || component?.title || component?.label || 'Workstation',
+    lines: Object.freeze(lines.slice(0, MAX_BODY_LINES)),
+    tone: metadata?.tone || 'quiet',
+    maxLines: MAX_BODY_LINES,
+  });
+}
+
+export function buildWorkstationNormalSummaryRows(component) {
+  return buildWorkstationPopoverViewModel(component).lines;
+}
+
+const VISUAL_STATES = Object.freeze(['idle', 'queued', 'working', 'awaiting', 'completed', 'failed']);
+const VISUAL_EFFECTS = Object.freeze(['none', 'pulse', 'shimmer', 'sparkle', 'glint']);
+
+function visualModel(hotspotId, metadata, visualState, effect, intensity = 0.7) {
+  const safeState = VISUAL_STATES.includes(visualState) ? visualState : 'idle';
+  const safeEffect = VISUAL_EFFECTS.includes(effect) ? effect : 'none';
+  return Object.freeze({
+    hotspotId,
+    visualState: safeState,
+    tone: metadata?.tone || 'quiet',
+    intensity: safeState === 'idle' ? 0 : Math.min(1, Math.max(0.18, intensity)),
+    effect: safeState === 'idle' ? 'none' : safeEffect,
+  });
+}
+
+export function buildWorkstationVisualStateViewModel(component) {
+  const hotspotId = component?.id || null;
+  const metadata = getWorkstationSemanticMetadata(hotspotId);
+  const summary = component?.summary && typeof component.summary === 'object' ? component.summary : {};
+
+  if (summary.anomaly || count(summary, 'focusedFailedTasks') > 0 || count(summary, 'failedTasks') > 0) {
+    return visualModel(hotspotId, metadata, 'failed', 'glint', 0.9);
+  }
+
+  if (hotspotId === 'engineCrystalHotspot') {
+    if (count(summary, 'focusedProcessingTasks') > 0 || count(summary, 'focusedActiveTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'working', 'shimmer', 0.72);
+    }
+    if (count(summary, 'focusedWaitingTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'queued', 'pulse', 0.58);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'intakeDeskHotspot') {
+    if (count(summary, 'focusedWaitingTasks') > 0 || count(summary, 'createdTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'queued', 'pulse', 0.52);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'approvalDeskHotspot') {
+    if (count(summary, 'focusedProcessingTasks') > 0 || count(summary, 'focusedActiveTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'awaiting', 'pulse', 0.66);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'archiveShelfHotspot') {
+    if (count(summary, 'focusedCompletedTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'completed', 'sparkle', 0.48);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'anomalyShelfHotspot') {
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'shopifyMonitorHotspot') {
+    if (count(summary, 'focusedProcessingTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'awaiting', 'pulse', 0.58);
+    }
+    if (count(summary, 'semanticActiveTasks') > 0 || count(summary, 'focusedActiveTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'working', 'shimmer', 0.58);
+    }
+    if (count(summary, 'focusedWaitingTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'queued', 'pulse', 0.44);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (hotspotId === 'supportMonitorHotspot') {
+    if (count(summary, 'semanticActiveTasks') > 0 || count(summary, 'focusedActiveTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'working', 'shimmer', 0.54);
+    }
+    if (count(summary, 'focusedWaitingTasks') > 0) {
+      return visualModel(hotspotId, metadata, 'queued', 'pulse', 0.42);
+    }
+    return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+  }
+
+  if (count(summary, 'semanticActiveTasks') > 0 || count(summary, 'focusedActiveTasks') > 0) {
+    return visualModel(hotspotId, metadata, 'working', 'shimmer', 0.56);
+  }
+
+  return visualModel(hotspotId, metadata, 'idle', 'none', 0);
+}
+
+const MAX_INSPECTION_LINES = 3;
+const MAX_TASK_SUMMARIES = 3;
+
+function titleCaseToken(value) {
+  return String(value || '')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function friendlyTaskLabel(workItem, metadata) {
+  const text = [workItem?.title, workItem?.taskType]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join(' ')
+    .toLowerCase();
+  if (text.includes('trend') || text.includes('research') || text.includes('scan')) return 'Trend scan';
+  if (text.includes('image') || text.includes('render') || text.includes('mockup') || text.includes('design')) return 'Image render';
+  if (text.includes('shopify') || text.includes('listing') || text.includes('product') || text.includes('publish')) return 'Listing work';
+  if (text.includes('discord') || text.includes('support') || text.includes('message') || text.includes('reply')) return 'Support message';
+  if (text.includes('approval') || text.includes('approve') || text.includes('review')) return 'Review item';
+  if (workItem?.anomaly) return 'Needs attention';
+  return metadata?.statusLabel ? titleCaseToken(`${metadata.statusLabel} work`) : 'Work item';
+}
+
+function friendlyTaskState(visualState) {
+  if (visualState === 'error') return 'needs attention';
+  if (visualState === 'completed') return 'complete';
+  if (visualState === 'processing') return 'processing';
+  if (visualState === 'working') return 'active';
+  if (visualState === 'idle' || visualState === 'waiting') return 'waiting';
+  return null;
+}
+
+function buildTaskSummaries(workItems, metadata) {
+  if (!Array.isArray(workItems)) return [];
+  const rows = [];
+  for (const item of workItems) {
+    const state = friendlyTaskState(item?.visualState);
+    const label = friendlyTaskLabel(item, metadata);
+    const text = state ? `${label}: ${state}` : label;
+    if (!rows.includes(text)) rows.push(text);
+    if (rows.length >= MAX_TASK_SUMMARIES) break;
+  }
+  return rows;
+}
+
+function statusLabelForInspection(hotspotId, visualModelValue, summary) {
+  if (visualModelValue.visualState === 'failed') return 'Needs attention';
+  if (visualModelValue.visualState === 'awaiting') return 'Awaiting review';
+  if (visualModelValue.visualState === 'completed') return 'Recently completed';
+  if (visualModelValue.visualState === 'working') return 'Active';
+  if (visualModelValue.visualState === 'queued') return hotspotId === 'intakeDeskHotspot' ? 'Requests waiting' : 'Queued';
+  if (count(summary, 'focusedWaitingTasks') > 0) return 'Waiting';
+  return 'Idle';
+}
+
+function idleInspectionLine(metadata) {
+  if (!metadata) return 'Ready for work';
+  if (metadata.stationKey === 'render_desk') return 'Ready for image and mockup work';
+  if (metadata.stationKey === 'research_desk') return 'Ready for trend research';
+  if (metadata.stationKey === 'shopify_desk') return 'Ready for listing work';
+  if (metadata.stationKey === 'support_desk') return 'Ready for messages';
+  if (metadata.stationKey === 'approval_desk') return 'Ready for review';
+  if (metadata.stationKey === 'archive_shelf') return 'Ready to store completed results';
+  if (metadata.stationKey === 'anomaly_shelf') return 'Watching for work that needs attention';
+  if (metadata.stationKey === 'intake_desk') return 'Ready for new requests';
+  if (metadata.stationKey === 'engine_core') return 'Queue is healthy';
+  return metadata.idleText || metadata.purpose || 'Ready for work';
+}
+
+function buildInspectionLines(component, metadata, visualModelValue, taskSummaries) {
+  const summary = component?.summary || {};
+  const lines = [];
+  if (visualModelValue.visualState === 'idle' && taskSummaries.length === 0) {
+    pushInspectionLine(lines, idleInspectionLine(metadata));
+    return lines.slice(0, MAX_INSPECTION_LINES);
+  }
+
+  if (component?.id === 'engineCrystalHotspot') {
+    pushInspectionLine(lines, countLine(count(summary, 'focusedWaitingTasks'), 'queued'));
+    pushInspectionLine(lines, countLine(count(summary, 'focusedProcessingTasks'), 'processing'));
+    pushInspectionLine(lines, countLine(count(summary, 'focusedActiveTasks'), 'active'));
+    return lines.slice(0, MAX_INSPECTION_LINES);
+  }
+
+  if (component?.id === 'archiveShelfHotspot') {
+    pushInspectionLine(lines, countLine(count(summary, 'focusedCompletedTasks'), 'completed result'));
+    return lines.slice(0, MAX_INSPECTION_LINES);
+  }
+
+  if (component?.id === 'anomalyShelfHotspot') {
+    if (count(summary, 'focusedFailedTasks') > 0 || summary.anomaly) pushInspectionLine(lines, 'Attention needed');
+    pushInspectionLine(lines, countLine(count(summary, 'focusedFailedTasks'), 'failed item'));
+    return lines.slice(0, MAX_INSPECTION_LINES);
+  }
+
+  pushInspectionLine(lines, countLine(count(summary, 'focusedWaitingTasks'), 'waiting'));
+  pushInspectionLine(lines, countLine(count(summary, 'focusedProcessingTasks'), 'processing'));
+  pushInspectionLine(lines, countLine(count(summary, 'semanticActiveTasks') || count(summary, 'focusedActiveTasks'), 'active'));
+  if (lines.length === 0 && taskSummaries.length > 0) pushInspectionLine(lines, metadata?.purpose || 'Work is attached here');
+  return lines.slice(0, MAX_INSPECTION_LINES);
+}
+
+export function buildWorkstationInspectionViewModel(component) {
+  const hotspotId = component?.id || null;
+  const metadata = getWorkstationSemanticMetadata(hotspotId);
+  const visualState = component?.visualStateViewModel || buildWorkstationVisualStateViewModel(component);
+  const summary = component?.summary && typeof component.summary === 'object' ? component.summary : {};
+  const taskSummaries = buildTaskSummaries(component?.stationWorkItems, metadata);
+  const lines = buildInspectionLines(component, metadata, visualState, taskSummaries);
+
+  return Object.freeze({
+    stationId: metadata?.stationKey || hotspotId,
+    hotspotId,
+    title: metadata?.title || component?.title || component?.label || 'Workstation',
+    statusLabel: statusLabelForInspection(hotspotId, visualState, summary),
+    tone: metadata?.tone || 'quiet',
+    lines: Object.freeze(lines.slice(0, MAX_INSPECTION_LINES)),
+    taskSummaries: Object.freeze(taskSummaries.slice(0, MAX_TASK_SUMMARIES)),
+  });
+}

--- a/ui/interactions/interactionTargets.js
+++ b/ui/interactions/interactionTargets.js
@@ -1,0 +1,191 @@
+/**
+ * Priority-based interaction targets for the projected Slothworld scene.
+ *
+ * Targets are built from selector-safe render component descriptors and
+ * workstation interaction metadata. No raw event data belongs here.
+ */
+
+import { pointInShape, scaleShape } from '../hotspots/hotspotGeometry.js';
+import { buildAgentInspectionViewModel } from '../selectors/agentInspectionSelectors.js';
+
+export const INTERACTION_PRIORITIES = Object.freeze({
+  taskResult: 100,
+  taskMarker: 90,
+  agent: 70,
+  station: 40,
+});
+
+const TASK_MARKER_SIZE = Object.freeze({ width: 36, height: 16 });
+const COMPACT_RESULT_SIZE = Object.freeze({ width: 44, height: 22 });
+const AGENT_FALLBACK_BOUNDS = Object.freeze({ width: 64, height: 54, dx: 0, dy: 0 });
+const AGENT_DESK_BOUNDS = Object.freeze({
+  'desk-0': Object.freeze({ width: 180, height: 170, dx: 0,  dy: 0 }),
+  'desk-1': Object.freeze({ width: 300, height: 150, dx: 0,  dy: 0 }),
+  'desk-2': Object.freeze({ width: 300, height: 150, dx: 0,  dy: 0 }),
+  'desk-3': Object.freeze({ width: 200, height: 175, dx: 0,  dy: 0 }),
+  'desk-4': Object.freeze({ width: 300, height: 150, dx: 14, dy: 0 }),
+  'desk-5': Object.freeze({ width: 300, height: 150, dx: 14, dy: 0 }),
+});
+
+function finite(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function posOf(component, entityPositions) {
+  const fromMap = entityPositions && component?.id ? entityPositions.get(component.id) : null;
+  if (Number.isFinite(fromMap?.x) && Number.isFinite(fromMap?.y)) return fromMap;
+  return { x: finite(component?.x), y: finite(component?.y) };
+}
+
+function rect(x, y, width, height) {
+  return { type: 'rect', x, y, width: Math.max(0, width), height: Math.max(0, height) };
+}
+
+function taskMarkerViewModel(component) {
+  const state = typeof component?.visualState === 'string' ? component.visualState : 'unknown';
+  const title = typeof component?.title === 'string' && component.title.trim()
+    ? component.title.trim()
+    : 'Task';
+  return Object.freeze({
+    title: 'Task',
+    lines: Object.freeze([
+      title,
+      state === 'error' ? 'Needs attention' : state === 'processing' ? 'Processing' : state === 'working' ? 'Active' : 'Waiting',
+    ]),
+    tone: state === 'error' ? 'warning' : 'task',
+  });
+}
+
+function taskResultViewModel(component) {
+  const panel = component?.trendPanelState && typeof component.trendPanelState === 'object'
+    ? component.trendPanelState
+    : {};
+  const keyword = typeof panel.keyword === 'string' && panel.keyword.trim() ? panel.keyword.trim() : 'result';
+  const results = Array.isArray(panel.results) ? panel.results : [];
+  const lines = results
+    .map((entry) => {
+      if (entry && typeof entry === 'object') return typeof entry.item === 'string' ? entry.item : '';
+      return typeof entry === 'string' ? entry : '';
+    })
+    .filter(Boolean)
+    .slice(-3);
+  if (lines.length === 0) lines.push(panel.status === 'working' ? 'Scan in progress' : 'Result ready');
+  return Object.freeze({
+    title: 'Task Result',
+    lines: Object.freeze([`Trend: ${keyword}`, ...lines].slice(0, 3)),
+    tone: 'result',
+  });
+}
+
+function target(id, type, priority, hitArea, label, viewModel, source) {
+  return Object.freeze({ id, type, priority, hitArea, label, viewModel, source });
+}
+
+function taskMarkerTarget(component, entityPositions) {
+  const p = posOf(component, entityPositions);
+  return target(
+    `taskMarker:${component.id}`,
+    'taskMarker',
+    INTERACTION_PRIORITIES.taskMarker,
+    rect(p.x - TASK_MARKER_SIZE.width / 2, p.y - TASK_MARKER_SIZE.height / 2, TASK_MARKER_SIZE.width, TASK_MARKER_SIZE.height),
+    'Task',
+    taskMarkerViewModel(component),
+    component
+  );
+}
+
+function taskResultTarget(component, entityPositions) {
+  const panel = component?.trendPanelState && typeof component.trendPanelState === 'object' ? component.trendPanelState : null;
+  if (!panel) return null;
+  const p = posOf(component, entityPositions);
+  return target(
+    `taskResult:${panel.taskId || component.id}`,
+    'taskResult',
+    INTERACTION_PRIORITIES.taskResult,
+    rect(p.x - COMPACT_RESULT_SIZE.width / 2, p.y - 48, COMPACT_RESULT_SIZE.width, COMPACT_RESULT_SIZE.height),
+    'Task Result',
+    taskResultViewModel(component),
+    component
+  );
+}
+
+function validAgentInspectionViewModel(model) {
+  return Boolean(model
+    && typeof model === 'object'
+    && typeof model.title === 'string'
+    && typeof model.statusLabel === 'string'
+    && Array.isArray(model.lines));
+}
+
+function agentTarget(component, entityPositions, viewModel = buildAgentInspectionViewModel(component)) {
+  const p = posOf(component, entityPositions);
+  const b = AGENT_DESK_BOUNDS[component?.deskId] || AGENT_FALLBACK_BOUNDS;
+  return target(
+    `agent:${component.id}`,
+    'agent',
+    INTERACTION_PRIORITIES.agent,
+    rect(p.x - b.width / 2 + b.dx, p.y - b.height / 2 + b.dy, b.width, b.height),
+    'Agent',
+    viewModel,
+    component
+  );
+}
+
+function stationTarget(hotspot, component, canvasSize) {
+  const hitArea = scaleShape(hotspot.hitArea || { type: 'rect', ...hotspot.bounds }, canvasSize);
+  return target(
+    `station:${hotspot.id}`,
+    'station',
+    INTERACTION_PRIORITIES.station,
+    hitArea,
+    hotspot.title || hotspot.label || 'Station',
+    component?.inspectionViewModel || component?.popoverViewModel || null,
+    { hotspot, component }
+  );
+}
+
+function isInteractiveAgent(component, debug) {
+  if (debug) return true;
+  const viewModel = component?.agentInspectionViewModel || buildAgentInspectionViewModel(component);
+  return component?.normalInteractive === true && validAgentInspectionViewModel(viewModel);
+}
+
+export function buildInteractionTargets(components, options = {}) {
+  const safeComponents = Array.isArray(components) ? components : [];
+  const targets = [];
+  const entityPositions = options.entityPositions || null;
+  const debug = options.debug === true;
+
+  for (const component of safeComponents) {
+    if (!component || component.componentType !== 'agent-sprite') continue;
+    const result = taskResultTarget(component, entityPositions);
+    if (result) targets.push(result);
+  }
+
+  for (const component of safeComponents) {
+    if (component?.componentType === 'task-chip') targets.push(taskMarkerTarget(component, entityPositions));
+  }
+
+  for (const component of safeComponents) {
+    if (component?.componentType === 'agent-sprite' && isInteractiveAgent(component, debug)) {
+      targets.push(agentTarget(component, entityPositions, component.agentInspectionViewModel || buildAgentInspectionViewModel(component)));
+    }
+  }
+
+  const hotspots = Array.isArray(options.hotspots) ? options.hotspots : [];
+  const stationComponents = Array.isArray(options.stationComponents) ? options.stationComponents : [];
+  const stationById = new Map(stationComponents.map((component) => [component.id, component]));
+  for (const hotspot of hotspots) {
+    if (hotspot?.id) targets.push(stationTarget(hotspot, stationById.get(hotspot.id), options.canvasSize));
+  }
+
+  return Object.freeze(targets);
+}
+
+export function getInteractionTargetAtPoint(targets, point) {
+  if (!Array.isArray(targets) || !point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return null;
+  return targets
+    .filter((candidate) => candidate?.hitArea && pointInShape(point, candidate.hitArea))
+    .sort((a, b) => b.priority - a.priority)
+    [0] || null;
+}

--- a/ui/selectors/agentInspectionSelectors.js
+++ b/ui/selectors/agentInspectionSelectors.js
@@ -1,0 +1,78 @@
+/**
+ * Selector-safe friendly agent inspection view models.
+ */
+
+const MAX_LINES = 2;
+
+const DESK_TITLES = Object.freeze({
+  'desk-0': 'Research Sloth',
+  'desk-1': 'Listings Sloth',
+  'desk-4': 'Render Sloth',
+  'desk-5': 'Support Sloth',
+});
+
+const ZONE_TITLES = Object.freeze({
+  engineCrystal: 'Engine Sloth',
+  researchDesk: 'Research Sloth',
+  renderDesk: 'Render Sloth',
+  shopifyDesk: 'Listings Sloth',
+  approvalDesk: 'Approval Sloth',
+  archiveLibrary: 'Archive Sloth',
+  anomalyShelf: 'Anomaly Watcher',
+  supportDesk: 'Support Sloth',
+});
+
+function clean(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function friendlyTitle(agent) {
+  return DESK_TITLES[agent?.deskId]
+    || ZONE_TITLES[agent?.worldZoneId]
+    || ZONE_TITLES[agent?.zoneId]
+    || 'Sloth Worker';
+}
+
+function statusLabel(agent) {
+  if (agent?.anomaly || agent?.visualState === 'error') return 'Needs attention';
+  if (agent?.visualState === 'processing') return 'Processing';
+  if (agent?.visualState === 'working' || agent?.currentTaskId) return 'Working';
+  return 'Idle';
+}
+
+function taskCategory(agent) {
+  const text = [
+    clean(agent?.taskType),
+    clean(agent?.title),
+    clean(agent?.trendPanelState?.keyword),
+  ].filter(Boolean).join(' ').toLowerCase();
+  if (text.includes('trend') || agent?.trendPanelState) return 'Checking trend results';
+  if (text.includes('shopify') || text.includes('listing') || text.includes('product') || text.includes('publish')) return 'Handling listing work';
+  if (text.includes('image') || text.includes('render') || text.includes('mockup') || text.includes('design')) return 'Working on visuals';
+  if (text.includes('discord') || text.includes('support') || text.includes('message') || text.includes('reply')) return 'Handling messages';
+  if (text.includes('approval') || text.includes('review')) return 'Reviewing work';
+  return agent?.currentTaskId ? 'Assigned to a task' : null;
+}
+
+export function buildAgentInspectionViewModel(agent) {
+  const status = statusLabel(agent);
+  const category = taskCategory(agent);
+  const lines = [];
+
+  if (status === 'Idle') {
+    lines.push('Waiting for work');
+  } else if (category) {
+    lines.push(category);
+  } else {
+    lines.push(status === 'Needs attention' ? 'Needs a look' : 'Work in progress');
+  }
+
+  return Object.freeze({
+    targetType: 'agent',
+    title: friendlyTitle(agent),
+    statusLabel: status,
+    lines: Object.freeze(lines.slice(0, MAX_LINES)),
+    tone: status === 'Needs attention' ? 'warning' : 'agent',
+    maxLines: MAX_LINES,
+  });
+}

--- a/ui/selectors/workstationInspectionSelectors.js
+++ b/ui/selectors/workstationInspectionSelectors.js
@@ -1,0 +1,7 @@
+/**
+ * Selector-safe workstation inspection view models.
+ */
+
+export {
+  buildWorkstationInspectionViewModel,
+} from '../hotspots/workstationSemantics.js';

--- a/ui/selectors/workstationPopoverSelectors.js
+++ b/ui/selectors/workstationPopoverSelectors.js
@@ -1,0 +1,11 @@
+/**
+ * Selector-safe workstation popover view models.
+ *
+ * Re-exported from the semantic metadata module so renderer boundaries can
+ * continue to avoid importing ui/selectors directly.
+ */
+
+export {
+  buildWorkstationNormalSummaryRows,
+  buildWorkstationPopoverViewModel,
+} from '../hotspots/workstationSemantics.js';

--- a/ui/selectors/workstationVisualStateSelectors.js
+++ b/ui/selectors/workstationVisualStateSelectors.js
@@ -1,0 +1,7 @@
+/**
+ * Selector-safe workstation visual-state view models.
+ */
+
+export {
+  buildWorkstationVisualStateViewModel,
+} from '../hotspots/workstationSemantics.js';


### PR DESCRIPTION
## Summary

Adds the Slothworld canvas interaction foundation:

- calibrated workstation hotspot geometry
- priority-based interaction targets
- station/task result/agent-safe popover routing
- normal-mode metadata leak guards
- debug/calibration-only agent/world-zone diagnostics
- hotspot calibration editor/export support
- baked background boot gate to prevent procedural fallback flash
- canvas interaction contract documentation

## Architecture

- Normal mode interaction priority:
  taskResult > taskMarker > station > background
- Debug/calibration priority:
  taskResult > taskMarker > agent > station > world/debug zones
- Renderer consumes selector-safe view models only.
- Normal mode must not expose raw IDs, target types, zones, bounds, or event names.
- Procedural fallback remains available only in debug/calibration or explicit opt-in.

## Verification

- 227 passing interaction/render tests
- background boot gate tests pass
- canvas inspection tests pass