### PR TITLE
image provider install

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ provider-agnostic and UI/rendering code never imports provider implementations.
 Future local model integrations should add provider modules behind registries
 without changing TaskEngine lifecycle authority.
 
+Image render workers resolve image generation through
+`integrations/image-generation/imageProviderRegistry.js`. `IMAGE_RENDER` remains
+the canonical image-generation task type; the registry only selects the provider
+implementation. Future ComfyUI or Stable Diffusion backends should register
+behind this boundary without adding routes or lifecycle events.
+
 ### Persistence
 
 - Stores events and execution records

--- a/core/workers/imageRenderWorker.js
+++ b/core/workers/imageRenderWorker.js
@@ -1,7 +1,10 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ProviderRegistry } from '../../integrations/rendering/providers/providerRegistry.js';
+import {
+  generateImageViaProvider,
+  hasImageProvider
+} from '../../integrations/image-generation/imageProviderRegistry.js';
 import { assertProviderExecutionContext, assertWorkerExecutionContext } from '../engine/enforcementRuntime.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -34,8 +37,7 @@ function sleep(ms) {
 
 async function runProvider(provider, prompt, context) {
   assertProviderExecutionContext();
-  const plugin = ProviderRegistry.get(provider);
-  return plugin.generate(prompt, context);
+  return generateImageViaProvider(prompt, context, provider);
 }
 
 async function runProviderWithTimeout(provider, prompt, context, timeoutMs) {
@@ -74,7 +76,7 @@ function buildProviderPlan(primaryProvider, context) {
       continue;
     }
 
-    if (!ProviderRegistry.has(providerName)) {
+    if (!hasImageProvider(providerName)) {
       continue;
     }
 

--- a/integrations/image-generation/imageProviderRegistry.js
+++ b/integrations/image-generation/imageProviderRegistry.js
@@ -1,0 +1,54 @@
+import { openAIImageProvider } from '../rendering/providers/openaiImageProvider.js';
+import { huggingFaceImageProvider } from '../rendering/providers/huggingfaceImageProvider.js';
+
+const DEFAULT_IMAGE_PROVIDER_ID = 'openai';
+const providers = new Map();
+
+function normalizeProviderId(providerId) {
+  return String(providerId || DEFAULT_IMAGE_PROVIDER_ID).trim().toLowerCase();
+}
+
+function isValidImageProvider(provider) {
+  return provider && typeof provider.generate === 'function';
+}
+
+export function registerImageProvider(providerId, provider) {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  if (!normalizedProviderId) {
+    throw new Error('image_provider_id_required');
+  }
+
+  if (!isValidImageProvider(provider)) {
+    throw new Error(`invalid_image_provider:${normalizedProviderId}`);
+  }
+
+  providers.set(normalizedProviderId, provider);
+  return provider;
+}
+
+export function resolveImageProvider(providerId = DEFAULT_IMAGE_PROVIDER_ID) {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  const provider = providers.get(normalizedProviderId);
+  if (!provider) {
+    throw new Error(`image_provider_not_supported:${normalizedProviderId}`);
+  }
+
+  return provider;
+}
+
+export function hasImageProvider(providerId) {
+  return providers.has(normalizeProviderId(providerId));
+}
+
+export function listImageProviders() {
+  return Array.from(providers.keys());
+}
+
+export async function generateImageViaProvider(prompt, context = {}, providerId = DEFAULT_IMAGE_PROVIDER_ID) {
+  return resolveImageProvider(providerId).generate(prompt, context);
+}
+
+registerImageProvider(DEFAULT_IMAGE_PROVIDER_ID, openAIImageProvider);
+registerImageProvider('huggingface', huggingFaceImageProvider);
+
+export { DEFAULT_IMAGE_PROVIDER_ID };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "lint": "eslint rendering/",
   "test": "npm run test:enforcement && npm run test:providers && npm run test:local-llm && npm run test:trend-llm && npm run test:contracts",
   "test:enforcement": "node --test tests/adversarial-enforcement.test.mjs",
-  "test:providers": "node --test tests/ollama-provider.test.mjs",
+  "test:providers": "node --test tests/ollama-provider.test.mjs tests/image-provider-registry.test.mjs",
   "test:local-llm": "node --test tests/local-llm-worker.test.mjs tests/task-creator-local-brain.test.mjs tests/local-brain-results.test.mjs",
   "test:trend-llm": "node --test tests/trend-research-ollama-analysis.test.mjs tests/workstation-status-selectors.test.mjs",
   "test:architecture": "node --test tests/selector-contract-freeze.test.mjs tests/taxonomy-contract.test.mjs tests/anomaly-cluster-contract.test.mjs",

--- a/tests/image-provider-registry.test.mjs
+++ b/tests/image-provider-registry.test.mjs
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DEFAULT_IMAGE_PROVIDER_ID,
+  generateImageViaProvider,
+  hasImageProvider,
+  listImageProviders,
+  registerImageProvider,
+  resolveImageProvider
+} from '../integrations/image-generation/imageProviderRegistry.js';
+import { openAIImageProvider } from '../integrations/rendering/providers/openaiImageProvider.js';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const UI_DIR = join(ROOT, 'ui');
+const RENDERING_DIR = join(ROOT, 'rendering');
+const IMAGE_RENDER_WORKER_PATH = join(ROOT, 'core', 'workers', 'imageRenderWorker.js');
+
+function collectJs(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...collectJs(full));
+    } else if (entry.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+test('image provider registry resolves OpenAI as the default image provider', () => {
+  assert.equal(DEFAULT_IMAGE_PROVIDER_ID, 'openai');
+  assert.equal(resolveImageProvider(), openAIImageProvider);
+  assert.equal(hasImageProvider('openai'), true);
+  assert.equal(hasImageProvider('huggingface'), true);
+  assert.deepEqual(listImageProviders(), ['openai', 'huggingface']);
+});
+
+test('image provider registry dispatches image generation through the resolved provider', async () => {
+  const calls = [];
+  const providerId = 'test-image-provider';
+
+  registerImageProvider(providerId, {
+    async generate(prompt, context) {
+      calls.push({ prompt, context });
+      return {
+        provider: providerId,
+        contentBase64: Buffer.from('image-bytes').toString('base64'),
+        mimeType: 'image/png'
+      };
+    }
+  });
+
+  const result = await generateImageViaProvider('draw a local scene', {
+    metadata: {
+      productId: 'local-scene'
+    }
+  }, providerId);
+
+  assert.equal(result.provider, providerId);
+  assert.equal(result.mimeType, 'image/png');
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    prompt: 'draw a local scene',
+    context: {
+      metadata: {
+        productId: 'local-scene'
+      }
+    }
+  });
+});
+
+test('UI and rendering files do not import image providers or image provider registry', () => {
+  const hits = [];
+
+  for (const dir of [UI_DIR, RENDERING_DIR]) {
+    for (const file of collectJs(dir)) {
+      const source = readFileSync(file, 'utf8');
+      if (/integrations\/(?:image-generation|rendering\/providers)|imageProviderRegistry|openAIImageProvider|huggingFaceImageProvider|openAIImageAdapter/.test(source)) {
+        hits.push(relative(ROOT, file));
+      }
+    }
+  }
+
+  assert.deepEqual(hits, []);
+});
+
+test('imageRenderWorker does not import concrete image providers directly', () => {
+  const source = readFileSync(IMAGE_RENDER_WORKER_PATH, 'utf8');
+
+  assert.equal(/integrations\/rendering\/providers\/(?:openaiImageProvider|huggingfaceImageProvider|openAIImageAdapter|providerRegistry)\.js/.test(source), false);
+  assert.equal(/\b(openAIImageProvider|huggingFaceImageProvider|openAIImageAdapter|ProviderRegistry)\b/.test(source), false);
+  assert.match(source, /imageProviderRegistry\.js/);
+});


### PR DESCRIPTION
Implemented Step 2.

Added [imageProviderRegistry.js](/slothworld/integrations/image-generation/imageProviderRegistry.js:1), with OpenAI registered as the default image provider and Hugging Face preserved as the existing fallback provider. It exposes `resolveImageProvider()`, `generateImageViaProvider()`, `hasImageProvider()`, and registration/list helpers.

Updated [imageRenderWorker.js](/slothworld/core/workers/imageRenderWorker.js:4) to call the image-generation registry instead of the rendering provider registry, preserving the existing provider plan, fallback behavior, timeout handling, persistence, and `IMAGE_RENDER` task semantics.

Added guard coverage in [image-provider-registry.test.mjs](/slothworld/tests/image-provider-registry.test.mjs:35):
- default registry resolves to OpenAI
- registry dispatches through the resolved provider
- UI/rendering do not import image providers or the image registry
- `imageRenderWorker` does not import concrete image providers directly

Updated `test:providers` in [package.json](/slothworld/package.json:12), and added the README boundary note at [README.md](/slothworld/README.md:101).

Verification: `npm test` passes.