### PR TITLE
refactor(ui): split left menu normal and debug modes

### DIFF
--- a/style.css
+++ b/style.css
@@ -49,6 +49,61 @@ body {
   border-bottom: 1px solid #4a3520;
 }
 
+#left-ui-mode-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 6px 7px;
+  border: 1px solid #4a3520;
+  background: rgba(26, 13, 4, 0.6);
+}
+
+.left-ui-mode-label {
+  font-size: 9px;
+  font-weight: 700;
+  color: #b8a88a;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.left-ui-mode-buttons {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.left-ui-mode-button {
+  border: 1px solid #5c3d1e;
+  background: #2a1808;
+  color: #b8a88a;
+  font: 10px monospace;
+  padding: 3px 7px;
+  cursor: pointer;
+}
+
+.left-ui-mode-button.is-active {
+  border-color: #00b8a9;
+  color: #e8d5b0;
+  box-shadow: inset 0 0 0 1px rgba(0, 184, 169, 0.3);
+}
+
+.left-ui-mode-button:hover {
+  border-color: #8b6347;
+}
+
+body[data-left-ui-mode="normal"] .ui-debug-only {
+  display: none !important;
+}
+
+body[data-left-ui-mode="debug"] .ui-debug-only {
+  display: block;
+}
+
+body[data-left-ui-mode="debug"] .ocp-debug-actions.ui-debug-only {
+  display: flex;
+}
+
 #control-panels-stack {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -177,6 +232,15 @@ canvas {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+}
+
+.ocp-compact-summary {
+  margin: 0 0 8px;
+  padding: 5px 7px;
+  font: 9px/1.35 monospace;
+  color: #b8a88a;
+  border: 1px solid #4a3520;
+  background: #1a0d04;
 }
 
 .ocp-toolbar {
@@ -639,6 +703,15 @@ canvas {
   list-style: none;
   max-height: 150px;
   overflow-y: auto;
+}
+
+.rfp-summary {
+  margin: 0 0 8px;
+  padding: 5px 7px;
+  font: 9px/1.35 monospace;
+  color: #b8a88a;
+  border: 1px solid #4a3520;
+  background: #1a0d04;
 }
 
 .rfp-item {

--- a/ui/graph-snapshot.js
+++ b/ui/graph-snapshot.js
@@ -1,0 +1,7 @@
+export function getGraphSnapshot() {
+  if (window.controlAPI && typeof window.controlAPI.getGraph === 'function') {
+    return window.controlAPI.getGraph();
+  }
+
+  return { nodes: [], edges: [], metadata: {} };
+}

--- a/ui/operator-control-panel.js
+++ b/ui/operator-control-panel.js
@@ -5,6 +5,8 @@
  * events -> deriveWorldState -> selectors -> rendering
  */
 
+import { getGraphSnapshot } from './graph-snapshot.js';
+
 
 
 const panelState = {
@@ -162,11 +164,8 @@ function renderTaskList(listElement, nodes, selectedTaskId) {
   });
 }
 
-function getGraphSnapshot() {
-  if (window.controlAPI && typeof window.controlAPI.getGraph === 'function') {
-    return window.controlAPI.getGraph();
-  }
-  return { nodes: [], edges: [], metadata: {} };
+function getLeftUiMode() {
+  return document.body.dataset.leftUiMode === 'debug' ? 'debug' : 'normal';
 }
 
 function createPanelRoot() {
@@ -180,7 +179,7 @@ function createPanelRoot() {
 
     <section class="ocp-section" data-section="tasks">
       <h3>Tasks (Derived)</h3>
-      <div class="ocp-debug-actions">
+      <div class="ocp-debug-actions ui-debug-only">
         <button type="button" class="ocp-debug-create" data-action="create-test-task">+ Create Test Task</button>
         <span class="ocp-debug-indicator" data-role="create-task-indicator"></span>
       </div>
@@ -198,6 +197,7 @@ function createPanelRoot() {
           </select>
         </label>
       </div>
+      <div class="ocp-compact-summary" data-detail="summary">No tasks yet.</div>
       <div class="ocp-grid-2">
         <div>
           <h4>Queued</h4>
@@ -216,8 +216,8 @@ function createPanelRoot() {
           <ul class="ocp-list" data-list="failed"></ul>
         </div>
       </div>
-      <pre class="ocp-detail" data-detail="task">Click a task to inspect derived details.</pre>
-      <div class="ocp-timeline-wrap">
+      <pre class="ocp-detail ui-debug-only" data-detail="task">Click a task to inspect derived details.</pre>
+      <div class="ocp-timeline-wrap ui-debug-only">
         <h4>Selected Task Timeline</h4>
         <ul class="ocp-list ocp-timeline" data-list="timeline"></ul>
         <pre class="ocp-detail" data-detail="event">Click a timeline event to inspect payload.</pre>
@@ -227,11 +227,11 @@ function createPanelRoot() {
     <section class="ocp-section" data-section="agents">
       <h3>Agents (Derived)</h3>
       <ul class="ocp-list" data-list="agents"></ul>
-      <pre class="ocp-detail" data-detail="agent">Click an agent to inspect derived assignment.</pre>
+      <pre class="ocp-detail ui-debug-only" data-detail="agent">Click an agent to inspect derived assignment.</pre>
     </section>
 
-    <section class="ocp-section" data-section="events">
-      <h3>Event Stream</h3>
+    <section class="ocp-section ui-debug-only" data-section="events">
+      <h3>Transition Stream</h3>
       <div class="ocp-toolbar">
         <label class="ocp-control">
           Show last
@@ -240,7 +240,7 @@ function createPanelRoot() {
             <option value="100" selected>100</option>
             <option value="300">300</option>
           </select>
-          events
+          transitions
         </label>
       </div>
       <ul class="ocp-list" data-list="events"></ul>
@@ -266,6 +266,7 @@ export function initOperatorControlPanel() {
   const timelineList = panel.querySelector('[data-list="timeline"]');
   const agentsList = panel.querySelector('[data-list="agents"]');
   const eventsList = panel.querySelector('[data-list="events"]');
+  const summaryDetail = panel.querySelector('[data-detail="summary"]');
   const taskDetail = panel.querySelector('[data-detail="task"]');
   const agentDetail = panel.querySelector('[data-detail="agent"]');
   const eventDetail = panel.querySelector('[data-detail="event"]');
@@ -340,6 +341,7 @@ export function initOperatorControlPanel() {
   });
 
   function renderPanel() {
+    panel.dataset.uiMode = getLeftUiMode();
     const graph = getGraphSnapshot();
     const allNodes = Array.isArray(graph.nodes) ? graph.nodes : [];
     const graphEdges = Array.isArray(graph.edges) ? graph.edges : [];
@@ -367,6 +369,20 @@ export function initOperatorControlPanel() {
     renderTaskList(activeList, buckets.active, panelState.selectedTaskId);
     renderTaskList(doneList, buckets.done, panelState.selectedTaskId);
     renderTaskList(failedList, buckets.failed, panelState.selectedTaskId);
+
+    if (summaryDetail) {
+      const summary = [
+        `Total ${filteredTaskNodes.length}`,
+        `Queued ${buckets.queued.length}`,
+        `Active ${buckets.active.length}`,
+        `Failed ${buckets.failed.length}`,
+        `Agents ${workerNodes.length}`
+      ];
+      if (panelState.selectedTaskId) {
+        summary.push(`Selected ${panelState.selectedTaskId}`);
+      }
+      summaryDetail.textContent = summary.join(' | ');
+    }
 
     eventsList.innerHTML = '';
     {
@@ -566,6 +582,9 @@ export function initOperatorControlPanel() {
 
   renderPanel();
   window.addEventListener('slothworld:graph', () => {
+    renderPanel();
+  });
+  window.addEventListener('slothworld:ui-mode', () => {
     renderPanel();
   });
 }

--- a/ui/raccoon-feeder-panel.js
+++ b/ui/raccoon-feeder-panel.js
@@ -10,6 +10,8 @@
  * - Trigger execution side effects
  */
 
+import { getGraphSnapshot } from './graph-snapshot.js';
+
 
 function stringify(value) {
   try {
@@ -53,6 +55,10 @@ function collectIncidents(graph) {
   return Array.from(byType.values());
 }
 
+function getLeftUiMode() {
+  return document.body.dataset.leftUiMode === 'debug' ? 'debug' : 'normal';
+}
+
 export function initRaccoonFeederPanel() {
   const panel = document.createElement('aside');
   panel.id = 'raccoon-feeder-panel';
@@ -63,8 +69,9 @@ export function initRaccoonFeederPanel() {
     </div>
     <section class="rfp-section">
       <h3>Incident Clusters</h3>
+      <div class="rfp-summary" data-detail="summary">No incidents.</div>
       <ul class="rfp-list" data-list="incidents"></ul>
-      <pre class="rfp-detail" data-detail="incident">Select an incident to inspect details.</pre>
+      <pre class="rfp-detail ui-debug-only" data-detail="incident">Select an incident to inspect details.</pre>
     </section>
   `;
 
@@ -76,15 +83,9 @@ export function initRaccoonFeederPanel() {
   }
 
   const incidentsList = panel.querySelector('[data-list="incidents"]');
+  const summaryDetail = panel.querySelector('[data-detail="summary"]');
   const incidentDetail = panel.querySelector('[data-detail="incident"]');
   let selectedClusterType = null;
-
-  function getGraphSnapshot() {
-    if (window.controlAPI && typeof window.controlAPI.getGraph === 'function') {
-      return window.controlAPI.getGraph();
-    }
-    return { nodes: [], edges: [], metadata: {} };
-  }
 
   panel.addEventListener('click', (event) => {
     const target = event.target;
@@ -102,6 +103,9 @@ export function initRaccoonFeederPanel() {
   });
 
   function renderPanel() {
+    const mode = getLeftUiMode();
+    panel.dataset.uiMode = mode;
+
     const graph = getGraphSnapshot();
     const incidents = collectIncidents(graph)
       .sort((a, b) => {
@@ -112,8 +116,28 @@ export function initRaccoonFeederPanel() {
         return String(a.type || '').localeCompare(String(b.type || ''));
       });
 
+    panel.style.display = mode === 'normal' && incidents.length === 0 ? 'none' : '';
+
     if (!incidents.some((item) => item.type === selectedClusterType)) {
       selectedClusterType = incidents.length ? incidents[0].type : null;
+    }
+
+    if (summaryDetail) {
+      const counts = incidents.reduce((acc, incident) => {
+        const severity = String(incident.severity || 'low').toLowerCase();
+        if (severity === 'high') {
+          acc.high += 1;
+        } else if (severity === 'medium') {
+          acc.medium += 1;
+        } else {
+          acc.low += 1;
+        }
+        return acc;
+      }, { high: 0, medium: 0, low: 0 });
+
+      summaryDetail.textContent = incidents.length
+        ? `Clusters ${incidents.length} | High ${counts.high} | Medium ${counts.medium} | Low ${counts.low}`
+        : 'No incidents.';
     }
 
     incidentsList.innerHTML = '';
@@ -160,6 +184,9 @@ export function initRaccoonFeederPanel() {
 
   renderPanel();
   window.addEventListener('slothworld:graph', () => {
+    renderPanel();
+  });
+  window.addEventListener('slothworld:ui-mode', () => {
     renderPanel();
   });
 }

--- a/ui/task-creator-panel.js
+++ b/ui/task-creator-panel.js
@@ -1,11 +1,6 @@
-export function initTaskCreatorPanel() {
-  function getGraphSnapshot() {
-    if (window.controlAPI && typeof window.controlAPI.getGraph === 'function') {
-      return window.controlAPI.getGraph();
-    }
-    return { nodes: [], edges: [], metadata: {} };
-  }
+import { getGraphSnapshot } from './graph-snapshot.js';
 
+export function initTaskCreatorPanel() {
   const FIXED_DISCORD_CHANNEL_ID = '1491500223288184964';
 
   const panelRuntime = {

--- a/ui/ui-bootstrap.js
+++ b/ui/ui-bootstrap.js
@@ -2,7 +2,68 @@ import { initOperatorControlPanel } from './operator-control-panel.js';
 import { initRaccoonFeederPanel } from './raccoon-feeder-panel.js';
 import { initTaskCreatorPanel } from './task-creator-panel.js';
 
+const LEFT_UI_MODE_EVENT = 'slothworld:ui-mode';
+
+function applyLeftUiMode(mode, modeToggle) {
+  const safeMode = mode === 'debug' ? 'debug' : 'normal';
+  document.body.dataset.leftUiMode = safeMode;
+
+  if (modeToggle) {
+    const buttons = modeToggle.querySelectorAll('[data-ui-mode]');
+    buttons.forEach((button) => {
+      if (!(button instanceof HTMLButtonElement)) {
+        return;
+      }
+      const isActive = button.dataset.uiMode === safeMode;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  window.dispatchEvent(new CustomEvent(LEFT_UI_MODE_EVENT, {
+    detail: { mode: safeMode }
+  }));
+}
+
+function initLeftUiModeToggle() {
+  const sidebar = document.getElementById('left-sidebar');
+  const panelHeader = document.getElementById('control-panels-header');
+  if (!sidebar || !panelHeader) {
+    document.body.dataset.leftUiMode = 'normal';
+    return;
+  }
+
+  const modeToggle = document.createElement('div');
+  modeToggle.id = 'left-ui-mode-toggle';
+  modeToggle.innerHTML = `
+    <span class="left-ui-mode-label">Mode</span>
+    <div class="left-ui-mode-buttons" role="group" aria-label="Left UI mode toggle">
+      <button type="button" class="left-ui-mode-button" data-ui-mode="normal" aria-pressed="true">Normal</button>
+      <button type="button" class="left-ui-mode-button" data-ui-mode="debug" aria-pressed="false">Debug</button>
+    </div>
+  `;
+
+  panelHeader.insertAdjacentElement('afterend', modeToggle);
+
+  modeToggle.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const button = target.closest('[data-ui-mode]');
+    if (!(button instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    applyLeftUiMode(button.dataset.uiMode, modeToggle);
+  });
+
+  applyLeftUiMode('normal', modeToggle);
+}
+
 export function initUI() {
+  initLeftUiModeToggle();
   initOperatorControlPanel();
   initRaccoonFeederPanel();
   initTaskCreatorPanel();


### PR DESCRIPTION
## Summary

Adds a Normal/Debug mode split to the left sidebar without removing existing functionality.

## Changes

- Added left sidebar mode toggle.
- Default mode is Normal.
- Normal mode keeps task creation, task buckets, agent overview, and anomaly summary.
- Debug mode reveals deeper internals:
  - test task controls
  - task timeline/details
  - transition stream
  - JSON/metadata panes
  - raccoon detail pane
- Renamed “Event Stream” to “Transition Stream”.
- Added shared `getGraphSnapshot()` helper.

## Verification

- `npm test`
- Result: 63/63 passing

## Notes

No TaskEngine, server, selector, renderer, or payload contract changes.