### PR TITLE
llm hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Bridge, UI, Workers, and Providers must NOT:
 - No filesystem access
 - No orchestration responsibilities
 
+LLM workers resolve text generation through `integrations/llm/llmProviderRegistry.js`.
+The registry owns the default local text provider (`ollama`), while workers stay
+provider-agnostic and UI/rendering code never imports provider implementations.
+Future local model integrations should add provider modules behind registries
+without changing TaskEngine lifecycle authority.
+
 ### Persistence
 
 - Stores events and execution records

--- a/core/workers/analyzeTrendsWorker.js
+++ b/core/workers/analyzeTrendsWorker.js
@@ -1,4 +1,4 @@
-import { ollamaProvider } from '../../integrations/llm/providers/ollamaProvider.js';
+import { generateTextViaLlmProvider } from '../../integrations/llm/llmProviderRegistry.js';
 import { assertWorkerExecutionContext } from '../engine/enforcementRuntime.js';
 
 const MAX_CANDIDATES = 3;
@@ -287,7 +287,7 @@ export async function runAnalyzeTrendsWorker({
     });
 
     const timeoutMs = trendAnalysisTimeoutMs();
-    const providerResult = await withTimeout((signal) => ollamaProvider.generateText({
+    const providerResult = await withTimeout((signal) => generateTextViaLlmProvider({
       prompt,
       system: SYSTEM_PROMPT,
       model,

--- a/core/workers/localLlmWorker.js
+++ b/core/workers/localLlmWorker.js
@@ -1,4 +1,4 @@
-import { ollamaProvider } from '../../integrations/llm/providers/ollamaProvider.js';
+import { generateTextViaLlmProvider } from '../../integrations/llm/llmProviderRegistry.js';
 import { assertWorkerExecutionContext } from '../engine/enforcementRuntime.js';
 
 function fail(error) {
@@ -31,7 +31,7 @@ export async function runLocalLlmWorker(task) {
   const payload = normalizePayload(task);
 
   try {
-    const result = await ollamaProvider.generateText({
+    const result = await generateTextViaLlmProvider({
       prompt: payload.prompt,
       system: payload.system,
       model: payload.model,

--- a/integrations/llm/llmProviderRegistry.js
+++ b/integrations/llm/llmProviderRegistry.js
@@ -1,0 +1,44 @@
+import { ollamaProvider } from './providers/ollamaProvider.js';
+
+const DEFAULT_LLM_PROVIDER_ID = 'ollama';
+const providers = new Map();
+
+function normalizeProviderId(providerId) {
+  return String(providerId || DEFAULT_LLM_PROVIDER_ID).trim().toLowerCase();
+}
+
+function isValidLlmProvider(provider) {
+  return provider && typeof provider.generateText === 'function';
+}
+
+export function registerLlmProvider(providerId, provider) {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  if (!normalizedProviderId) {
+    throw new Error('llm_provider_id_required');
+  }
+
+  if (!isValidLlmProvider(provider)) {
+    throw new Error(`invalid_llm_provider:${normalizedProviderId}`);
+  }
+
+  providers.set(normalizedProviderId, provider);
+  return provider;
+}
+
+export function resolveLlmProvider(providerId = DEFAULT_LLM_PROVIDER_ID) {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  const provider = providers.get(normalizedProviderId);
+  if (!provider) {
+    throw new Error(`llm_provider_not_supported:${normalizedProviderId}`);
+  }
+
+  return provider;
+}
+
+export async function generateTextViaLlmProvider(request = {}, providerId = DEFAULT_LLM_PROVIDER_ID) {
+  return resolveLlmProvider(providerId).generateText(request);
+}
+
+registerLlmProvider(DEFAULT_LLM_PROVIDER_ID, ollamaProvider);
+
+export { DEFAULT_LLM_PROVIDER_ID };

--- a/tests/ollama-provider.test.mjs
+++ b/tests/ollama-provider.test.mjs
@@ -8,10 +8,17 @@ import {
   getOllamaConfig,
   ollamaProvider
 } from '../integrations/llm/providers/ollamaProvider.js';
+import {
+  DEFAULT_LLM_PROVIDER_ID,
+  generateTextViaLlmProvider,
+  resolveLlmProvider
+} from '../integrations/llm/llmProviderRegistry.js';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const PROVIDER_PATH = join(ROOT, 'integrations', 'llm', 'providers', 'ollamaProvider.js');
 const UI_DIR = join(ROOT, 'ui');
+const RENDERING_DIR = join(ROOT, 'rendering');
+const WORKERS_DIR = join(ROOT, 'core', 'workers');
 
 function collectJs(dir) {
   const results = [];
@@ -155,6 +162,36 @@ test('Ollama provider handles failed responses as structured errors', async () =
   }));
 });
 
+test('LLM provider registry resolves Ollama as the default text provider', async () => {
+  const calls = [];
+
+  assert.equal(DEFAULT_LLM_PROVIDER_ID, 'ollama');
+  assert.equal(resolveLlmProvider(), ollamaProvider);
+
+  await withOllamaEnv({
+    OLLAMA_BASE_URL: 'http://ollama.local:11434',
+    OLLAMA_MODEL: 'llama3.1:8b'
+  }, async () => withFetch(async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        model: 'llama3.1:8b',
+        response: 'registry response',
+        done: true
+      })
+    };
+  }, async () => {
+    const result = await generateTextViaLlmProvider({ prompt: 'hello registry' });
+
+    assert.equal(result.provider, 'ollama');
+    assert.equal(result.text, 'registry response');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'http://ollama.local:11434/api/generate');
+  }));
+});
+
 test('Ollama provider does not import TaskEngine', () => {
   const source = readFileSync(PROVIDER_PATH, 'utf8');
   assert.equal(/from\s+['"][^'"]*taskEngine\.js['"]/.test(source), false);
@@ -168,6 +205,34 @@ test('UI files do not import the Ollama provider', () => {
   for (const file of collectJs(UI_DIR)) {
     const source = readFileSync(file, 'utf8');
     if (/integrations\/llm\/providers\/ollamaProvider|ollamaProvider/.test(source)) {
+      hits.push(relative(ROOT, file));
+    }
+  }
+
+  assert.deepEqual(hits, []);
+});
+
+test('UI and rendering files do not import LLM providers or registry', () => {
+  const hits = [];
+
+  for (const dir of [UI_DIR, RENDERING_DIR]) {
+    for (const file of collectJs(dir)) {
+      const source = readFileSync(file, 'utf8');
+      if (/integrations\/llm|llmProviderRegistry|ollamaProvider/.test(source)) {
+        hits.push(relative(ROOT, file));
+      }
+    }
+  }
+
+  assert.deepEqual(hits, []);
+});
+
+test('workers do not import the Ollama provider directly', () => {
+  const hits = [];
+
+  for (const file of collectJs(WORKERS_DIR)) {
+    const source = readFileSync(file, 'utf8');
+    if (/from\s+['"][^'"]*integrations\/llm\/providers\/ollamaProvider\.js['"]|import\s+\{\s*ollamaProvider\s*\}/.test(source)) {
       hits.push(relative(ROOT, file));
     }
   }


### PR DESCRIPTION
Implemented Step 1.

Added [llmProviderRegistry.js]/slothworld/integrations/llm/llmProviderRegistry.js:1), with Ollama registered as the default LLM provider and exports for `resolveLlmProvider()` plus `generateTextViaLlmProvider()`.

Updated workers to go through the registry instead of importing Ollama directly:
- [localLlmWorker.js](slothworld/core/workers/localLlmWorker.js:1)
- [analyzeTrendsWorker.js]/slothworld/core/workers/analyzeTrendsWorker.js:1)

Added registry and boundary tests in [ollama-provider.test.mjs](/slothworld/tests/ollama-provider.test.mjs:165):
- default registry resolves to Ollama
- UI/rendering do not import LLM providers or registry
- workers do not import `ollamaProvider` directly

Added a short provider-boundary note to [README.md]/slothworld/README.md:95).

Verification: `npm test` passes.